### PR TITLE
Add ggml vulkan matmul compute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,43 @@ via Vulkan.
 curl -fsSL https://raw.githubusercontent.com/ericcurtin/vllm-vulkan/main/install.sh | bash
 ```
 
+## Development
+
+The Rust extension links against ggml's Vulkan backend for compute bring-up.
+The local installer initializes the ggml submodule and installs the Vulkan
+build dependencies:
+
+```bash
+./install.sh
+```
+
+For manual setup, clone with submodules:
+
+```bash
+git clone --recurse-submodules https://github.com/ericcurtin/vllm-vulkan.git
+```
+
+or initialize them after cloning:
+
+```bash
+git submodule update --init --recursive
+```
+
+On macOS, ggml builds against the Homebrew Vulkan headers/loader, uses
+`shaderc` for `glslc` shader compilation, and needs `spirv-headers` for SPIR-V
+headers. The runtime Vulkan provider remains KosmicKrisp.
+
+```bash
+brew install vulkan-headers vulkan-loader shaderc spirv-headers
+```
+
+On Linux, install the Vulkan loader, headers, shader compiler, and SPIR-V
+headers from your distribution:
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install -y build-essential cmake libvulkan-dev glslc spirv-headers
+
+# Fedora / RHEL
+sudo dnf install -y cmake gcc-c++ make vulkan-loader-devel glslc spirv-headers
+```

--- a/build.rs
+++ b/build.rs
@@ -12,8 +12,11 @@
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=ggml");
 
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    build_and_link_ggml(&target_os);
 
     match target_os.as_str() {
         "macos" => link_macos(),
@@ -27,6 +30,139 @@ fn main() {
     }
 }
 
