### PR TITLE
add pytorch.org whl cpu build index for torch==*+cpu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,7 @@ main() {
   tar xf "$filename"
   cd "vllm-$vllm_v"
 
-  uv pip install -r requirements/cpu.txt --index-strategy unsafe-best-match
+  uv pip install -r requirements/cpu.txt --index-strategy unsafe-best-match --extra-index-url=https://download.pytorch.org/whl/cpu
   CXXFLAGS="-Wno-parentheses" uv pip install .
   cd -
   rm -rf "vllm-$vllm_v"*


### PR DESCRIPTION
right now `uv pip install -r requirements/cpu.txt` on L151 is failing due to `torch==2.10.0+cpu` not being published on pypi.

pytorch.org publishes CPU wheels over at download.pytorch.org/whl/cpu, so add it as an extra-index-url to be able to satisfy this requirement.