+// ─── ggml ───────────────────────────────────────────────────────────────────
+
+fn build_and_link_ggml(target_os: &str) {
+    let manifest_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let ggml_dir = manifest_dir.join("ggml");
+    if !ggml_dir.join("CMakeLists.txt").exists() {
+        panic!("ggml submodule is missing. Run: git submodule update --init --recursive");
+    }
+
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let build_dir = out_dir.join("ggml-build");
+    std::fs::create_dir_all(&build_dir).expect("failed to create ggml build directory");
+
+    let mut configure = std::process::Command::new("cmake");
+    configure
+        .arg("-S")
+        .arg(&ggml_dir)
+        .arg("-B")
+        .arg(&build_dir)
+        .arg("-DCMAKE_BUILD_TYPE=Release")
+        .arg("-DBUILD_SHARED_LIBS=OFF")
+        .arg("-DGGML_VULKAN=ON")
+        .arg("-DGGML_BUILD_EXAMPLES=OFF")
+        .arg("-DGGML_BUILD_TESTS=OFF")
+        .arg("-DGGML_METAL=OFF")
+        .arg("-DGGML_BLAS=OFF")
+        .arg("-DGGML_ACCELERATE=OFF")
+        .arg("-DGGML_OPENMP=OFF")
+        .arg("-DGGML_NATIVE=OFF");
+
+    if target_os == "macos" {
+        add_macos_vulkan_cmake_hints(&mut configure);
+        add_macos_homebrew_include_hints(&mut configure);
+    }
+
+    if let Some(glslc) = find_executable("glslc").or_else(|| {
+        find_file(&[
+            "/opt/homebrew/opt/shaderc/bin/glslc",
+            "/usr/local/opt/shaderc/bin/glslc",
+        ])
+    }) {
+        configure.arg(format!("-DVulkan_GLSLC_EXECUTABLE={}", glslc.display()));
+    }
+
+    run_command(configure, "configure ggml with Vulkan");
+
+    let mut build = std::process::Command::new("cmake");
+    build
+        .arg("--build")
+        .arg(&build_dir)
+        .arg("--config")
+        .arg("Release")
+        .arg("--target")
+        .arg("ggml")
+        .arg("--parallel");
+    run_command(build, "build ggml Vulkan backend");
+
+    for dir in [
+        build_dir.join("src"),
+        build_dir.join("src/ggml-cpu"),
+        build_dir.join("src/ggml-vulkan"),
+    ] {
+        println!("cargo:rustc-link-search=native={}", dir.display());
+    }
+
+    // Keep this order: ggml references backend registration symbols, and the
+    // backend libraries reference ggml-base symbols.
+    println!("cargo:rustc-link-lib=static=ggml");
+    println!("cargo:rustc-link-lib=static=ggml-cpu");
+    println!("cargo:rustc-link-lib=static=ggml-vulkan");
+    println!("cargo:rustc-link-lib=static=ggml-base");
+
+    match target_os {
+        "macos" => println!("cargo:rustc-link-lib=c++"),
+        "linux" => {
+            println!("cargo:rustc-link-lib=stdc++");
+            println!("cargo:rustc-link-lib=pthread");
+            println!("cargo:rustc-link-lib=dl");
+            println!("cargo:rustc-link-lib=m");
+        }
+        _ => {}
+    }
+}
+
+fn add_macos_vulkan_cmake_hints(configure: &mut std::process::Command) {
+    for prefix in ["/opt/homebrew", "/usr/local"] {
+        let prefix = std::path::Path::new(prefix);
+        let include_dir = prefix.join("include");
+        let library = prefix.join("lib/libvulkan.dylib");
+        if include_dir.join("vulkan/vulkan.h").exists() && library.exists() {
+            configure
+                .arg(format!("-DVulkan_INCLUDE_DIR={}", include_dir.display()))
+                .arg(format!("-DVulkan_LIBRARY={}", library.display()));
+            return;
+        }
+    }
+}
+
+fn add_macos_homebrew_include_hints(configure: &mut std::process::Command) {
+    for include_dir in ["/opt/homebrew/include", "/usr/local/include"] {
+        let include_dir = std::path::Path::new(include_dir);
+        if include_dir.join("spirv/unified1/spirv.hpp").exists() {
+            configure
+                .arg(format!("-DCMAKE_C_FLAGS=-I{}", include_dir.display()))
+                .arg(format!("-DCMAKE_CXX_FLAGS=-I{}", include_dir.display()));
+            return;
+        }
+    }
+}
+
+fn run_command(mut command: std::process::Command, label: &str) {
+    let status = command
+        .status()
+        .unwrap_or_else(|err| panic!("failed to {label}: {err}"));
+    if !status.success() {
+        panic!("{label} failed with status {status}");
+    }
+}
+
+fn find_executable(name: &str) -> Option<std::path::PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(name))
+        .find(|candidate| candidate.is_file())
+}
+
+fn find_file(paths: &[&str]) -> Option<std::path::PathBuf> {
+    paths
+        .iter()
+        .map(std::path::PathBuf::from)
+        .find(|candidate| candidate.is_file())
+}
+
 // ─── macOS ───────────────────────────────────────────────────────────────────
 
 fn link_macos() {
@@ -37,7 +173,10 @@ fn link_macos() {
 
     let mut linked = false;
     for lib_dir in &search_paths {
-        if std::path::Path::new(lib_dir).join("libvulkan.dylib").exists() {
+        if std::path::Path::new(lib_dir)
+            .join("libvulkan.dylib")
+            .exists()
+        {
             println!("cargo:rustc-link-search=native={lib_dir}");
             println!("cargo:rustc-link-lib=dylib=vulkan");
             linked = true;
@@ -77,9 +216,9 @@ fn link_linux() {
         "/usr/local/lib",
     ];
 
-    let found = search_paths.iter().any(|dir| {
-        std::path::Path::new(dir).join("libvulkan.so").exists()
-    });
+    let found = search_paths
+        .iter()
+        .any(|dir| std::path::Path::new(dir).join("libvulkan.so").exists());
 
     if !found {
         println!(

--- a/install.sh
+++ b/install.sh
@@ -205,14 +205,41 @@ install_kosmickrisp() {
 install_system_vulkan_deps() {
   if is_macos; then
     install_kosmickrisp
+    section "Installing Vulkan build dependencies (macOS)"
+    local missing=()
+    for pkg in vulkan-headers vulkan-loader shaderc spirv-headers; do
+      if ! brew list "$pkg" &>/dev/null 2>&1; then
+        missing+=("$pkg")
+      fi
+    done
+    if [[ "${#missing[@]}" -gt 0 ]]; then
+      if ! brew install "${missing[@]}"; then
+        error "Failed to install Vulkan build dependencies via Homebrew."
+        echo "Please install manually: brew install vulkan-headers vulkan-loader shaderc spirv-headers" >&2
+        exit 1
+      fi
+    fi
+    success "Vulkan build dependencies present"
   else
-    section "Checking Vulkan loader (Linux)"
-    if ! ldconfig -p 2>/dev/null | grep -q libvulkan || ! [ -f /usr/include/vulkan/vulkan.h ] 2>/dev/null; then
-      echo "Vulkan loader not found. Install it with:"
-      echo "  Debian/Ubuntu: sudo apt-get install -y libvulkan-dev"
-      echo "  Fedora/RHEL:   sudo dnf install -y vulkan-loader-devel"
+    section "Installing Vulkan build dependencies (Linux)"
+    if command -v apt-get &>/dev/null; then
+      sudo apt-get update -qq
+      sudo apt-get install -y build-essential cmake libvulkan-dev glslc spirv-headers
+    elif command -v dnf &>/dev/null; then
+      sudo dnf install -y cmake gcc-c++ make vulkan-loader-devel glslc spirv-headers
+    else
+      echo "Could not detect apt-get or dnf. Install these packages manually:"
+      echo "  Debian/Ubuntu: sudo apt-get install -y build-essential cmake libvulkan-dev glslc spirv-headers"
+      echo "  Fedora/RHEL:   sudo dnf install -y cmake gcc-c++ make vulkan-loader-devel glslc spirv-headers"
       echo ""
     fi
+  fi
+}
+
+ensure_submodules_for_source_install() {
+  if [[ -f ".gitmodules" && -d ".git" ]]; then
+    section "Initializing git submodules"
+    git submodule update --init --recursive
   fi
 }
 
@@ -245,6 +272,10 @@ main() {
     # shellcheck source=/dev/null
     source "$lib_tmp"
     rm -f "$lib_tmp"
+  fi
+
+  if [[ -n "$local_lib" && -f "$local_lib" ]]; then
+    ensure_submodules_for_source_install
   fi
 
   install_system_vulkan_deps

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -157,8 +157,16 @@ install_kosmickrisp() {
   success "KosmicKrisp built and installed"
 }
 
+ensure_submodules() {
+  if [ -f ".gitmodules" ] && [ -d ".git" ]; then
+    section "Initializing git submodules"
+    git submodule update --init --recursive
+  fi
+}
+
 ensure_vulkan() {
-  # Install the Vulkan headers/loader needed to compile the Rust extension.
+  # Install the Vulkan loader/headers and shader tooling needed to compile
+  # ggml's Vulkan backend from source.
   # Must be called before maturin/cargo runs (i.e. before install_dev_deps).
   #
   # On macOS: install vulkan-headers + vulkan-loader via Homebrew. This is
@@ -168,23 +176,35 @@ ensure_vulkan() {
   # than the runtime library (libvulkan.so.1), because the linker needs
   # -lvulkan which resolves via the unversioned symlink in the -dev package.
   if is_macos; then
-    if ! brew list vulkan-loader &>/dev/null 2>&1; then
-      section "Installing Vulkan headers and loader (macOS)"
-      brew install vulkan-headers vulkan-loader
+    section "Checking Vulkan build dependencies (macOS)"
+    local missing=()
+    for pkg in vulkan-headers vulkan-loader shaderc spirv-headers; do
+      if ! brew list "$pkg" &>/dev/null 2>&1; then
+        missing+=("$pkg")
+      fi
+    done
+    if [ "${#missing[@]}" -gt 0 ]; then
+      brew install "${missing[@]}"
     fi
+    success "Vulkan build dependencies present"
   else
-    # Ubuntu 24.04 ships libvulkan1 (runtime) by default, but the linker needs
-    # libvulkan.so (the unversioned symlink) from libvulkan-dev.
-    if ! find /usr/lib /usr/lib64 /usr/local/lib -name "libvulkan.so" 2>/dev/null | grep -q .; then
-      section "Installing Vulkan dev headers (Linux)"
+    section "Checking Vulkan build dependencies (Linux)"
+    if command -v apt-get &>/dev/null; then
       sudo apt-get update -qq
-      sudo apt-get install -y libvulkan-dev
+      sudo apt-get install -y build-essential cmake libvulkan-dev glslc spirv-headers
+    elif command -v dnf &>/dev/null; then
+      sudo dnf install -y cmake gcc-c++ make vulkan-loader-devel glslc spirv-headers
+    else
+      echo "Could not detect apt-get or dnf. Install these packages manually:"
+      echo "  Debian/Ubuntu: sudo apt-get install -y build-essential cmake libvulkan-dev glslc spirv-headers"
+      echo "  Fedora/RHEL:   sudo dnf install -y cmake gcc-c++ make vulkan-loader-devel glslc spirv-headers"
     fi
   fi
 }
 
 setup_dev_env() {
   ensure_uv
+  ensure_submodules
   ensure_vulkan
   ensure_venv ".venv-vllm-vulkan"
   install_dev_deps

--- a/src/ggml.rs
+++ b/src/ggml.rs
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Minimal ggml Vulkan compute bridge.
+//!
+//! This is intentionally tiny: it proves that Python can call into Rust,
+//! Rust can call ggml, and ggml can execute a Vulkan `ggml_mul_mat`.
+
+use std::ffi::{c_char, c_void, CStr};
+use std::ptr;
+
+const GGML_DEFAULT_GRAPH_SIZE: usize = 2048;
+
+// Keep this hand-written enum value in sync with the pinned ggml submodule
+// when bumping it. Runtime validation below checks that it still resolves to
+// ggml's "f32" tensor type; bindgen can replace this once the FFI surface grows.
+const GGML_TYPE_F32: i32 = 0;
+
+#[repr(C)]
+struct GgmlInitParams {
+    mem_size: usize,
+    mem_buffer: *mut c_void,
+    no_alloc: bool,
+}
+
+#[repr(C)]
+struct GgmlContext {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+struct GgmlTensor {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+struct GgmlCGraph {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+struct GgmlBackend {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+struct GgmlBackendSched {
+    _private: [u8; 0],
+}
+
+extern "C" {
+    fn ggml_init(params: GgmlInitParams) -> *mut GgmlContext;
+    fn ggml_free(ctx: *mut GgmlContext);
+    fn ggml_tensor_overhead() -> usize;
+    fn ggml_graph_overhead() -> usize;
+    fn ggml_new_graph(ctx: *mut GgmlContext) -> *mut GgmlCGraph;
+    fn ggml_new_tensor_2d(
+        ctx: *mut GgmlContext,
+        tensor_type: i32,
+        ne0: i64,
+        ne1: i64,
+    ) -> *mut GgmlTensor;
+    fn ggml_mul_mat(
+        ctx: *mut GgmlContext,
+        a: *mut GgmlTensor,
+        b: *mut GgmlTensor,
+    ) -> *mut GgmlTensor;
+    fn ggml_build_forward_expand(graph: *mut GgmlCGraph, tensor: *mut GgmlTensor);
+    fn ggml_nbytes(tensor: *const GgmlTensor) -> usize;
+    fn ggml_type_name(tensor_type: i32) -> *const c_char;
+    fn ggml_status_to_string(status: i32) -> *const c_char;
+
+    fn ggml_backend_vk_init(dev_num: usize) -> *mut GgmlBackend;
+    fn ggml_backend_vk_get_device_count() -> i32;
+    fn ggml_backend_cpu_init() -> *mut GgmlBackend;
+    fn ggml_backend_free(backend: *mut GgmlBackend);
+    fn ggml_backend_tensor_set(
+        tensor: *mut GgmlTensor,
+        data: *const c_void,
+        offset: usize,
+        size: usize,
+    );
+    fn ggml_backend_tensor_get(
+        tensor: *const GgmlTensor,
+        data: *mut c_void,
+        offset: usize,
+        size: usize,
+    );
+    fn ggml_backend_name(backend: *mut GgmlBackend) -> *const c_char;
+    fn ggml_backend_sched_new(
+        backends: *mut *mut GgmlBackend,
+        bufts: *mut c_void,
+        n_backends: i32,
+        graph_size: usize,
+        parallel: bool,
+        op_offload: bool,
+    ) -> *mut GgmlBackendSched;
+    fn ggml_backend_sched_free(sched: *mut GgmlBackendSched);
+    fn ggml_backend_sched_reset(sched: *mut GgmlBackendSched);
+    fn ggml_backend_sched_alloc_graph(sched: *mut GgmlBackendSched, graph: *mut GgmlCGraph)
+        -> bool;
+    fn ggml_backend_sched_get_tensor_backend(
+        sched: *mut GgmlBackendSched,
+        node: *mut GgmlTensor,
+    ) -> *mut GgmlBackend;
+    fn ggml_backend_sched_graph_compute(
+        sched: *mut GgmlBackendSched,
+        graph: *mut GgmlCGraph,
+    ) -> i32;
+}
+
+struct Context(*mut GgmlContext);
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { ggml_free(self.0) };
+        }
+    }
+}
+
+struct Backend(*mut GgmlBackend);
+
+impl Drop for Backend {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { ggml_backend_free(self.0) };
+        }
+    }
+}
+
+struct Scheduler(*mut GgmlBackendSched);
+
+impl Drop for Scheduler {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { ggml_backend_sched_free(self.0) };
+        }
+    }
+}
+
+pub struct MatmulResult {
+    pub output: Vec<f32>,
+    pub backend_name: String,
+}
+
+pub fn vulkan_matmul_f32(
+    a: &[f32],
+    b_transposed: &[f32],
+    m: usize,
+    k: usize,
+    n: usize,
+    device_idx: usize,
+) -> Result<MatmulResult, String> {
+    validate_dims(a, b_transposed, m, k, n)?;
+
+    unsafe {
+        validate_ggml_ffi_constants()?;
+
+        let device_count = ggml_backend_vk_get_device_count();
+        if device_count <= 0 {
+            return Err("ggml Vulkan backend found no Vulkan devices".to_string());
+        }
+        if device_idx >= device_count as usize {
+            return Err(format!(
+                "Vulkan device index {device_idx} out of range; ggml sees {device_count} device(s)"
+            ));
+        }
+
+        let graph_buf_size = ggml_tensor_overhead()
+            .checked_mul(GGML_DEFAULT_GRAPH_SIZE)
+            .and_then(|size| size.checked_add(ggml_graph_overhead()))
+            .ok_or_else(|| "ggml graph buffer size overflowed".to_string())?;
+        let mut graph_buf = vec![0u8; graph_buf_size];
+
+        let params = GgmlInitParams {
+            mem_size: graph_buf.len(),
+            mem_buffer: graph_buf.as_mut_ptr().cast(),
+            no_alloc: true,
+        };
+        let ctx = Context(ggml_init(params));
+        if ctx.0.is_null() {
+            return Err("ggml_init failed".to_string());
+        }
+
+        let vk_backend = Backend(ggml_backend_vk_init(device_idx));
+        if vk_backend.0.is_null() {
+            return Err(format!(
+                "ggml_backend_vk_init failed for device {device_idx}"
+            ));
+        }
+
+        let cpu_backend = Backend(ggml_backend_cpu_init());
+        if cpu_backend.0.is_null() {
+            return Err("ggml CPU backend initialization failed".to_string());
+        }
+
+        let mut backends = [vk_backend.0, cpu_backend.0];
+        let sched = Scheduler(ggml_backend_sched_new(
+            backends.as_mut_ptr(),
+            ptr::null_mut(),
+            backends.len() as i32,
+            GGML_DEFAULT_GRAPH_SIZE,
+            false,
+            true,
+        ));
+        if sched.0.is_null() {
+            return Err("ggml backend scheduler initialization failed".to_string());
+        }
+
+        // To compute Python-style `A @ B`, ggml receives `B^T` as the weight
+        // tensor and `A` as the input tensor. With shapes `(m, k) @ (k, n)`,
+        // ggml tensors are weight `(k, n)`, input `(k, m)`, output `(m, n)`.
+        let weight = ggml_new_tensor_2d(ctx.0, GGML_TYPE_F32, k as i64, n as i64);
+        let input = ggml_new_tensor_2d(ctx.0, GGML_TYPE_F32, k as i64, m as i64);
+
+        if weight.is_null() || input.is_null() {
+            return Err("ggml tensor allocation failed".to_string());
+        }
+
+        let result = ggml_mul_mat(ctx.0, weight, input);
+        if result.is_null() {
+            return Err("ggml_mul_mat failed to create an output tensor".to_string());
+        }
+
+        let graph = ggml_new_graph(ctx.0);
+        if graph.is_null() {
+            return Err("ggml_new_graph failed".to_string());
+        }
+
+        ggml_build_forward_expand(graph, result);
+        ggml_backend_sched_reset(sched.0);
+
+        if !ggml_backend_sched_alloc_graph(sched.0, graph) {
+            return Err("ggml failed to allocate the Vulkan graph".to_string());
+        }
+        let backend_name = tensor_backend_name(sched.0, result)
+            .ok_or_else(|| "ggml did not assign the matmul result to a backend".to_string())?;
+
+        ggml_backend_tensor_set(
+            weight,
+            b_transposed.as_ptr().cast(),
+            0,
+            std::mem::size_of_val(b_transposed),
+        );
+        ggml_backend_tensor_set(input, a.as_ptr().cast(), 0, std::mem::size_of_val(a));
+
+        let status = ggml_backend_sched_graph_compute(sched.0, graph);
+        if !is_success_status(status) {
+            return Err(format!(
+                "ggml graph compute failed: {}",
+                status_name(status)
+            ));
+        }
+
+        let result_bytes = ggml_nbytes(result);
+        let expected_bytes = m
+            .checked_mul(n)
+            .and_then(|elements| elements.checked_mul(std::mem::size_of::<f32>()))
+            .ok_or_else(|| "ggml output size overflowed".to_string())?;
+
+        if result_bytes != expected_bytes {
+            return Err(format!(
+                "ggml output size mismatch: expected {expected_bytes} bytes, got {result_bytes}"
+            ));
+        }
+
+        let mut output = vec![0.0f32; m * n];
+        ggml_backend_tensor_get(result, output.as_mut_ptr().cast(), 0, result_bytes);
+
+        Ok(MatmulResult {
+            output,
+            backend_name,
+        })
+    }
+}
+
+fn validate_ggml_ffi_constants() -> Result<(), String> {
+    unsafe {
+        let type_name = ggml_type_name(GGML_TYPE_F32);
+        if type_name.is_null() {
+            return Err("ggml_type_name returned null for GGML_TYPE_F32".to_string());
+        }
+        let type_name = CStr::from_ptr(type_name).to_string_lossy();
+        if type_name != "f32" {
+            return Err(format!(
+                "GGML_TYPE_F32 binding mismatch: expected 'f32', got '{type_name}'"
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn tensor_backend_name(sched: *mut GgmlBackendSched, tensor: *mut GgmlTensor) -> Option<String> {
+    unsafe {
+        let backend = ggml_backend_sched_get_tensor_backend(sched, tensor);
+        if backend.is_null() {
+            return None;
+        }
+        let name = ggml_backend_name(backend);
+        if name.is_null() {
+            return None;
+        }
+        Some(CStr::from_ptr(name).to_string_lossy().into_owned())
+    }
+}
+
+fn validate_dims(
+    a: &[f32],
+    b_transposed: &[f32],
+    m: usize,
+    k: usize,
+    n: usize,
+) -> Result<(), String> {
+    if m == 0 || k == 0 || n == 0 {
+        return Err("matmul dimensions must be non-zero".to_string());
+    }
+    if a.len() != m * k {
+        return Err(format!(
+            "left input has {} values, expected {} for shape ({m}, {k})",
+            a.len(),
+            m * k
+        ));
+    }
+    if b_transposed.len() != n * k {
+        return Err(format!(
+            "right input has {} transposed values, expected {} for original shape ({k}, {n})",
+            b_transposed.len(),
+            n * k
+        ));
+    }
+    if m > i64::MAX as usize || k > i64::MAX as usize || n > i64::MAX as usize {
+        return Err("matmul dimensions exceed ggml i64 tensor limits".to_string());
+    }
+    Ok(())
+}
+
+fn is_success_status(status: i32) -> bool {
+    status_name(status) == "GGML status: success"
+}
+
+fn status_name(status: i32) -> String {
+    unsafe {
+        let ptr = ggml_status_to_string(status);
+        if ptr.is_null() {
+            return status.to_string();
+        }
+        CStr::from_ptr(ptr).to_string_lossy().into_owned()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! package `vllm_vulkan`.
 
 mod device;
+mod ggml;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -77,6 +78,93 @@ fn get_memory_info(device_idx: usize) -> PyResult<(u64, u64)> {
     device::memory_info(device_idx).map_err(PyRuntimeError::new_err)
 }
 
+/// Run a small FP32 matrix multiplication through ggml's Vulkan backend.
+///
+/// Inputs are Python nested sequences with standard shapes:
+///   a: (m, k)
+///   b: (k, n)
+/// The return value is a nested list with shape (m, n).
+#[pyfunction]
+#[pyo3(signature = (a, b, device_idx = 0))]
+fn vulkan_matmul(a: Vec<Vec<f32>>, b: Vec<Vec<f32>>, device_idx: usize) -> PyResult<Vec<Vec<f32>>> {
+    let (a_flat, b_transposed, m, k, n) =
+        flatten_matmul_inputs(&a, &b).map_err(pyo3::exceptions::PyValueError::new_err)?;
+    let result = ggml::vulkan_matmul_f32(&a_flat, &b_transposed, m, k, n, device_idx)
+        .map_err(PyRuntimeError::new_err)?;
+
+    Ok(result.output.chunks(n).map(|row| row.to_vec()).collect())
+}
+
+/// Run Vulkan matmul and return `(output, backend_name)`.
+///
+/// This is a diagnostic API for tests and backend bring-up. It lets tests
+/// assert that ggml assigned the matmul result to the Vulkan backend instead
+/// of silently falling back to CPU.
+#[pyfunction]
+#[pyo3(signature = (a, b, device_idx = 0))]
+fn vulkan_matmul_with_backend(
+    a: Vec<Vec<f32>>,
+    b: Vec<Vec<f32>>,
+    device_idx: usize,
+) -> PyResult<(Vec<Vec<f32>>, String)> {
+    let (a_flat, b_transposed, m, k, n) =
+        flatten_matmul_inputs(&a, &b).map_err(pyo3::exceptions::PyValueError::new_err)?;
+    let result = ggml::vulkan_matmul_f32(&a_flat, &b_transposed, m, k, n, device_idx)
+        .map_err(PyRuntimeError::new_err)?;
+    let output = result.output.chunks(n).map(|row| row.to_vec()).collect();
+
+    Ok((output, result.backend_name))
+}
+
+fn flatten_matmul_inputs(
+    a: &[Vec<f32>],
+    b: &[Vec<f32>],
+) -> Result<(Vec<f32>, Vec<f32>, usize, usize, usize), String> {
+    let m = a.len();
+    let k = a
+        .first()
+        .map(Vec::len)
+        .ok_or_else(|| "left matrix must have at least one row".to_string())?;
+
+    if k == 0 {
+        return Err("left matrix must have at least one column".to_string());
+    }
+
+    if a.iter().any(|row| row.len() != k) {
+        return Err("left matrix rows must all have the same length".to_string());
+    }
+
+    if b.len() != k {
+        return Err(format!(
+            "shape mismatch: left matrix is ({m}, {k}) but right matrix has {} row(s)",
+            b.len()
+        ));
+    }
+
+    let n = b
+        .first()
+        .map(Vec::len)
+        .ok_or_else(|| "right matrix must have at least one row".to_string())?;
+
+    if n == 0 {
+        return Err("right matrix must have at least one column".to_string());
+    }
+
+    if b.iter().any(|row| row.len() != n) {
+        return Err("right matrix rows must all have the same length".to_string());
+    }
+
+    let a_flat = a.iter().flat_map(|row| row.iter().copied()).collect();
+    let mut b_transposed = vec![0.0; n * k];
+    for row in 0..k {
+        for col in 0..n {
+            b_transposed[col * k + row] = b[row][col];
+        }
+    }
+
+    Ok((a_flat, b_transposed, m, k, n))
+}
+
 // ─── PyO3 module ────────────────────────────────────────────────────────────
 
 /// Python-visible module `vllm_vulkan._rs`.
@@ -90,6 +178,8 @@ fn _rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_device_info, m)?)?;
     m.add_function(wrap_pyfunction!(synchronize, m)?)?;
     m.add_function(wrap_pyfunction!(get_memory_info, m)?)?;
+    m.add_function(wrap_pyfunction!(vulkan_matmul, m)?)?;
+    m.add_function(wrap_pyfunction!(vulkan_matmul_with_backend, m)?)?;
 
     m.add_class::<VulkanDevice>()?;
 

--- a/tests/python/test_ggml_matmul.py
+++ b/tests/python/test_ggml_matmul.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the first real ggml Vulkan compute path."""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from vllm_vulkan import _rs
+
+
+@pytest.fixture(scope="module")
+def vulkan_runtime():
+    # On macOS, the Vulkan loader may need an explicit ICD path. Without it,
+    # ggml can abort inside the C backend before Rust can turn the failure into
+    # a Python exception. Keep default test runs safe, and run this test with
+    # VK_ICD_FILENAMES set when validating MoltenVK locally.
+    if (
+        sys.platform == "darwin"
+        and not os.environ.get("VK_ICD_FILENAMES")
+        and not _rs.is_available()
+    ):
+        pytest.skip("macOS Vulkan ICD is not configured")
+
+
+@pytest.fixture(scope="module")
+def log_vulkan_devices(vulkan_runtime):
+    try:
+        devices = _rs.enumerate_devices()
+    except RuntimeError as exc:
+        print(f"Vulkan device enumeration unavailable: {exc}")
+    else:
+        print(f"Vulkan devices visible to test: {devices}")
+
+
+def run_vulkan_matmul_or_skip(left, right):
+    try:
+        return _rs.vulkan_matmul_with_backend(left, right)
+    except RuntimeError as exc:
+        unavailable_markers = (
+            "ggml Vulkan backend found no Vulkan devices",
+            "Vulkan device index",
+            "ggml_backend_vk_init failed",
+        )
+        if any(marker in str(exc) for marker in unavailable_markers):
+            pytest.skip(f"ggml Vulkan backend unavailable: {exc}")
+        raise
+
+
+@pytest.mark.parametrize(
+    ("m", "k", "n", "rtol", "atol"),
+    [
+        (2, 3, 2, 1e-4, 1e-4),
+        (1, 4, 3, 1e-4, 1e-4),
+        (4, 5, 1, 1e-4, 1e-4),
+        (8, 7, 6, 1e-4, 1e-4),
+        # ggml's Vulkan matmul can differ from NumPy's CPU BLAS reference due
+        # to backend-specific FP32 reduction order / precision choices. Keep a
+        # larger shape in the smoke test, but use a tolerance observed on real
+        # MoltenVK output instead of weakening the small exactness checks.
+        (32, 64, 16, 1e-3, 1e-2),
+    ],
+)
+def test_vulkan_matmul_matches_numpy(log_vulkan_devices, m, k, n, rtol, atol):
+    rng = np.random.default_rng(seed=m * 100 + k * 10 + n)
+    left = rng.normal(size=(m, k)).astype(np.float32)
+    right = rng.normal(size=(k, n)).astype(np.float32)
+
+    output, backend_name = run_vulkan_matmul_or_skip(left, right)
+    actual = np.array(output, dtype=np.float32)
+
+    print(f"ggml matmul backend: {backend_name}")
+    assert "Vulkan" in backend_name, f"matmul ran on {backend_name}, not Vulkan"
+    np.testing.assert_allclose(actual, left @ right, rtol=rtol, atol=atol)
+
+
+def test_vulkan_matmul_rejects_bad_shapes():
+    with pytest.raises(ValueError, match="shape mismatch"):
+        _rs.vulkan_matmul([[1.0, 2.0]], [[1.0, 2.0]])


### PR DESCRIPTION
## Summary

Aadd the first Vulkan compute path by integrating ggml as a pinned submodule and exposing a Python-callable Vulkan matmul through the Rust extension.

Before this, the plugin could register a Vulkan platform and enumerate devices, but execution still went through vLLM's CPU path. 

## Testing

Verified that ggml discovers the Vulkan device and that the matmul result is assigned to the Vulkan backend.