### PR TITLE
feat: init Vulkan decode attention backend

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -43,23 +43,14 @@ fn compile_shaders() {
 
     fs::create_dir_all(&out_spirv).expect("failed to create OUT_DIR/spirv");
 
-    // Count already-compiled .spv files in OUT_DIR (incremental rebuild).
-    let compiled: Vec<_> = fs::read_dir(&out_spirv)
-        .map(|rd| {
-            rd.flatten()
-                .filter(|e| {
-                    e.path().extension().and_then(|x| x.to_str()) == Some("spv")
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
-    if !compiled.is_empty() {
-        println!(
-            "cargo:warning=vllm-vulkan: {} SPIR-V shaders already in OUT_DIR, skipping compilation",
-            compiled.len()
-        );
-        return;
+    // The build script only reruns when shader sources change, so when it does
+    // run, rebuild OUT_DIR's SPIR-V set from source.  Otherwise adding a new
+    // shader can leave stale OUT_DIR contents and break include_bytes! below.
+    for entry in fs::read_dir(&out_spirv).unwrap().flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("spv") {
+            fs::remove_file(path).ok();
+        }
     }
 
     // Run compile_shaders.sh to build the .spv files into OUT_DIR/spirv.
@@ -124,6 +115,7 @@ fn link_macos() {
         if Path::new(lib_dir.as_str()).join("libvulkan.dylib").exists() {
             println!("cargo:rustc-link-search=native={lib_dir}");
             println!("cargo:rustc-link-lib=dylib=vulkan");
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{lib_dir}");
             linked = true;
             break;
         }

--- a/scripts/compile_shaders.sh
+++ b/scripts/compile_shaders.sh
@@ -339,6 +339,14 @@ echo "=== Quantization utils ==="
 compile "quantize_q8_1_x4" "quantize_q8_1.comp" \
   DATA_A_F32=1 A_TYPE=float D_TYPE=float FLOAT_TYPE=float QBLOCK_X4=1 RMS_NORM_ROPE_FUSION=0
 
+# ── Paged KV cache ────────────────────────────────────────────────────────────
+echo ""
+echo "=== Paged KV cache ==="
+compile "paged_kv_write_f16" "paged_kv_write_f16.comp"
+compile "paged_kv_write_f32" "paged_kv_write_f32.comp"
+compile "paged_attn_decode_f16" "paged_attn_decode_f16.comp"
+compile "paged_attn_decode_f32" "paged_attn_decode_f32.comp"
+
 # ── Summary ────────────────────────────────────────────────────────────────────
 echo ""
 if [ "${FAILED}" -gt 0 ]; then

--- a/scripts/compile_shaders.sh
+++ b/scripts/compile_shaders.sh
@@ -345,7 +345,9 @@ echo "=== Paged KV cache ==="
 compile "paged_kv_write_f16" "paged_kv_write_f16.comp"
 compile "paged_kv_write_f32" "paged_kv_write_f32.comp"
 compile "paged_attn_decode_f16" "paged_attn_decode_f16.comp"
+compile "paged_attn_decode_f16_coop" "paged_attn_decode_f16_coop.comp"
 compile "paged_attn_decode_f32" "paged_attn_decode_f32.comp"
+compile "paged_attn_decode_f32_coop" "paged_attn_decode_f32_coop.comp"
 
 # ── Summary ────────────────────────────────────────────────────────────────────
 echo ""

--- a/shaders/paged_attn_decode_f16.comp
+++ b/shaders/paged_attn_decode_f16.comp
@@ -1,0 +1,85 @@
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_16bit_storage : require
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer QInput {
+    float q[];
+};
+
+layout(binding = 1) readonly buffer BlockTable {
+    uint blocks[];
+};
+
+layout(binding = 2) readonly buffer KVCache {
+    float16_t cache[];
+};
+
+layout(binding = 3) writeonly buffer Output {
+    float output_data[];
+};
+
+layout(push_constant) uniform parameter {
+    uint seq_len;
+    uint num_q_heads;
+    uint num_kv_heads;
+    uint head_size;
+    uint block_size;
+    uint layer_base_elements;
+    uint plane_elements_per_block;
+    uint block_elements;
+    float scale;
+} p;
+
+uint kv_base_for_token(uint token_idx, uint kv_head) {
+    const uint logical_block_id = token_idx / p.block_size;
+    const uint token_offset_in_block =
+        token_idx - logical_block_id * p.block_size;
+    const uint physical_block_id = blocks[logical_block_id];
+    const uint elements_per_token = p.num_kv_heads * p.head_size;
+    return p.layer_base_elements +
+        physical_block_id * p.block_elements +
+        token_offset_in_block * elements_per_token +
+        kv_head * p.head_size;
+}
+
+void main() {
+    const uint global_idx = gl_GlobalInvocationID.x;
+    const uint total_elements = p.num_q_heads * p.head_size;
+    if (global_idx >= total_elements) {
+        return;
+    }
+
+    const uint q_head = global_idx / p.head_size;
+    const uint head_element = global_idx - q_head * p.head_size;
+    const uint gqa_ratio = p.num_q_heads / p.num_kv_heads;
+    const uint kv_head = q_head / gqa_ratio;
+    const uint q_base = q_head * p.head_size;
+
+    float max_logit = -3.402823466e+38;
+    for (uint token_idx = 0; token_idx < p.seq_len; token_idx++) {
+        const uint k_base = kv_base_for_token(token_idx, kv_head);
+        float dot = 0.0;
+        for (uint d = 0; d < p.head_size; d++) {
+            dot += q[q_base + d] * float(cache[k_base + d]);
+        }
+        max_logit = max(max_logit, dot * p.scale);
+    }
+
+    float denom = 0.0;
+    float acc = 0.0;
+    for (uint token_idx = 0; token_idx < p.seq_len; token_idx++) {
+        const uint kv_base = kv_base_for_token(token_idx, kv_head);
+        float dot = 0.0;
+        for (uint d = 0; d < p.head_size; d++) {
+            dot += q[q_base + d] * float(cache[kv_base + d]);
+        }
+        const float weight = exp(dot * p.scale - max_logit);
+        denom += weight;
+        acc += weight * float(
+            cache[kv_base + p.plane_elements_per_block + head_element]);
+    }
+
+    output_data[global_idx] = denom > 0.0 ? acc / denom : 0.0;
+}

--- a/shaders/paged_attn_decode_f16.comp
+++ b/shaders/paged_attn_decode_f16.comp
@@ -57,16 +57,9 @@ void main() {
     const uint kv_head = q_head / gqa_ratio;
     const uint q_base = q_head * p.head_size;
 
-    float max_logit = -3.402823466e+38;
-    for (uint token_idx = 0; token_idx < p.seq_len; token_idx++) {
-        const uint k_base = kv_base_for_token(token_idx, kv_head);
-        float dot = 0.0;
-        for (uint d = 0; d < p.head_size; d++) {
-            dot += q[q_base + d] * float(cache[k_base + d]);
-        }
-        max_logit = max(max_logit, dot * p.scale);
-    }
-
+    // Online softmax keeps the numerically stable max/sum state while scanning
+    // K/V once instead of recomputing every QK dot product in a second pass.
+    float running_max = -3.402823466e+38;
     float denom = 0.0;
     float acc = 0.0;
     for (uint token_idx = 0; token_idx < p.seq_len; token_idx++) {
@@ -75,10 +68,16 @@ void main() {
         for (uint d = 0; d < p.head_size; d++) {
             dot += q[q_base + d] * float(cache[kv_base + d]);
         }
-        const float weight = exp(dot * p.scale - max_logit);
+        const float logit = dot * p.scale;
+        const float new_max = max(running_max, logit);
+        const float old_scale = exp(running_max - new_max);
+        const float weight = exp(logit - new_max);
+        denom = denom * old_scale;
+        acc = acc * old_scale;
         denom += weight;
         acc += weight * float(
             cache[kv_base + p.plane_elements_per_block + head_element]);
+        running_max = new_max;
     }
 
     output_data[global_idx] = denom > 0.0 ? acc / denom : 0.0;

--- a/shaders/paged_attn_decode_f16_coop.comp
+++ b/shaders/paged_attn_decode_f16_coop.comp
@@ -1,0 +1,107 @@
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_16bit_storage : require
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer QInput {
+    float q[];
+};
+
+layout(binding = 1) readonly buffer BlockTable {
+    uint blocks[];
+};
+
+layout(binding = 2) readonly buffer KVCache {
+    float16_t cache[];
+};
+
+layout(binding = 3) writeonly buffer Output {
+    float output_data[];
+};
+
+layout(push_constant) uniform parameter {
+    uint seq_len;
+    uint num_q_heads;
+    uint num_kv_heads;
+    uint head_size;
+    uint block_size;
+    uint layer_base_elements;
+    uint plane_elements_per_block;
+    uint block_elements;
+    float scale;
+} p;
+
+shared float dot_sums[256];
+
+uint kv_base_for_token(uint token_idx, uint kv_head) {
+    const uint logical_block_id = token_idx / p.block_size;
+    const uint token_offset_in_block =
+        token_idx - logical_block_id * p.block_size;
+    const uint physical_block_id = blocks[logical_block_id];
+    const uint elements_per_token = p.num_kv_heads * p.head_size;
+    return p.layer_base_elements +
+        physical_block_id * p.block_elements +
+        token_offset_in_block * elements_per_token +
+        kv_head * p.head_size;
+}
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint q_head = gl_WorkGroupID.x;
+    const uint output_tile = gl_WorkGroupID.y;
+    if (q_head >= p.num_q_heads) {
+        return;
+    }
+
+    const uint head_element = output_tile * gl_WorkGroupSize.x + tid;
+    const bool writes_output = head_element < p.head_size;
+    const uint gqa_ratio = p.num_q_heads / p.num_kv_heads;
+    const uint kv_head = q_head / gqa_ratio;
+    const uint q_base = q_head * p.head_size;
+
+    // One workgroup cooperatively computes QK for one q_head/output tile.
+    // This reuses each QK score across up to 256 output elements instead of
+    // recomputing the same dot product once per element.
+    float running_max = -3.402823466e+38;
+    float denom = 0.0;
+    float acc = 0.0;
+    for (uint token_idx = 0; token_idx < p.seq_len; token_idx++) {
+        const uint kv_base = kv_base_for_token(token_idx, kv_head);
+
+        float partial_dot = 0.0;
+        for (uint d = tid; d < p.head_size; d += gl_WorkGroupSize.x) {
+            partial_dot += q[q_base + d] * float(cache[kv_base + d]);
+        }
+
+        dot_sums[tid] = partial_dot;
+        barrier();
+
+        for (uint stride = gl_WorkGroupSize.x / 2; stride > 0; stride >>= 1) {
+            if (tid < stride) {
+                dot_sums[tid] += dot_sums[tid + stride];
+            }
+            barrier();
+        }
+
+        const float logit = dot_sums[0] * p.scale;
+        const float new_max = max(running_max, logit);
+        const float old_scale = exp(running_max - new_max);
+        const float weight = exp(logit - new_max);
+        denom = denom * old_scale;
+        acc = acc * old_scale;
+        denom += weight;
+        if (writes_output) {
+            acc += weight * float(
+                cache[kv_base + p.plane_elements_per_block + head_element]);
+        }
+        running_max = new_max;
+
+        barrier();
+    }
+
+    if (writes_output) {
+        output_data[q_head * p.head_size + head_element] =
+            denom > 0.0 ? acc / denom : 0.0;
+    }
+}

--- a/shaders/paged_attn_decode_f32.comp
+++ b/shaders/paged_attn_decode_f32.comp
@@ -1,0 +1,82 @@
+#version 450
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer QInput {
+    float q[];
+};
+
+layout(binding = 1) readonly buffer BlockTable {
+    uint blocks[];
+};
+
+layout(binding = 2) readonly buffer KVCache {
+    float cache[];
+};
+
+layout(binding = 3) writeonly buffer Output {
+    float output_data[];
+};
+
+layout(push_constant) uniform parameter {
+    uint seq_len;
+    uint num_q_heads;
+    uint num_kv_heads;
+    uint head_size;
+    uint block_size;
+    uint layer_base_elements;
+    uint plane_elements_per_block;
+    uint block_elements;
+    float scale;
+} p;
+
+uint kv_base_for_token(uint token_idx, uint kv_head) {
+    const uint logical_block_id = token_idx / p.block_size;
+    const uint token_offset_in_block =
+        token_idx - logical_block_id * p.block_size;
+    const uint physical_block_id = blocks[logical_block_id];
+    const uint elements_per_token = p.num_kv_heads * p.head_size;
+    return p.layer_base_elements +
+        physical_block_id * p.block_elements +
+        token_offset_in_block * elements_per_token +
+        kv_head * p.head_size;
+}
+
+void main() {
+    const uint global_idx = gl_GlobalInvocationID.x;
+    const uint total_elements = p.num_q_heads * p.head_size;
+    if (global_idx >= total_elements) {
+        return;
+    }
+
+    const uint q_head = global_idx / p.head_size;
+    const uint head_element = global_idx - q_head * p.head_size;
+    const uint gqa_ratio = p.num_q_heads / p.num_kv_heads;
+    const uint kv_head = q_head / gqa_ratio;
+    const uint q_base = q_head * p.head_size;
+
+    float max_logit = -3.402823466e+38;
+    for (uint token_idx = 0; token_idx < p.seq_len; token_idx++) {
+        const uint k_base = kv_base_for_token(token_idx, kv_head);
+        float dot = 0.0;
+        for (uint d = 0; d < p.head_size; d++) {
+            dot += q[q_base + d] * cache[k_base + d];
+        }
+        max_logit = max(max_logit, dot * p.scale);
+    }
+
+    float denom = 0.0;
+    float acc = 0.0;
+    for (uint token_idx = 0; token_idx < p.seq_len; token_idx++) {
+        const uint kv_base = kv_base_for_token(token_idx, kv_head);
+        float dot = 0.0;
+        for (uint d = 0; d < p.head_size; d++) {
+            dot += q[q_base + d] * cache[kv_base + d];
+        }
+        const float weight = exp(dot * p.scale - max_logit);
+        denom += weight;
+        acc += weight * cache[kv_base + p.plane_elements_per_block + head_element];
+    }
+
+    output_data[global_idx] = denom > 0.0 ? acc / denom : 0.0;
+}

--- a/shaders/paged_attn_decode_f32.comp
+++ b/shaders/paged_attn_decode_f32.comp
@@ -55,16 +55,9 @@ void main() {
     const uint kv_head = q_head / gqa_ratio;
     const uint q_base = q_head * p.head_size;
 
-    float max_logit = -3.402823466e+38;
-    for (uint token_idx = 0; token_idx < p.seq_len; token_idx++) {
-        const uint k_base = kv_base_for_token(token_idx, kv_head);
-        float dot = 0.0;
-        for (uint d = 0; d < p.head_size; d++) {
-            dot += q[q_base + d] * cache[k_base + d];
-        }
-        max_logit = max(max_logit, dot * p.scale);
-    }
-
+    // Online softmax keeps the numerically stable max/sum state while scanning
+    // K/V once instead of recomputing every QK dot product in a second pass.
+    float running_max = -3.402823466e+38;
     float denom = 0.0;
     float acc = 0.0;
     for (uint token_idx = 0; token_idx < p.seq_len; token_idx++) {
@@ -73,9 +66,15 @@ void main() {
         for (uint d = 0; d < p.head_size; d++) {
             dot += q[q_base + d] * cache[kv_base + d];
         }
-        const float weight = exp(dot * p.scale - max_logit);
+        const float logit = dot * p.scale;
+        const float new_max = max(running_max, logit);
+        const float old_scale = exp(running_max - new_max);
+        const float weight = exp(logit - new_max);
+        denom = denom * old_scale;
+        acc = acc * old_scale;
         denom += weight;
         acc += weight * cache[kv_base + p.plane_elements_per_block + head_element];
+        running_max = new_max;
     }
 
     output_data[global_idx] = denom > 0.0 ? acc / denom : 0.0;

--- a/shaders/paged_attn_decode_f32_coop.comp
+++ b/shaders/paged_attn_decode_f32_coop.comp
@@ -1,0 +1,105 @@
+#version 450
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer QInput {
+    float q[];
+};
+
+layout(binding = 1) readonly buffer BlockTable {
+    uint blocks[];
+};
+
+layout(binding = 2) readonly buffer KVCache {
+    float cache[];
+};
+
+layout(binding = 3) writeonly buffer Output {
+    float output_data[];
+};
+
+layout(push_constant) uniform parameter {
+    uint seq_len;
+    uint num_q_heads;
+    uint num_kv_heads;
+    uint head_size;
+    uint block_size;
+    uint layer_base_elements;
+    uint plane_elements_per_block;
+    uint block_elements;
+    float scale;
+} p;
+
+shared float dot_sums[256];
+
+uint kv_base_for_token(uint token_idx, uint kv_head) {
+    const uint logical_block_id = token_idx / p.block_size;
+    const uint token_offset_in_block =
+        token_idx - logical_block_id * p.block_size;
+    const uint physical_block_id = blocks[logical_block_id];
+    const uint elements_per_token = p.num_kv_heads * p.head_size;
+    return p.layer_base_elements +
+        physical_block_id * p.block_elements +
+        token_offset_in_block * elements_per_token +
+        kv_head * p.head_size;
+}
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint q_head = gl_WorkGroupID.x;
+    const uint output_tile = gl_WorkGroupID.y;
+    if (q_head >= p.num_q_heads) {
+        return;
+    }
+
+    const uint head_element = output_tile * gl_WorkGroupSize.x + tid;
+    const bool writes_output = head_element < p.head_size;
+    const uint gqa_ratio = p.num_q_heads / p.num_kv_heads;
+    const uint kv_head = q_head / gqa_ratio;
+    const uint q_base = q_head * p.head_size;
+
+    // One workgroup cooperatively computes QK for one q_head/output tile.
+    // This reuses each QK score across up to 256 output elements instead of
+    // recomputing the same dot product once per element.
+    float running_max = -3.402823466e+38;
+    float denom = 0.0;
+    float acc = 0.0;
+    for (uint token_idx = 0; token_idx < p.seq_len; token_idx++) {
+        const uint kv_base = kv_base_for_token(token_idx, kv_head);
+
+        float partial_dot = 0.0;
+        for (uint d = tid; d < p.head_size; d += gl_WorkGroupSize.x) {
+            partial_dot += q[q_base + d] * cache[kv_base + d];
+        }
+
+        dot_sums[tid] = partial_dot;
+        barrier();
+
+        for (uint stride = gl_WorkGroupSize.x / 2; stride > 0; stride >>= 1) {
+            if (tid < stride) {
+                dot_sums[tid] += dot_sums[tid + stride];
+            }
+            barrier();
+        }
+
+        const float logit = dot_sums[0] * p.scale;
+        const float new_max = max(running_max, logit);
+        const float old_scale = exp(running_max - new_max);
+        const float weight = exp(logit - new_max);
+        denom = denom * old_scale;
+        acc = acc * old_scale;
+        denom += weight;
+        if (writes_output) {
+            acc += weight *
+                cache[kv_base + p.plane_elements_per_block + head_element];
+        }
+        running_max = new_max;
+
+        barrier();
+    }
+
+    if (writes_output) {
+        output_data[q_head * p.head_size + head_element] =
+            denom > 0.0 ? acc / denom : 0.0;
+    }
+}

--- a/shaders/paged_kv_write_f16.comp
+++ b/shaders/paged_kv_write_f16.comp
@@ -1,0 +1,55 @@
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_16bit_storage : require
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer KInput {
+    float16_t data_k[];
+};
+
+layout(binding = 1) readonly buffer VInput {
+    float16_t data_v[];
+};
+
+layout(binding = 2) readonly buffer SlotMapping {
+    uint slots[];
+};
+
+layout(binding = 3) buffer KVCache {
+    float16_t cache[];
+};
+
+layout(push_constant) uniform parameter {
+    uint num_tokens;
+    uint num_kv_heads;
+    uint head_size;
+    uint block_size;
+    uint layer_base_elements;
+    uint plane_elements_per_block;
+    uint block_elements;
+} p;
+
+void main() {
+    const uint global_idx = gl_GlobalInvocationID.x;
+    const uint elements_per_token = p.num_kv_heads * p.head_size;
+    const uint total_elements = p.num_tokens * elements_per_token;
+    if (global_idx >= total_elements) {
+        return;
+    }
+
+    const uint token_idx = global_idx / elements_per_token;
+    const uint token_element = global_idx - token_idx * elements_per_token;
+    const uint slot = slots[token_idx];
+
+    const uint physical_block_id = slot / p.block_size;
+    const uint token_offset_in_block = slot - physical_block_id * p.block_size;
+
+    const uint block_base =
+        p.layer_base_elements + physical_block_id * p.block_elements;
+    const uint dst =
+        block_base + token_offset_in_block * elements_per_token + token_element;
+
+    cache[dst] = data_k[global_idx];
+    cache[dst + p.plane_elements_per_block] = data_v[global_idx];
+}

--- a/shaders/paged_kv_write_f32.comp
+++ b/shaders/paged_kv_write_f32.comp
@@ -1,0 +1,53 @@
+#version 450
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer KInput {
+    float data_k[];
+};
+
+layout(binding = 1) readonly buffer VInput {
+    float data_v[];
+};
+
+layout(binding = 2) readonly buffer SlotMapping {
+    uint slots[];
+};
+
+layout(binding = 3) buffer KVCache {
+    float cache[];
+};
+
+layout(push_constant) uniform parameter {
+    uint num_tokens;
+    uint num_kv_heads;
+    uint head_size;
+    uint block_size;
+    uint layer_base_elements;
+    uint plane_elements_per_block;
+    uint block_elements;
+} p;
+
+void main() {
+    const uint global_idx = gl_GlobalInvocationID.x;
+    const uint elements_per_token = p.num_kv_heads * p.head_size;
+    const uint total_elements = p.num_tokens * elements_per_token;
+    if (global_idx >= total_elements) {
+        return;
+    }
+
+    const uint token_idx = global_idx / elements_per_token;
+    const uint token_element = global_idx - token_idx * elements_per_token;
+    const uint slot = slots[token_idx];
+
+    const uint physical_block_id = slot / p.block_size;
+    const uint token_offset_in_block = slot - physical_block_id * p.block_size;
+
+    const uint block_base =
+        p.layer_base_elements + physical_block_id * p.block_elements;
+    const uint dst =
+        block_base + token_offset_in_block * elements_per_token + token_element;
+
+    cache[dst] = data_k[global_idx];
+    cache[dst + p.plane_elements_per_block] = data_v[global_idx];
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -271,20 +271,25 @@ impl ComputeDevice {
         // Query device capabilities.
         let props = unsafe { instance.get_physical_device_properties(pd) };
 
-        // Enable fp16 if the device supports it.
-        // We query the features into local structs, then extract raw copies.
-        let (fp16, has_float64) = unsafe {
+        // f16 KV-cache shaders need both f16 storage buffers and f16 shader
+        // arithmetic/conversion.
+        let (storage_buffer_16_bit_access, shader_float16, has_float64) = unsafe {
             let mut features16 = vk::PhysicalDevice16BitStorageFeatures::default();
+            let mut float16_int8 = vk::PhysicalDeviceShaderFloat16Int8Features::default();
             let p16 = &mut features16 as *mut vk::PhysicalDevice16BitStorageFeatures;
-            let mut features2 = vk::PhysicalDeviceFeatures2::default().push_next(&mut *p16);
+            let pf16 = &mut float16_int8 as *mut vk::PhysicalDeviceShaderFloat16Int8Features;
+            let mut features2 = vk::PhysicalDeviceFeatures2::default()
+                .push_next(&mut *pf16)
+                .push_next(&mut *p16);
             instance.get_physical_device_features2(pd, &mut features2);
             // Read results from the raw pointers — safe because Vulkan has
             // filled the structs and we are still within the unsafe block.
-            let fp16_val = (*p16).storage_buffer16_bit_access == vk::TRUE;
+            let storage16_val = (*p16).storage_buffer16_bit_access == vk::TRUE;
+            let shader_f16_val = (*pf16).shader_float16 == vk::TRUE;
             let f64_val  = features2.features.shader_float64 == vk::TRUE;
-            (fp16_val, f64_val)
+            (storage16_val, shader_f16_val, f64_val)
         };
-        let fp16 = fp16 || has_float64; // rough heuristic
+        let fp16 = storage_buffer_16_bit_access && shader_float16;
 
         let device_features = vk::PhysicalDeviceFeatures {
             shader_float64: if has_float64 { vk::TRUE } else { vk::FALSE },
@@ -305,18 +310,35 @@ impl ComputeDevice {
             .collect();
 
         let ext_16bit = c"VK_KHR_16bit_storage";
+        let ext_float16_int8 = c"VK_KHR_shader_float16_int8";
         let ext_storage8 = c"VK_KHR_8bit_storage";
         let ext_portability = c"VK_KHR_portability_subset";
 
         let mut exts: Vec<*const c_char> = Vec::new();
         if available_names.contains(&&*ext_16bit)   { exts.push(ext_16bit.as_ptr()); }
+        if available_names.contains(&&*ext_float16_int8) { exts.push(ext_float16_int8.as_ptr()); }
         if available_names.contains(&&*ext_storage8) { exts.push(ext_storage8.as_ptr()); }
         if available_names.contains(&&*ext_portability) { exts.push(ext_portability.as_ptr()); }
 
-        let device_ci = vk::DeviceCreateInfo::default()
+        let mut enabled_features16 = vk::PhysicalDevice16BitStorageFeatures {
+            storage_buffer16_bit_access: if storage_buffer_16_bit_access { vk::TRUE } else { vk::FALSE },
+            ..Default::default()
+        };
+        let mut enabled_float16_int8 = vk::PhysicalDeviceShaderFloat16Int8Features {
+            shader_float16: if shader_float16 { vk::TRUE } else { vk::FALSE },
+            ..Default::default()
+        };
+
+        let mut device_ci = vk::DeviceCreateInfo::default()
             .queue_create_infos(std::slice::from_ref(&queue_ci))
             .enabled_extension_names(&exts)
             .enabled_features(&device_features);
+        if storage_buffer_16_bit_access {
+            device_ci = device_ci.push_next(&mut enabled_features16);
+        }
+        if shader_float16 {
+            device_ci = device_ci.push_next(&mut enabled_float16_int8);
+        }
 
         let device = unsafe { instance.create_device(pd, &device_ci, None) }
             .map_err(|e| format!("vkCreateDevice: {e}"))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -751,6 +751,10 @@ fn include_all_shaders() -> std::collections::HashMap<String, Vec<u8>> {
     spv!("matmul_f32_f32");
     spv!("mul_mat_vec_f32_f32_f32");
     spv!("flash_attn_f32_f16_f32_fp32");
+    spv!("paged_kv_write_f16");
+    spv!("paged_kv_write_f32");
+    spv!("paged_attn_decode_f16");
+    spv!("paged_attn_decode_f32");
 
     map
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -754,7 +754,9 @@ fn include_all_shaders() -> std::collections::HashMap<String, Vec<u8>> {
     spv!("paged_kv_write_f16");
     spv!("paged_kv_write_f32");
     spv!("paged_attn_decode_f16");
+    spv!("paged_attn_decode_f16_coop");
     spv!("paged_attn_decode_f32");
+    spv!("paged_attn_decode_f32_coop");
 
     map
 }

--- a/tests/python/test_attention_backend.py
+++ b/tests/python/test_attention_backend.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Vulkan attention backend shim."""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm", reason="vllm not installed; skipping attention tests")
+_rs = pytest.importorskip("vllm_vulkan._rs", exc_type=ImportError)
+
+from vllm.v1.attention.backend import AttentionType  # noqa: E402
+from vllm.v1.attention.backends.cpu_attn import CPUAttentionMetadata  # noqa: E402
+
+from vllm_vulkan.attention import VulkanAttentionBackendImpl  # noqa: E402
+
+
+def _require_vulkan_context():
+    if not _rs.is_available():
+        pytest.skip("no Vulkan device available")
+    try:
+        return _rs.VulkanContext(0)
+    except RuntimeError as exc:
+        pytest.skip(f"VulkanContext unavailable: {exc}")
+
+
+def test_vulkan_attention_backend_uses_paged_decode_for_single_token_batch():
+    _require_vulkan_context()
+
+    num_heads = 4
+    num_kv_heads = 2
+    head_size = 32
+    block_size = 16
+    num_blocks = 4
+    num_reqs = 2
+    scale = head_size**-0.5
+
+    query = torch.randn(num_reqs, num_heads, head_size, dtype=torch.float32)
+    key = torch.randn(num_reqs, num_kv_heads, head_size, dtype=torch.float16)
+    value = torch.randn(num_reqs, num_kv_heads, head_size, dtype=torch.float16)
+    kv_cache = torch.zeros(
+        (2, num_blocks, num_kv_heads, block_size, head_size),
+        dtype=torch.float16,
+    )
+    output = torch.empty((num_reqs, num_heads, head_size), dtype=torch.float32)
+
+    metadata = CPUAttentionMetadata(
+        isa="vec16",
+        num_actual_tokens=num_reqs,
+        max_query_len=1,
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        max_seq_len=1,
+        seq_lens=torch.tensor([1, 1], dtype=torch.int32),
+        block_table=torch.tensor([[0], [1]], dtype=torch.int32),
+        slot_mapping=torch.tensor([0, block_size], dtype=torch.int64),
+        scheduler_metadata=None,
+        causal=True,
+    )
+    impl = VulkanAttentionBackendImpl(
+        num_heads=num_heads,
+        head_size=head_size,
+        scale=scale,
+        num_kv_heads=num_kv_heads,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+        attn_type=AttentionType.DECODER,
+        kv_sharing_target_layer_name=None,
+    )
+
+    result = impl.forward(
+        layer=None,  # type: ignore[arg-type]
+        query=query,
+        key=key,
+        value=value,
+        kv_cache=kv_cache,
+        attn_metadata=metadata,
+        output=output,
+    )
+
+    # With seq_len=1 per request, softmax is exactly 1 for the current token, so
+    # decode output is the request's V head repeated through GQA.
+    expected = []
+    gqa_ratio = num_heads // num_kv_heads
+    for req_idx in range(num_reqs):
+        rows = []
+        for q_head in range(num_heads):
+            rows.append(value[req_idx, q_head // gqa_ratio].float())
+        expected.append(torch.stack(rows))
+    expected = torch.stack(expected)
+
+    assert impl._last_vulkan_decode_used is True
+    assert result is output
+
+    torch.testing.assert_close(output, expected, rtol=5e-3, atol=5e-3)

--- a/tests/python/test_attention_backend.py
+++ b/tests/python/test_attention_backend.py
@@ -202,3 +202,47 @@ def test_vulkan_attention_backend_mirrors_prefill_kv_before_decode():
     assert impl._last_vulkan_decode_used is True
     assert result is output
     torch.testing.assert_close(output, expected, rtol=5e-3, atol=5e-3)
+
+
+def test_vulkan_attention_backend_rejects_unsupported_decode_features():
+    num_heads = 2
+    num_kv_heads = 1
+    head_size = 8
+    block_size = 4
+
+    impl = VulkanAttentionBackendImpl(
+        num_heads=num_heads,
+        head_size=head_size,
+        scale=head_size**-0.5,
+        num_kv_heads=num_kv_heads,
+        alibi_slopes=None,
+        sliding_window=block_size,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+        attn_type=AttentionType.DECODER,
+        kv_sharing_target_layer_name=None,
+    )
+    metadata = CPUAttentionMetadata(
+        isa="vec16",
+        num_actual_tokens=1,
+        max_query_len=1,
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        max_seq_len=1,
+        seq_lens=torch.tensor([1], dtype=torch.int32),
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        slot_mapping=torch.tensor([0], dtype=torch.int64),
+        scheduler_metadata=None,
+        causal=True,
+    )
+
+    assert not impl._supports_vulkan_decode(
+        key=torch.zeros(1, num_kv_heads, head_size, dtype=torch.float16),
+        value=torch.zeros(1, num_kv_heads, head_size, dtype=torch.float16),
+        kv_cache=torch.zeros(
+            (2, 1, num_kv_heads, block_size, head_size),
+            dtype=torch.float16,
+        ),
+        attn_metadata=metadata,
+        output=torch.empty(1, num_heads, head_size),
+        num_actual_tokens=1,
+    )

--- a/tests/python/test_attention_backend.py
+++ b/tests/python/test_attention_backend.py
@@ -12,6 +12,7 @@ _rs = pytest.importorskip("vllm_vulkan._rs", exc_type=ImportError)
 from vllm.v1.attention.backend import AttentionType  # noqa: E402
 from vllm.v1.attention.backends.cpu_attn import CPUAttentionMetadata  # noqa: E402
 
+import vllm_vulkan.attention as attention_mod  # noqa: E402
 from vllm_vulkan.attention import VulkanAttentionBackendImpl  # noqa: E402
 
 
@@ -24,8 +25,14 @@ def _require_vulkan_context():
         pytest.skip(f"VulkanContext unavailable: {exc}")
 
 
-def test_vulkan_attention_backend_uses_paged_decode_for_single_token_batch():
+def test_vulkan_attention_backend_uses_paged_decode_for_single_token_batch(monkeypatch):
     _require_vulkan_context()
+    logged_messages = []
+    monkeypatch.setattr(
+        attention_mod.logger,
+        "debug",
+        lambda msg, *args, **kwargs: logged_messages.append(msg % args),
+    )
 
     num_heads = 4
     num_kv_heads = 2
@@ -92,5 +99,106 @@ def test_vulkan_attention_backend_uses_paged_decode_for_single_token_batch():
 
     assert impl._last_vulkan_decode_used is True
     assert result is output
+    assert any("Vulkan attention decode used" in msg for msg in logged_messages)
 
+    torch.testing.assert_close(output, expected, rtol=5e-3, atol=5e-3)
+
+
+def test_vulkan_attention_backend_mirrors_prefill_kv_before_decode():
+    _require_vulkan_context()
+
+    num_heads = 4
+    num_kv_heads = 2
+    head_size = 32
+    block_size = 16
+    num_blocks = 2
+    seq_len = 3
+    scale = head_size**-0.5
+
+    torch.manual_seed(0)
+    query = torch.randn(1, num_heads, head_size, dtype=torch.float32)
+    prefill_k = torch.randn(seq_len - 1, num_kv_heads, head_size, dtype=torch.float16)
+    prefill_v = torch.randn_like(prefill_k)
+    decode_k = torch.randn(1, num_kv_heads, head_size, dtype=torch.float16)
+    decode_v = torch.randn_like(decode_k)
+
+    kv_cache = torch.zeros(
+        (2, num_blocks, num_kv_heads, block_size, head_size),
+        dtype=torch.float16,
+    )
+    impl = VulkanAttentionBackendImpl(
+        num_heads=num_heads,
+        head_size=head_size,
+        scale=scale,
+        num_kv_heads=num_kv_heads,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+        attn_type=AttentionType.DECODER,
+        kv_sharing_target_layer_name=None,
+    )
+
+    prefill_metadata = CPUAttentionMetadata(
+        isa="vec16",
+        num_actual_tokens=seq_len - 1,
+        max_query_len=seq_len - 1,
+        query_start_loc=torch.tensor([0, seq_len - 1], dtype=torch.int32),
+        max_seq_len=seq_len - 1,
+        seq_lens=torch.tensor([seq_len - 1], dtype=torch.int32),
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        slot_mapping=torch.arange(seq_len - 1, dtype=torch.int64),
+        scheduler_metadata=None,
+        causal=True,
+        use_sdpa_prefill=True,
+        num_decode_tokens=0,
+        sdpa_start_loc=torch.tensor([0, seq_len - 1], dtype=torch.int32),
+    )
+    impl.forward(
+        layer=None,  # type: ignore[arg-type]
+        query=torch.randn(seq_len - 1, num_heads, head_size, dtype=torch.float16),
+        key=prefill_k,
+        value=prefill_v,
+        kv_cache=kv_cache,
+        attn_metadata=prefill_metadata,
+        output=torch.empty(seq_len - 1, num_heads, head_size, dtype=torch.float16),
+    )
+    assert impl._last_vulkan_decode_used is False
+
+    output = torch.empty((1, num_heads, head_size), dtype=torch.float32)
+    metadata = CPUAttentionMetadata(
+        isa="vec16",
+        num_actual_tokens=1,
+        max_query_len=1,
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        max_seq_len=seq_len,
+        seq_lens=torch.tensor([seq_len], dtype=torch.int32),
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        slot_mapping=torch.tensor([seq_len - 1], dtype=torch.int64),
+        scheduler_metadata=None,
+        causal=True,
+    )
+    result = impl.forward(
+        layer=None,  # type: ignore[arg-type]
+        query=query,
+        key=decode_k,
+        value=decode_v,
+        kv_cache=kv_cache,
+        attn_metadata=metadata,
+        output=output,
+    )
+
+    k_ref = torch.cat([prefill_k, decode_k], dim=0).float()
+    v_ref = torch.cat([prefill_v, decode_v], dim=0).float()
+    expected_rows = []
+    gqa_ratio = num_heads // num_kv_heads
+    for q_head in range(num_heads):
+        kv_head = q_head // gqa_ratio
+        scores = (k_ref[:, kv_head, :] * query[0, q_head]).sum(dim=-1) * scale
+        weights = torch.softmax(scores, dim=-1)
+        expected_rows.append((weights[:, None] * v_ref[:, kv_head, :]).sum(dim=0))
+    expected = torch.stack(expected_rows).unsqueeze(0)
+
+    assert impl._last_vulkan_decode_used is True
+    assert result is output
     torch.testing.assert_close(output, expected, rtol=5e-3, atol=5e-3)

--- a/tests/python/test_envs.py
+++ b/tests/python/test_envs.py
@@ -35,25 +35,10 @@ def test_debug_enabled(monkeypatch):
     assert envs.VLLM_VULKAN_DEBUG is True
 
 
-def test_disable_attention_default(monkeypatch):
-    monkeypatch.delenv("VLLM_VULKAN_DISABLE_ATTN", raising=False)
-    assert envs.VLLM_VULKAN_DISABLE_ATTN is False
-
-
-def test_disable_attention_enabled(monkeypatch):
-    monkeypatch.setenv("VLLM_VULKAN_DISABLE_ATTN", "1")
-    assert envs.VLLM_VULKAN_DISABLE_ATTN is True
-
-
 def test_device_index_default(monkeypatch):
     monkeypatch.delenv("VLLM_VULKAN_DEVICE_INDEX", raising=False)
     val = envs.VLLM_VULKAN_DEVICE_INDEX
     assert val == 0
-
-
-def test_rust_model_default(monkeypatch):
-    monkeypatch.delenv("VLLM_VULKAN_RUST_MODEL", raising=False)
-    assert envs.VLLM_VULKAN_RUST_MODEL is True
 
 
 def test_rust_model_disabled(monkeypatch):

--- a/tests/python/test_envs.py
+++ b/tests/python/test_envs.py
@@ -35,10 +35,30 @@ def test_debug_enabled(monkeypatch):
     assert envs.VLLM_VULKAN_DEBUG is True
 
 
+def test_disable_attention_default(monkeypatch):
+    monkeypatch.delenv("VLLM_VULKAN_DISABLE_ATTN", raising=False)
+    assert envs.VLLM_VULKAN_DISABLE_ATTN is False
+
+
+def test_disable_attention_enabled(monkeypatch):
+    monkeypatch.setenv("VLLM_VULKAN_DISABLE_ATTN", "1")
+    assert envs.VLLM_VULKAN_DISABLE_ATTN is True
+
+
 def test_device_index_default(monkeypatch):
     monkeypatch.delenv("VLLM_VULKAN_DEVICE_INDEX", raising=False)
     val = envs.VLLM_VULKAN_DEVICE_INDEX
     assert val == 0
+
+
+def test_rust_model_default(monkeypatch):
+    monkeypatch.delenv("VLLM_VULKAN_RUST_MODEL", raising=False)
+    assert envs.VLLM_VULKAN_RUST_MODEL is True
+
+
+def test_rust_model_disabled(monkeypatch):
+    monkeypatch.setenv("VLLM_VULKAN_RUST_MODEL", "0")
+    assert envs.VLLM_VULKAN_RUST_MODEL is False
 
 
 def test_unknown_attr_raises():
@@ -51,3 +71,5 @@ def test_environment_variables_dict_populated():
     assert "VLLM_VULKAN_BLOCK_SIZE" in envs.environment_variables
     assert "VLLM_VULKAN_DEBUG" in envs.environment_variables
     assert "VLLM_VULKAN_DEVICE_INDEX" in envs.environment_variables
+    assert "VLLM_VULKAN_DISABLE_ATTN" in envs.environment_variables
+    assert "VLLM_VULKAN_RUST_MODEL" in envs.environment_variables

--- a/tests/python/test_kv_layout.py
+++ b/tests/python/test_kv_layout.py
@@ -85,12 +85,14 @@ def test_paged_kv_layout_exposes_attention_load_strides():
     layout = VulkanPagedKVLayout((spec,), num_blocks=2)
 
     k_strides = layout.k_plane_strides_for_attn_load(0, 1)
+
     assert k_strides.base_offset == spec.bytes_per_block
     assert k_strides.token_stride == spec.bytes_per_token_per_plane
     assert k_strides.kv_head_stride == spec.head_size * spec.dtype_size
     assert k_strides.head_element_stride == spec.dtype_size
 
     v_strides = layout.v_plane_strides_for_attn_load(0, 1)
+
     assert v_strides.base_offset == spec.bytes_per_block + spec.plane_bytes_per_block
     assert v_strides.token_stride == k_strides.token_stride
     assert v_strides.kv_head_stride == k_strides.kv_head_stride
@@ -109,10 +111,13 @@ def test_layout_rejects_invalid_indices():
 
     with pytest.raises(ValueError, match="physical_block_id"):
         layout.block_base_offset(0, 1)
+
     with pytest.raises(ValueError, match="token_offset_in_block"):
         layout.token_offset(0, 0, 16, 0, 0, "k")
+
     with pytest.raises(ValueError, match="kv_head"):
         layout.token_offset(0, 0, 0, 2, 0, "k")
+
     with pytest.raises(ValueError, match="head_element"):
         layout.token_offset(0, 0, 0, 0, 4, "k")
 

--- a/tests/python/test_kv_layout.py
+++ b/tests/python/test_kv_layout.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Vulkan paged KV-cache layout contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_vulkan.kv_layout import (
+    KVCacheLayerSpec,
+    VulkanPagedKVLayout,
+    dtype_size_bytes,
+    infer_kv_layer_specs,
+    layout_from_hf_config,
+)
+
+
+class _TextConfig:
+    num_hidden_layers = 3
+    num_attention_heads = 8
+    num_key_value_heads = 2
+    head_dim = 64
+    layer_types = ["sliding_attention", "full_attention", "sliding_attention"]
+    global_head_dim = 128
+    num_global_key_value_heads = 1
+
+
+class _WrappedConfig:
+    text_config = _TextConfig()
+
+
+def test_dtype_size_bytes_accepts_common_names():
+    assert dtype_size_bytes("bfloat16") == 2
+    assert dtype_size_bytes("torch.float16") == 2
+    assert dtype_size_bytes("float32") == 4
+    assert dtype_size_bytes(1) == 1
+
+    with pytest.raises(ValueError, match="Unsupported"):
+        dtype_size_bytes("not-a-dtype")
+
+
+def test_paged_kv_layout_offsets_are_block_token_head_major():
+    specs = tuple(
+        KVCacheLayerSpec(
+            layer_index=i,
+            num_kv_heads=2,
+            head_size=4,
+            block_size=16,
+            dtype_size=2,
+        )
+        for i in range(2)
+    )
+    layout = VulkanPagedKVLayout(specs, num_blocks=3)
+
+    assert layout.block_size == 16
+    assert layout.capacity_tokens_per_layer == 48
+    assert layout.bytes_per_token == 64
+    assert layout.total_bytes == 2 * 3 * 512
+
+    assert layout.layer_base_offset(0) == 0
+    assert layout.layer_base_offset(1) == 3 * 512
+
+    block_base = layout.block_base_offset(layer_index=1, physical_block_id=2)
+    assert block_base == 3 * 512 + 2 * 512
+    assert layout.plane_base_offset(1, 2, "k") == block_base
+    assert layout.plane_base_offset(1, 2, "v") == block_base + 256
+
+    # token 5, KV head 1, element 3 in V:
+    # scalar index = ((5 * 2 + 1) * 4 + 3) = 47
+    assert layout.token_offset(1, 2, 5, 1, 3, "v") == block_base + 256 + 47 * 2
+
+    slot = 2 * layout.block_size + 5
+    assert layout.slot_offset(1, slot, 1, 3, "v") == layout.token_offset(
+        1, 2, 5, 1, 3, "v"
+    )
+
+
+def test_paged_kv_layout_exposes_attention_load_strides():
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=2,
+        head_size=4,
+        block_size=16,
+        dtype_size=4,
+    )
+    layout = VulkanPagedKVLayout((spec,), num_blocks=2)
+
+    k_strides = layout.k_plane_strides_for_attn_load(0, 1)
+    assert k_strides.base_offset == spec.bytes_per_block
+    assert k_strides.token_stride == spec.bytes_per_token_per_plane
+    assert k_strides.kv_head_stride == spec.head_size * spec.dtype_size
+    assert k_strides.head_element_stride == spec.dtype_size
+
+    v_strides = layout.v_plane_strides_for_attn_load(0, 1)
+    assert v_strides.base_offset == spec.bytes_per_block + spec.plane_bytes_per_block
+    assert v_strides.token_stride == k_strides.token_stride
+    assert v_strides.kv_head_stride == k_strides.kv_head_stride
+    assert v_strides.head_element_stride == k_strides.head_element_stride
+
+
+def test_layout_rejects_invalid_indices():
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=2,
+        head_size=4,
+        block_size=16,
+        dtype_size=2,
+    )
+    layout = VulkanPagedKVLayout((spec,), num_blocks=1)
+
+    with pytest.raises(ValueError, match="physical_block_id"):
+        layout.block_base_offset(0, 1)
+    with pytest.raises(ValueError, match="token_offset_in_block"):
+        layout.token_offset(0, 0, 16, 0, 0, "k")
+    with pytest.raises(ValueError, match="kv_head"):
+        layout.token_offset(0, 0, 0, 2, 0, "k")
+    with pytest.raises(ValueError, match="head_element"):
+        layout.token_offset(0, 0, 0, 0, 4, "k")
+
+
+def test_infer_kv_layer_specs_supports_heterogeneous_attention_layers():
+    specs = infer_kv_layer_specs(
+        _WrappedConfig(),
+        block_size=16,
+        dtype="bfloat16",
+    )
+
+    assert len(specs) == 3
+    assert specs[0].num_kv_heads == 2
+    assert specs[0].head_size == 64
+    assert specs[1].num_kv_heads == 1
+    assert specs[1].head_size == 128
+    assert specs[2].num_kv_heads == 2
+    assert specs[2].head_size == 64
+    assert all(spec.dtype_size == 2 for spec in specs)
+
+
+def test_layout_from_hf_config_computes_total_bytes():
+    layout = layout_from_hf_config(
+        _WrappedConfig(),
+        block_size=16,
+        num_blocks=4,
+        dtype="float16",
+    )
+
+    # All three specs are 2 * 16 * 128 * 2 = 8192 bytes/block.
+    assert layout.total_bytes == 3 * 4 * 8192
+    assert layout.bytes_per_token == 3 * 2 * 128 * 2

--- a/tests/python/test_kv_ops.py
+++ b/tests/python/test_kv_ops.py
@@ -21,6 +21,7 @@ from vllm_vulkan.kv_ops import (  # noqa: E402
 def _require_vulkan_context():
     if not _rs.is_available():
         pytest.skip("no Vulkan device available")
+
     try:
         return _rs.VulkanContext(0)
     except RuntimeError as exc:
@@ -29,6 +30,7 @@ def _require_vulkan_context():
 
 def test_paged_kv_write_f32_round_trips_gpu_cache_slots():
     ctx = _require_vulkan_context()
+
     assert "paged_kv_write_f32" in ctx.available_shaders()
 
     spec = KVCacheLayerSpec(
@@ -56,6 +58,7 @@ def test_paged_kv_write_f32_round_trips_gpu_cache_slots():
             for head_element in range(spec.head_size):
                 k_offset = layout.slot_offset(0, slot, kv_head, head_element, "k") // 4
                 v_offset = layout.slot_offset(0, slot, kv_head, head_element, "v") // 4
+
                 assert cache_view[k_offset] == pytest.approx(
                     float(k[token_index, kv_head, head_element])
                 )
@@ -64,12 +67,14 @@ def test_paged_kv_write_f32_round_trips_gpu_cache_slots():
                 )
 
     untouched_slot = 1
+
     assert cache_view[layout.slot_offset(0, untouched_slot, 0, 0, "k") // 4] == 0.0
     assert cache_view[layout.slot_offset(0, untouched_slot, 0, 0, "v") // 4] == 0.0
 
 
 def test_paged_kv_write_f16_round_trips_gpu_cache_slots():
     ctx = _require_vulkan_context()
+
     if "paged_kv_write_f16" not in ctx.available_shaders():
         pytest.skip("paged_kv_write_f16 shader is unavailable")
 
@@ -98,6 +103,7 @@ def test_paged_kv_write_f16_round_trips_gpu_cache_slots():
             for head_element in range(spec.head_size):
                 k_offset = layout.slot_offset(0, slot, kv_head, head_element, "k") // 2
                 v_offset = layout.slot_offset(0, slot, kv_head, head_element, "v") // 2
+
                 assert cache_view[k_offset] == pytest.approx(
                     float(k[token_index, kv_head, head_element])
                 )
@@ -121,7 +127,9 @@ def test_paged_kv_write_f32_validates_slot_capacity():
     v = torch.zeros_like(k)
 
     with pytest.raises(ValueError, match="outside capacity"):
-        paged_kv_write_f32(ctx, layout, cache, 0, k, v, [layout.capacity_tokens_per_layer])
+        paged_kv_write_f32(
+            ctx, layout, cache, 0, k, v, [layout.capacity_tokens_per_layer]
+        )
 
 
 def test_paged_kv_write_f32_rejects_empty_tokens():

--- a/tests/python/test_kv_ops.py
+++ b/tests/python/test_kv_ops.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for Vulkan paged KV-cache operations."""
+"""GPU correctness tests for Vulkan paged KV-cache operations."""
 
 from __future__ import annotations
+
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -28,36 +30,100 @@ def _require_vulkan_context():
         pytest.skip(f"VulkanContext unavailable: {exc}")
 
 
-def test_paged_kv_write_f32_round_trips_gpu_cache_slots():
-    ctx = _require_vulkan_context()
+def _require_shader(ctx, *shader_names: str) -> None:
+    available = set(ctx.available_shaders())
+    if not any(name in available for name in shader_names):
+        pytest.skip(f"none of {shader_names!r} are available")
 
-    assert "paged_kv_write_f32" in ctx.available_shaders()
+
+def _make_layout(dtype_size: int) -> tuple[KVCacheLayerSpec, VulkanPagedKVLayout]:
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=2,
+        head_size=8,
+        block_size=4,
+        dtype_size=dtype_size,
+    )
+    return spec, VulkanPagedKVLayout((spec,), num_blocks=4)
+
+
+def _slot_mapping_from_block_table(
+    block_table: torch.Tensor, seq_len: int, block_size: int
+) -> torch.Tensor:
+    slots = [
+        int(block_table[token_idx // block_size]) * block_size + token_idx % block_size
+        for token_idx in range(seq_len)
+    ]
+    return torch.tensor(slots, dtype=torch.int64)
+
+
+def _attention_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    k_ref = k.float()
+    v_ref = v.float()
+    gqa_ratio = q.shape[0] // k_ref.shape[1]
+    rows = []
+    for q_head in range(q.shape[0]):
+        kv_head = q_head // gqa_ratio
+        scores = (k_ref[:, kv_head, :] * q[q_head]).sum(dim=-1) * scale
+        weights = torch.softmax(scores, dim=-1)
+        rows.append((weights[:, None] * v_ref[:, kv_head, :]).sum(dim=0))
+    return torch.stack(rows)
+
+
+@pytest.mark.parametrize(
+    ("torch_dtype", "numpy_dtype", "dtype_size", "write_fn", "shader_name"),
+    [
+        (torch.float32, np.float32, 4, paged_kv_write_f32, "paged_kv_write_f32"),
+        (torch.float16, np.float16, 2, paged_kv_write_f16, "paged_kv_write_f16"),
+    ],
+)
+def test_paged_kv_write_round_trips_gpu_cache_slots(
+    torch_dtype: torch.dtype,
+    numpy_dtype: np.dtype,
+    dtype_size: int,
+    write_fn: Callable,
+    shader_name: str,
+):
+    ctx = _require_vulkan_context()
+    _require_shader(ctx, shader_name)
 
     spec = KVCacheLayerSpec(
         layer_index=0,
         num_kv_heads=2,
         head_size=4,
         block_size=4,
-        dtype_size=4,
+        dtype_size=dtype_size,
     )
     layout = VulkanPagedKVLayout((spec,), num_blocks=3)
     cache = ctx.alloc_activation(layout.total_bytes)
     ctx.update_activation(cache, bytes(layout.total_bytes))
 
-    k = torch.arange(3 * spec.num_kv_heads * spec.head_size, dtype=torch.float32)
-    k = k.reshape(3, spec.num_kv_heads, spec.head_size)
+    k = torch.arange(
+        3 * spec.num_kv_heads * spec.head_size,
+        dtype=torch_dtype,
+    ).reshape(3, spec.num_kv_heads, spec.head_size)
     v = k + 1000
     slot_mapping = torch.tensor([0, 5, 10], dtype=torch.int64)
 
-    paged_kv_write_f32(ctx, layout, cache, 0, k, v, slot_mapping)
+    write_fn(ctx, layout, cache, 0, k, v, slot_mapping)
 
-    raw = ctx.read_activation(cache)
-    cache_view = np.frombuffer(raw, dtype=np.float32)
+    cache_view = np.frombuffer(ctx.read_activation(cache), dtype=numpy_dtype)
     for token_index, slot in enumerate(slot_mapping.tolist()):
         for kv_head in range(spec.num_kv_heads):
             for head_element in range(spec.head_size):
-                k_offset = layout.slot_offset(0, slot, kv_head, head_element, "k") // 4
-                v_offset = layout.slot_offset(0, slot, kv_head, head_element, "v") // 4
+                k_offset = (
+                    layout.slot_offset(0, slot, kv_head, head_element, "k")
+                    // dtype_size
+                )
+                v_offset = (
+                    layout.slot_offset(0, slot, kv_head, head_element, "v")
+                    // dtype_size
+                )
 
                 assert cache_view[k_offset] == pytest.approx(
                     float(k[token_index, kv_head, head_element])
@@ -67,53 +133,20 @@ def test_paged_kv_write_f32_round_trips_gpu_cache_slots():
                 )
 
     untouched_slot = 1
-
-    assert cache_view[layout.slot_offset(0, untouched_slot, 0, 0, "k") // 4] == 0.0
-    assert cache_view[layout.slot_offset(0, untouched_slot, 0, 0, "v") // 4] == 0.0
-
-
-def test_paged_kv_write_f16_round_trips_gpu_cache_slots():
-    ctx = _require_vulkan_context()
-
-    if "paged_kv_write_f16" not in ctx.available_shaders():
-        pytest.skip("paged_kv_write_f16 shader is unavailable")
-
-    spec = KVCacheLayerSpec(
-        layer_index=0,
-        num_kv_heads=2,
-        head_size=4,
-        block_size=4,
-        dtype_size=2,
+    assert (
+        cache_view[layout.slot_offset(0, untouched_slot, 0, 0, "k") // dtype_size]
+        == 0.0
     )
-    layout = VulkanPagedKVLayout((spec,), num_blocks=3)
-    cache = ctx.alloc_activation(layout.total_bytes)
-    ctx.update_activation(cache, bytes(layout.total_bytes))
-
-    k = torch.arange(3 * spec.num_kv_heads * spec.head_size, dtype=torch.float16)
-    k = k.reshape(3, spec.num_kv_heads, spec.head_size)
-    v = k + 1000
-    slot_mapping = torch.tensor([0, 5, 10], dtype=torch.int64)
-
-    paged_kv_write_f16(ctx, layout, cache, 0, k, v, slot_mapping)
-
-    raw = ctx.read_activation(cache)
-    cache_view = np.frombuffer(raw, dtype=np.float16)
-    for token_index, slot in enumerate(slot_mapping.tolist()):
-        for kv_head in range(spec.num_kv_heads):
-            for head_element in range(spec.head_size):
-                k_offset = layout.slot_offset(0, slot, kv_head, head_element, "k") // 2
-                v_offset = layout.slot_offset(0, slot, kv_head, head_element, "v") // 2
-
-                assert cache_view[k_offset] == pytest.approx(
-                    float(k[token_index, kv_head, head_element])
-                )
-                assert cache_view[v_offset] == pytest.approx(
-                    float(v[token_index, kv_head, head_element])
-                )
+    assert (
+        cache_view[layout.slot_offset(0, untouched_slot, 0, 0, "v") // dtype_size]
+        == 0.0
+    )
 
 
-def test_paged_kv_write_f32_validates_slot_capacity():
+def test_paged_kv_write_validates_slots_and_empty_inputs():
     ctx = _require_vulkan_context()
+    _require_shader(ctx, "paged_kv_write_f32")
+
     spec = KVCacheLayerSpec(
         layer_index=0,
         num_kv_heads=1,
@@ -131,127 +164,90 @@ def test_paged_kv_write_f32_validates_slot_capacity():
             ctx, layout, cache, 0, k, v, [layout.capacity_tokens_per_layer]
         )
 
-
-def test_paged_kv_write_f32_rejects_empty_tokens():
-    ctx = _require_vulkan_context()
-    spec = KVCacheLayerSpec(
-        layer_index=0,
-        num_kv_heads=1,
-        head_size=2,
-        block_size=4,
-        dtype_size=4,
-    )
-    layout = VulkanPagedKVLayout((spec,), num_blocks=1)
-    cache = ctx.alloc_activation(layout.total_bytes)
-    k = torch.zeros((0, spec.num_kv_heads, spec.head_size), dtype=torch.float32)
-    v = torch.zeros_like(k)
-
+    empty_k = torch.zeros((0, spec.num_kv_heads, spec.head_size), dtype=torch.float32)
     with pytest.raises(ValueError, match="at least one token"):
-        paged_kv_write_f32(ctx, layout, cache, 0, k, v, [])
+        paged_kv_write_f32(
+            ctx, layout, cache, 0, empty_k, torch.zeros_like(empty_k), []
+        )
 
 
-def test_paged_attn_decode_f32_matches_torch_reference():
+@pytest.mark.parametrize(
+    (
+        "torch_dtype",
+        "dtype_size",
+        "write_fn",
+        "decode_fn",
+        "write_shader",
+        "decode_shaders",
+        "seed",
+        "rtol",
+        "atol",
+    ),
+    [
+        (
+            torch.float32,
+            4,
+            paged_kv_write_f32,
+            paged_attn_decode_f32,
+            "paged_kv_write_f32",
+            ("paged_attn_decode_f32", "paged_attn_decode_f32_coop"),
+            0,
+            1e-4,
+            1e-4,
+        ),
+        (
+            torch.float16,
+            2,
+            paged_kv_write_f16,
+            paged_attn_decode_f16,
+            "paged_kv_write_f16",
+            ("paged_attn_decode_f16", "paged_attn_decode_f16_coop"),
+            1,
+            5e-3,
+            5e-3,
+        ),
+    ],
+)
+def test_paged_attn_decode_matches_torch_reference(
+    torch_dtype: torch.dtype,
+    dtype_size: int,
+    write_fn: Callable,
+    decode_fn: Callable,
+    write_shader: str,
+    decode_shaders: tuple[str, ...],
+    seed: int,
+    rtol: float,
+    atol: float,
+):
     ctx = _require_vulkan_context()
-    assert "paged_kv_write_f32" in ctx.available_shaders()
-    assert "paged_attn_decode_f32" in ctx.available_shaders()
+    _require_shader(ctx, write_shader)
+    _require_shader(ctx, *decode_shaders)
 
-    spec = KVCacheLayerSpec(
-        layer_index=0,
-        num_kv_heads=2,
-        head_size=8,
-        block_size=4,
-        dtype_size=4,
-    )
-    layout = VulkanPagedKVLayout((spec,), num_blocks=4)
+    spec, layout = _make_layout(dtype_size)
     cache = ctx.alloc_activation(layout.total_bytes)
     ctx.update_activation(cache, bytes(layout.total_bytes))
 
     seq_len = 6
     block_table = torch.tensor([2, 0], dtype=torch.int64)
-    slot_mapping = torch.tensor(
-        [
-            int(block_table[token_idx // spec.block_size]) * spec.block_size
-            + token_idx % spec.block_size
-            for token_idx in range(seq_len)
-        ],
-        dtype=torch.int64,
-    )
+    slot_mapping = _slot_mapping_from_block_table(block_table, seq_len, spec.block_size)
 
-    torch.manual_seed(0)
-    k = torch.randn(seq_len, spec.num_kv_heads, spec.head_size, dtype=torch.float32)
+    torch.manual_seed(seed)
+    k = torch.randn(seq_len, spec.num_kv_heads, spec.head_size, dtype=torch_dtype)
     v = torch.randn_like(k)
     q = torch.randn(4, spec.head_size, dtype=torch.float32)
     scale = spec.head_size**-0.5
 
-    paged_kv_write_f32(ctx, layout, cache, 0, k, v, slot_mapping)
-    out = paged_attn_decode_f32(ctx, layout, cache, 0, q, block_table, seq_len, scale)
+    write_fn(ctx, layout, cache, 0, k, v, slot_mapping)
+    out = decode_fn(ctx, layout, cache, 0, q, block_table, seq_len, scale)
 
-    expected_rows = []
-    gqa_ratio = q.shape[0] // spec.num_kv_heads
-    for q_head in range(q.shape[0]):
-        kv_head = q_head // gqa_ratio
-        scores = (k[:, kv_head, :] * q[q_head]).sum(dim=-1) * scale
-        weights = torch.softmax(scores, dim=-1)
-        expected_rows.append((weights[:, None] * v[:, kv_head, :]).sum(dim=0))
-    expected = torch.stack(expected_rows)
-
-    torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+    expected = _attention_reference(q, k, v, scale)
+    torch.testing.assert_close(out, expected, rtol=rtol, atol=atol)
 
 
-def test_paged_attn_decode_f16_matches_torch_reference():
+def test_paged_attn_decode_validates_block_table():
     ctx = _require_vulkan_context()
-    if "paged_kv_write_f16" not in ctx.available_shaders():
-        pytest.skip("paged_kv_write_f16 shader is unavailable")
-    if "paged_attn_decode_f16" not in ctx.available_shaders():
-        pytest.skip("paged_attn_decode_f16 shader is unavailable")
+    _require_shader(ctx, "paged_attn_decode_f32", "paged_attn_decode_f32_coop")
 
-    spec = KVCacheLayerSpec(
-        layer_index=0,
-        num_kv_heads=2,
-        head_size=8,
-        block_size=4,
-        dtype_size=2,
-    )
-    layout = VulkanPagedKVLayout((spec,), num_blocks=4)
-    cache = ctx.alloc_activation(layout.total_bytes)
-    ctx.update_activation(cache, bytes(layout.total_bytes))
-
-    seq_len = 6
-    block_table = torch.tensor([2, 0], dtype=torch.int64)
-    slot_mapping = torch.tensor(
-        [
-            int(block_table[token_idx // spec.block_size]) * spec.block_size
-            + token_idx % spec.block_size
-            for token_idx in range(seq_len)
-        ],
-        dtype=torch.int64,
-    )
-
-    torch.manual_seed(1)
-    k = torch.randn(seq_len, spec.num_kv_heads, spec.head_size, dtype=torch.float16)
-    v = torch.randn_like(k)
-    q = torch.randn(4, spec.head_size, dtype=torch.float32)
-    scale = spec.head_size**-0.5
-
-    paged_kv_write_f16(ctx, layout, cache, 0, k, v, slot_mapping)
-    out = paged_attn_decode_f16(ctx, layout, cache, 0, q, block_table, seq_len, scale)
-
-    k_ref = k.float()
-    v_ref = v.float()
-    expected_rows = []
-    gqa_ratio = q.shape[0] // spec.num_kv_heads
-    for q_head in range(q.shape[0]):
-        kv_head = q_head // gqa_ratio
-        scores = (k_ref[:, kv_head, :] * q[q_head]).sum(dim=-1) * scale
-        weights = torch.softmax(scores, dim=-1)
-        expected_rows.append((weights[:, None] * v_ref[:, kv_head, :]).sum(dim=0))
-    expected = torch.stack(expected_rows)
-
-    torch.testing.assert_close(out, expected, rtol=5e-3, atol=5e-3)
-
-
-def test_paged_attn_decode_f32_validates_block_table():
-    ctx = _require_vulkan_context()
     spec = KVCacheLayerSpec(
         layer_index=0,
         num_kv_heads=1,

--- a/tests/python/test_kv_ops.py
+++ b/tests/python/test_kv_ops.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Vulkan paged KV-cache operations."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+_rs = pytest.importorskip("vllm_vulkan._rs", exc_type=ImportError)
+
+from vllm_vulkan.kv_layout import KVCacheLayerSpec, VulkanPagedKVLayout  # noqa: E402
+from vllm_vulkan.kv_ops import (  # noqa: E402
+    paged_attn_decode_f16,
+    paged_attn_decode_f32,
+    paged_kv_write_f16,
+    paged_kv_write_f32,
+)
+
+
+def _require_vulkan_context():
+    if not _rs.is_available():
+        pytest.skip("no Vulkan device available")
+    try:
+        return _rs.VulkanContext(0)
+    except RuntimeError as exc:
+        pytest.skip(f"VulkanContext unavailable: {exc}")
+
+
+def test_paged_kv_write_f32_round_trips_gpu_cache_slots():
+    ctx = _require_vulkan_context()
+    assert "paged_kv_write_f32" in ctx.available_shaders()
+
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=2,
+        head_size=4,
+        block_size=4,
+        dtype_size=4,
+    )
+    layout = VulkanPagedKVLayout((spec,), num_blocks=3)
+    cache = ctx.alloc_activation(layout.total_bytes)
+    ctx.update_activation(cache, bytes(layout.total_bytes))
+
+    k = torch.arange(3 * spec.num_kv_heads * spec.head_size, dtype=torch.float32)
+    k = k.reshape(3, spec.num_kv_heads, spec.head_size)
+    v = k + 1000
+    slot_mapping = torch.tensor([0, 5, 10], dtype=torch.int64)
+
+    paged_kv_write_f32(ctx, layout, cache, 0, k, v, slot_mapping)
+
+    raw = ctx.read_activation(cache)
+    cache_view = np.frombuffer(raw, dtype=np.float32)
+    for token_index, slot in enumerate(slot_mapping.tolist()):
+        for kv_head in range(spec.num_kv_heads):
+            for head_element in range(spec.head_size):
+                k_offset = layout.slot_offset(0, slot, kv_head, head_element, "k") // 4
+                v_offset = layout.slot_offset(0, slot, kv_head, head_element, "v") // 4
+                assert cache_view[k_offset] == pytest.approx(
+                    float(k[token_index, kv_head, head_element])
+                )
+                assert cache_view[v_offset] == pytest.approx(
+                    float(v[token_index, kv_head, head_element])
+                )
+
+    untouched_slot = 1
+    assert cache_view[layout.slot_offset(0, untouched_slot, 0, 0, "k") // 4] == 0.0
+    assert cache_view[layout.slot_offset(0, untouched_slot, 0, 0, "v") // 4] == 0.0
+
+
+def test_paged_kv_write_f16_round_trips_gpu_cache_slots():
+    ctx = _require_vulkan_context()
+    if "paged_kv_write_f16" not in ctx.available_shaders():
+        pytest.skip("paged_kv_write_f16 shader is unavailable")
+
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=2,
+        head_size=4,
+        block_size=4,
+        dtype_size=2,
+    )
+    layout = VulkanPagedKVLayout((spec,), num_blocks=3)
+    cache = ctx.alloc_activation(layout.total_bytes)
+    ctx.update_activation(cache, bytes(layout.total_bytes))
+
+    k = torch.arange(3 * spec.num_kv_heads * spec.head_size, dtype=torch.float16)
+    k = k.reshape(3, spec.num_kv_heads, spec.head_size)
+    v = k + 1000
+    slot_mapping = torch.tensor([0, 5, 10], dtype=torch.int64)
+
+    paged_kv_write_f16(ctx, layout, cache, 0, k, v, slot_mapping)
+
+    raw = ctx.read_activation(cache)
+    cache_view = np.frombuffer(raw, dtype=np.float16)
+    for token_index, slot in enumerate(slot_mapping.tolist()):
+        for kv_head in range(spec.num_kv_heads):
+            for head_element in range(spec.head_size):
+                k_offset = layout.slot_offset(0, slot, kv_head, head_element, "k") // 2
+                v_offset = layout.slot_offset(0, slot, kv_head, head_element, "v") // 2
+                assert cache_view[k_offset] == pytest.approx(
+                    float(k[token_index, kv_head, head_element])
+                )
+                assert cache_view[v_offset] == pytest.approx(
+                    float(v[token_index, kv_head, head_element])
+                )
+
+
+def test_paged_kv_write_f32_validates_slot_capacity():
+    ctx = _require_vulkan_context()
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=1,
+        head_size=2,
+        block_size=4,
+        dtype_size=4,
+    )
+    layout = VulkanPagedKVLayout((spec,), num_blocks=1)
+    cache = ctx.alloc_activation(layout.total_bytes)
+    k = torch.zeros((1, spec.num_kv_heads, spec.head_size), dtype=torch.float32)
+    v = torch.zeros_like(k)
+
+    with pytest.raises(ValueError, match="outside capacity"):
+        paged_kv_write_f32(ctx, layout, cache, 0, k, v, [layout.capacity_tokens_per_layer])
+
+
+def test_paged_kv_write_f32_rejects_empty_tokens():
+    ctx = _require_vulkan_context()
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=1,
+        head_size=2,
+        block_size=4,
+        dtype_size=4,
+    )
+    layout = VulkanPagedKVLayout((spec,), num_blocks=1)
+    cache = ctx.alloc_activation(layout.total_bytes)
+    k = torch.zeros((0, spec.num_kv_heads, spec.head_size), dtype=torch.float32)
+    v = torch.zeros_like(k)
+
+    with pytest.raises(ValueError, match="at least one token"):
+        paged_kv_write_f32(ctx, layout, cache, 0, k, v, [])
+
+
+def test_paged_attn_decode_f32_matches_torch_reference():
+    ctx = _require_vulkan_context()
+    assert "paged_kv_write_f32" in ctx.available_shaders()
+    assert "paged_attn_decode_f32" in ctx.available_shaders()
+
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=2,
+        head_size=8,
+        block_size=4,
+        dtype_size=4,
+    )
+    layout = VulkanPagedKVLayout((spec,), num_blocks=4)
+    cache = ctx.alloc_activation(layout.total_bytes)
+    ctx.update_activation(cache, bytes(layout.total_bytes))
+
+    seq_len = 6
+    block_table = torch.tensor([2, 0], dtype=torch.int64)
+    slot_mapping = torch.tensor(
+        [
+            int(block_table[token_idx // spec.block_size]) * spec.block_size
+            + token_idx % spec.block_size
+            for token_idx in range(seq_len)
+        ],
+        dtype=torch.int64,
+    )
+
+    torch.manual_seed(0)
+    k = torch.randn(seq_len, spec.num_kv_heads, spec.head_size, dtype=torch.float32)
+    v = torch.randn_like(k)
+    q = torch.randn(4, spec.head_size, dtype=torch.float32)
+    scale = spec.head_size**-0.5
+
+    paged_kv_write_f32(ctx, layout, cache, 0, k, v, slot_mapping)
+    out = paged_attn_decode_f32(ctx, layout, cache, 0, q, block_table, seq_len, scale)
+
+    expected_rows = []
+    gqa_ratio = q.shape[0] // spec.num_kv_heads
+    for q_head in range(q.shape[0]):
+        kv_head = q_head // gqa_ratio
+        scores = (k[:, kv_head, :] * q[q_head]).sum(dim=-1) * scale
+        weights = torch.softmax(scores, dim=-1)
+        expected_rows.append((weights[:, None] * v[:, kv_head, :]).sum(dim=0))
+    expected = torch.stack(expected_rows)
+
+    torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_paged_attn_decode_f16_matches_torch_reference():
+    ctx = _require_vulkan_context()
+    if "paged_kv_write_f16" not in ctx.available_shaders():
+        pytest.skip("paged_kv_write_f16 shader is unavailable")
+    if "paged_attn_decode_f16" not in ctx.available_shaders():
+        pytest.skip("paged_attn_decode_f16 shader is unavailable")
+
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=2,
+        head_size=8,
+        block_size=4,
+        dtype_size=2,
+    )
+    layout = VulkanPagedKVLayout((spec,), num_blocks=4)
+    cache = ctx.alloc_activation(layout.total_bytes)
+    ctx.update_activation(cache, bytes(layout.total_bytes))
+
+    seq_len = 6
+    block_table = torch.tensor([2, 0], dtype=torch.int64)
+    slot_mapping = torch.tensor(
+        [
+            int(block_table[token_idx // spec.block_size]) * spec.block_size
+            + token_idx % spec.block_size
+            for token_idx in range(seq_len)
+        ],
+        dtype=torch.int64,
+    )
+
+    torch.manual_seed(1)
+    k = torch.randn(seq_len, spec.num_kv_heads, spec.head_size, dtype=torch.float16)
+    v = torch.randn_like(k)
+    q = torch.randn(4, spec.head_size, dtype=torch.float32)
+    scale = spec.head_size**-0.5
+
+    paged_kv_write_f16(ctx, layout, cache, 0, k, v, slot_mapping)
+    out = paged_attn_decode_f16(ctx, layout, cache, 0, q, block_table, seq_len, scale)
+
+    k_ref = k.float()
+    v_ref = v.float()
+    expected_rows = []
+    gqa_ratio = q.shape[0] // spec.num_kv_heads
+    for q_head in range(q.shape[0]):
+        kv_head = q_head // gqa_ratio
+        scores = (k_ref[:, kv_head, :] * q[q_head]).sum(dim=-1) * scale
+        weights = torch.softmax(scores, dim=-1)
+        expected_rows.append((weights[:, None] * v_ref[:, kv_head, :]).sum(dim=0))
+    expected = torch.stack(expected_rows)
+
+    torch.testing.assert_close(out, expected, rtol=5e-3, atol=5e-3)
+
+
+def test_paged_attn_decode_f32_validates_block_table():
+    ctx = _require_vulkan_context()
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=1,
+        head_size=4,
+        block_size=4,
+        dtype_size=4,
+    )
+    layout = VulkanPagedKVLayout((spec,), num_blocks=1)
+    cache = ctx.alloc_activation(layout.total_bytes)
+    q = torch.zeros((1, spec.head_size), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="expected at least"):
+        paged_attn_decode_f32(ctx, layout, cache, 0, q, [], seq_len=1)
+
+    with pytest.raises(ValueError, match="outside"):
+        paged_attn_decode_f32(ctx, layout, cache, 0, q, [layout.num_blocks], seq_len=1)

--- a/vllm_vulkan/__init__.py
+++ b/vllm_vulkan/__init__.py
@@ -61,6 +61,14 @@ def __getattr__(name: str):  # noqa: ANN001, ANN201
         from vllm_vulkan.config import VulkanConfig
 
         return VulkanConfig
+    if name == "KVCacheLayerSpec":
+        from vllm_vulkan.kv_layout import KVCacheLayerSpec
+
+        return KVCacheLayerSpec
+    if name == "VulkanPagedKVLayout":
+        from vllm_vulkan.kv_layout import VulkanPagedKVLayout
+
+        return VulkanPagedKVLayout
     if name == "get_config":
         from vllm_vulkan.config import get_config
 
@@ -80,7 +88,9 @@ def __getattr__(name: str):  # noqa: ANN001, ANN201
 
 __all__ = [
     "VulkanConfig",
+    "KVCacheLayerSpec",
     "VulkanPlatform",
+    "VulkanPagedKVLayout",
     "get_config",
     "reset_config",
     "register",

--- a/vllm_vulkan/attention.py
+++ b/vllm_vulkan/attention.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+"""vLLM attention backend shim for Vulkan decode bring-up.
+
+This backend intentionally keeps vLLM's CPU attention metadata and CPU KV cache
+layout as the source of truth, then mirrors supported decode updates into the
+Vulkan paged KV cache. Unsupported cases fall back to CPU_ATTN.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import weakref
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+from vllm import _custom_ops as ops
+from vllm.v1.attention.backend import AttentionLayer, AttentionType
+from vllm.v1.attention.backends.cpu_attn import (
+    CPUAttentionBackend,
+    CPUAttentionBackendImpl,
+    CPUAttentionMetadata,
+)
+
+from vllm_vulkan.kv_layout import KVCacheLayerSpec, VulkanPagedKVLayout
+
+if TYPE_CHECKING:
+    from vllm_vulkan._rs import GpuTensor, VulkanContext
+
+logger = logging.getLogger(__name__)
+
+
+class VulkanAttentionBackend(CPUAttentionBackend):
+    """CPU_ATTN-compatible backend that opportunistically uses Vulkan decode.
+
+    The backend name intentionally remains ``CPU_ATTN`` because vLLM currently
+    indexes ``AttentionBackendEnum`` by backend name. Returning a new name would
+    require upstream enum registration. The implementation class is Vulkan
+    specific, while the metadata builder and KV-cache shape stay CPU-compatible.
+    """
+
+    @staticmethod
+    def get_name() -> str:
+        return CPUAttentionBackend.get_name()
+
+    @staticmethod
+    def get_impl_cls() -> type[VulkanAttentionBackendImpl]:
+        return VulkanAttentionBackendImpl
+
+
+@dataclass
+class _VulkanKVCacheEntry:
+    storage_ref: weakref.ReferenceType
+    layout: VulkanPagedKVLayout
+    cache: GpuTensor
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+
+
+_VULKAN_KV_CACHES: dict[int, _VulkanKVCacheEntry] = {}
+
+
+class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
+    """CPU attention implementation with a guarded Vulkan decode fast path."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._last_vulkan_decode_used = False
+
+    def forward(
+        self,
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: CPUAttentionMetadata | None,
+        output: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert output is not None, "Output tensor must be provided."
+
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for VulkanAttentionBackendImpl"
+            )
+
+        self._last_vulkan_decode_used = False
+
+        # For warming-up.
+        if attn_metadata is None:
+            return output
+
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        if self.attn_type in (AttentionType.ENCODER_ONLY, AttentionType.ENCODER):
+            return self._run_sdpa_forward(
+                query[:num_actual_tokens],
+                key[:num_actual_tokens],
+                value[:num_actual_tokens],
+                output[:num_actual_tokens],
+                attn_metadata,
+                self.attn_type,
+            )
+
+        key_cache, value_cache = kv_cache.unbind(0)
+
+        # Keep vLLM's CPU KV cache updated first. This preserves the existing
+        # fallback behavior and lets unsupported cases use CPU_ATTN immediately.
+        if (
+            self.kv_sharing_target_layer_name is None
+            and key is not None
+            and value is not None
+        ):
+            ops.cpu_attn_reshape_and_cache(
+                key,
+                value,
+                key_cache,
+                value_cache,
+                attn_metadata.slot_mapping,
+                attn_metadata.isa,
+            )
+
+        if attn_metadata.use_sdpa_prefill:
+            assert self.sinks is None, "Attention sink is unsupported in SDPA prefill"
+            num_decode_tokens = attn_metadata.num_decode_tokens
+            self._run_sdpa_forward(
+                query[num_decode_tokens:num_actual_tokens],
+                key[num_decode_tokens:num_actual_tokens],
+                value[num_decode_tokens:num_actual_tokens],
+                output[num_decode_tokens:num_actual_tokens],
+                attn_metadata,
+                self.attn_type,
+            )
+            num_actual_tokens = num_decode_tokens
+
+        if num_actual_tokens > 0:
+            if not self._try_vulkan_decode(
+                query=query,
+                key=key,
+                value=value,
+                kv_cache=kv_cache,
+                attn_metadata=attn_metadata,
+                output=output,
+                num_actual_tokens=num_actual_tokens,
+            ):
+                ops.cpu_attention_with_kv_cache(
+                    query=query[:num_actual_tokens],
+                    key_cache=key_cache,
+                    value_cache=value_cache,
+                    output=output[:num_actual_tokens],  # type: ignore[arg-type]
+                    query_start_loc=attn_metadata.query_start_loc,
+                    seq_lens=attn_metadata.seq_lens,
+                    scale=self.scale,
+                    causal=attn_metadata.causal,
+                    alibi_slopes=self.alibi_slopes,  # type: ignore[arg-type]
+                    sliding_window=self.sliding_window,
+                    block_table=attn_metadata.block_table,
+                    softcap=self.logits_soft_cap,
+                    scheduler_metadata=attn_metadata.scheduler_metadata,
+                    s_aux=self.sinks,
+                )
+
+        return output
+
+    def _try_vulkan_decode(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor | None,
+        value: torch.Tensor | None,
+        kv_cache: torch.Tensor,
+        attn_metadata: CPUAttentionMetadata,
+        output: torch.Tensor,
+        num_actual_tokens: int,
+    ) -> bool:
+        if os.environ.get("VLLM_VULKAN_DISABLE_ATTN"):
+            return False
+
+        is_supported_decode_batch = (
+            self.attn_type == AttentionType.DECODER
+            and not attn_metadata.use_sdpa_prefill
+            and attn_metadata.causal
+        )
+        if not is_supported_decode_batch:
+            return False
+
+        has_supported_kv_update = (
+            self.kv_sharing_target_layer_name is None
+            and key is not None
+            and value is not None
+        )
+        if not has_supported_kv_update:
+            return False
+
+        has_unsupported_attention_features = (
+            self.alibi_slopes is not None
+            or bool(self.logits_soft_cap)
+            or self.sinks is not None
+            or self.sliding_window != (-1, -1)
+        )
+        if has_unsupported_attention_features:
+            return False
+
+        has_supported_tensor_layout = output.shape[
+            -1
+        ] == self.head_size and kv_cache.dtype in (torch.float16, torch.float32)
+        if not has_supported_tensor_layout:
+            return False
+
+        query_lens = (
+            attn_metadata.query_start_loc[1:] - attn_metadata.query_start_loc[:-1]
+        )
+        if query_lens.numel() != num_actual_tokens:
+            return False
+        if not torch.all(query_lens[:num_actual_tokens].cpu() == 1):
+            return False
+
+        try:
+            ctx = _get_vulkan_context()
+
+            if ctx is None:
+                return False
+
+            layout, gpu_cache = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
+            if kv_cache.dtype == torch.float16:
+                from vllm_vulkan.kv_ops import (  # noqa: PLC0415
+                    paged_attn_decode_f16,
+                    paged_kv_write_f16,
+                )
+
+                paged_kv_write_f16(
+                    ctx,
+                    layout,
+                    gpu_cache,
+                    0,
+                    key[:num_actual_tokens],
+                    value[:num_actual_tokens],
+                    attn_metadata.slot_mapping[:num_actual_tokens],
+                )
+                decode = paged_attn_decode_f16
+            else:
+                from vllm_vulkan.kv_ops import (  # noqa: PLC0415
+                    paged_attn_decode_f32,
+                    paged_kv_write_f32,
+                )
+
+                paged_kv_write_f32(
+                    ctx,
+                    layout,
+                    gpu_cache,
+                    0,
+                    key[:num_actual_tokens],
+                    value[:num_actual_tokens],
+                    attn_metadata.slot_mapping[:num_actual_tokens],
+                )
+                decode = paged_attn_decode_f32
+
+            seq_lens = attn_metadata.seq_lens[:num_actual_tokens].to("cpu")
+            block_table = attn_metadata.block_table[:num_actual_tokens].to("cpu")
+            outs = []
+            for token_idx in range(num_actual_tokens):
+                outs.append(
+                    decode(
+                        ctx,
+                        layout,
+                        gpu_cache,
+                        0,
+                        query[token_idx].detach().to("cpu"),
+                        block_table[token_idx],
+                        int(seq_lens[token_idx]),
+                        self.scale,
+                    )
+                )
+
+            output[:num_actual_tokens].copy_(
+                torch.stack(outs).to(dtype=output.dtype, device=output.device)
+            )
+            self._last_vulkan_decode_used = True
+
+            return True
+        except Exception as exc:
+            logger.debug("Vulkan attention decode fallback to CPU_ATTN: %s", exc)
+
+            return False
+
+
+def _get_vulkan_context() -> VulkanContext | None:
+    try:
+        from vllm_vulkan import vulkan_ops  # noqa: PLC0415
+        from vllm_vulkan._rs import VulkanContext  # noqa: PLC0415
+
+        if not vulkan_ops.is_ready():
+            vulkan_ops.set_context(VulkanContext(0))
+        if not vulkan_ops.is_ready():
+            return None
+        return vulkan_ops.get_context()
+    except Exception as exc:
+        logger.debug("VulkanContext unavailable for attention decode: %s", exc)
+        return None
+
+
+def _get_or_create_vulkan_kv_cache(
+    ctx: VulkanContext,
+    kv_cache: torch.Tensor,
+) -> tuple[VulkanPagedKVLayout, GpuTensor]:
+    storage = kv_cache.untyped_storage()
+    key = id(storage)
+    shape = tuple(int(dim) for dim in kv_cache.shape)
+    entry = _VULKAN_KV_CACHES.get(key)
+
+    if (
+        entry is not None
+        and entry.storage_ref() is not None
+        and entry.shape == shape
+        and entry.dtype == kv_cache.dtype
+    ):
+        return entry.layout, entry.cache
+
+    if entry is not None:
+        _VULKAN_KV_CACHES.pop(key, None)
+
+    if len(shape) != 5 or shape[0] != 2:
+        raise ValueError(
+            f"expected KV cache shape [2, blocks, heads, block, dim], got {shape}"
+        )
+    _, num_blocks, num_kv_heads, block_size, head_size = shape
+    dtype_size = _kv_cache_dtype_size(kv_cache.dtype)
+    layout = VulkanPagedKVLayout(
+        (
+            KVCacheLayerSpec(
+                layer_index=0,
+                num_kv_heads=num_kv_heads,
+                head_size=head_size,
+                block_size=block_size,
+                dtype_size=dtype_size,
+            ),
+        ),
+        num_blocks=num_blocks,
+    )
+    gpu_cache = ctx.alloc_activation(layout.total_bytes)
+    ctx.update_activation(gpu_cache, bytes(layout.total_bytes))
+
+    _VULKAN_KV_CACHES[key] = _VulkanKVCacheEntry(
+        storage_ref=weakref.ref(storage),
+        layout=layout,
+        cache=gpu_cache,
+        shape=shape,
+        dtype=kv_cache.dtype,
+    )
+
+    return layout, gpu_cache
+
+
+def _kv_cache_dtype_size(dtype: torch.dtype) -> int:
+    if dtype == torch.float16:
+        return 2
+
+    if dtype == torch.float32:
+        return 4
+
+    raise ValueError(f"unsupported Vulkan KV cache dtype: {dtype}")

--- a/vllm_vulkan/attention.py
+++ b/vllm_vulkan/attention.py
@@ -9,7 +9,6 @@ Vulkan paged KV cache. Unsupported cases fall back to CPU_ATTN.
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -22,6 +21,7 @@ from vllm.v1.attention.backends.cpu_attn import (
     CPUAttentionMetadata,
 )
 
+from vllm_vulkan import envs
 from vllm_vulkan.kv_layout import KVCacheLayerSpec, VulkanPagedKVLayout
 
 if TYPE_CHECKING:
@@ -182,46 +182,17 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
         output: torch.Tensor,
         num_actual_tokens: int,
     ) -> bool:
-        if os.environ.get("VLLM_VULKAN_DISABLE_ATTN"):
+        if envs.VLLM_VULKAN_DISABLE_ATTN:
             return False
 
-        is_supported_decode_batch = (
-            self.attn_type == AttentionType.DECODER
-            and not attn_metadata.use_sdpa_prefill
-            and attn_metadata.causal
-        )
-        if not is_supported_decode_batch:
-            return False
-
-        has_supported_kv_update = (
-            self.kv_sharing_target_layer_name is None
-            and key is not None
-            and value is not None
-        )
-        if not has_supported_kv_update:
-            return False
-
-        has_unsupported_attention_features = (
-            self.alibi_slopes is not None
-            or bool(self.logits_soft_cap)
-            or self.sinks is not None
-            or self.sliding_window != (-1, -1)
-        )
-        if has_unsupported_attention_features:
-            return False
-
-        has_supported_tensor_layout = output.shape[
-            -1
-        ] == self.head_size and kv_cache.dtype in (torch.float16, torch.float32)
-        if not has_supported_tensor_layout:
-            return False
-
-        query_lens = (
-            attn_metadata.query_start_loc[1:] - attn_metadata.query_start_loc[:-1]
-        )
-        if query_lens.numel() != num_actual_tokens:
-            return False
-        if not torch.all(query_lens[:num_actual_tokens].cpu() == 1):
+        if not self._supports_vulkan_decode(
+            key=key,
+            value=value,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            output=output,
+            num_actual_tokens=num_actual_tokens,
+        ):
             return False
 
         try:
@@ -281,6 +252,41 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
             logger.debug("Vulkan attention decode fallback to CPU_ATTN: %s", exc)
 
             return False
+
+    def _supports_vulkan_decode(
+        self,
+        *,
+        key: torch.Tensor | None,
+        value: torch.Tensor | None,
+        kv_cache: torch.Tensor,
+        attn_metadata: CPUAttentionMetadata,
+        output: torch.Tensor,
+        num_actual_tokens: int,
+    ) -> bool:
+        """Return True for the conservative decode-only path we can run."""
+        if self.attn_type != AttentionType.DECODER:
+            return False
+        if attn_metadata.use_sdpa_prefill or not attn_metadata.causal:
+            return False
+        if self.kv_sharing_target_layer_name is not None:
+            return False
+        if key is None or value is None:
+            return False
+        if self.alibi_slopes is not None or bool(self.logits_soft_cap):
+            return False
+        if self.sinks is not None or self.sliding_window != (-1, -1):
+            return False
+        if output.shape[-1] != self.head_size:
+            return False
+        if kv_cache.dtype not in (torch.float16, torch.float32):
+            return False
+
+        query_lens = (
+            attn_metadata.query_start_loc[1:] - attn_metadata.query_start_loc[:-1]
+        ).to(device="cpu")
+        if query_lens.numel() != num_actual_tokens:
+            return False
+        return bool(torch.all(query_lens[:num_actual_tokens] == 1).item())
 
 
 def _try_write_tokens_to_vulkan_cache(
@@ -343,8 +349,12 @@ def _vulkan_cache_has_sequences(
         row = block_table[req_idx]
         for token_pos in range(seq_len):
             logical_block_id = token_pos // spec.block_size
+            if logical_block_id >= row.numel():
+                return False
             token_offset = token_pos % spec.block_size
             physical_block_id = int(row[logical_block_id])
+            if not 0 <= physical_block_id < layout.num_blocks:
+                return False
             slot = physical_block_id * spec.block_size + token_offset
             if slot not in written_slots:
                 return False

--- a/vllm_vulkan/attention.py
+++ b/vllm_vulkan/attention.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import logging
 import os
-import weakref
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -51,11 +50,12 @@ class VulkanAttentionBackend(CPUAttentionBackend):
 
 @dataclass
 class _VulkanKVCacheEntry:
-    storage_ref: weakref.ReferenceType
+    storage_key: int
     layout: VulkanPagedKVLayout
     cache: GpuTensor
     shape: tuple[int, ...]
     dtype: torch.dtype
+    written_slots: set[int]
 
 
 _VULKAN_KV_CACHES: dict[int, _VulkanKVCacheEntry] = {}
@@ -121,6 +121,13 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
                 value_cache,
                 attn_metadata.slot_mapping,
                 attn_metadata.isa,
+            )
+            _try_write_tokens_to_vulkan_cache(
+                kv_cache=kv_cache,
+                key=key,
+                value=value,
+                slot_mapping=attn_metadata.slot_mapping,
+                num_tokens=num_actual_tokens,
             )
 
         if attn_metadata.use_sdpa_prefill:
@@ -227,38 +234,21 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
             if kv_cache.dtype == torch.float16:
                 from vllm_vulkan.kv_ops import (  # noqa: PLC0415
                     paged_attn_decode_f16,
-                    paged_kv_write_f16,
                 )
 
-                paged_kv_write_f16(
-                    ctx,
-                    layout,
-                    gpu_cache,
-                    0,
-                    key[:num_actual_tokens],
-                    value[:num_actual_tokens],
-                    attn_metadata.slot_mapping[:num_actual_tokens],
-                )
                 decode = paged_attn_decode_f16
             else:
                 from vllm_vulkan.kv_ops import (  # noqa: PLC0415
                     paged_attn_decode_f32,
-                    paged_kv_write_f32,
                 )
 
-                paged_kv_write_f32(
-                    ctx,
-                    layout,
-                    gpu_cache,
-                    0,
-                    key[:num_actual_tokens],
-                    value[:num_actual_tokens],
-                    attn_metadata.slot_mapping[:num_actual_tokens],
-                )
                 decode = paged_attn_decode_f32
 
             seq_lens = attn_metadata.seq_lens[:num_actual_tokens].to("cpu")
             block_table = attn_metadata.block_table[:num_actual_tokens].to("cpu")
+            if not _vulkan_cache_has_sequences(layout, kv_cache, block_table, seq_lens):
+                return False
+
             outs = []
             for token_idx in range(num_actual_tokens):
                 outs.append(
@@ -277,6 +267,13 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
             output[:num_actual_tokens].copy_(
                 torch.stack(outs).to(dtype=output.dtype, device=output.device)
             )
+            logger.debug(
+                "Vulkan attention decode used: tokens=%d heads=%d head_size=%d dtype=%s",
+                num_actual_tokens,
+                self.num_heads,
+                self.head_size,
+                kv_cache.dtype,
+            )
             self._last_vulkan_decode_used = True
 
             return True
@@ -284,6 +281,81 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
             logger.debug("Vulkan attention decode fallback to CPU_ATTN: %s", exc)
 
             return False
+
+
+def _try_write_tokens_to_vulkan_cache(
+    *,
+    kv_cache: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    num_tokens: int,
+) -> None:
+    """Best-effort mirror of newly produced K/V tokens into Vulkan cache."""
+    if num_tokens <= 0 or kv_cache.dtype not in (torch.float16, torch.float32):
+        return
+
+    try:
+        ctx = _get_vulkan_context()
+        if ctx is None:
+            return
+
+        layout, gpu_cache = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
+        if kv_cache.dtype == torch.float16:
+            from vllm_vulkan.kv_ops import (  # noqa: PLC0415
+                paged_kv_write_f16 as write_kv,
+            )
+        else:
+            from vllm_vulkan.kv_ops import (  # noqa: PLC0415
+                paged_kv_write_f32 as write_kv,
+            )
+
+        slots = (
+            slot_mapping[:num_tokens]
+            .detach()
+            .to(device="cpu", dtype=torch.int64)
+            .contiguous()
+        )
+        write_kv(
+            ctx,
+            layout,
+            gpu_cache,
+            0,
+            key[:num_tokens],
+            value[:num_tokens],
+            slots,
+        )
+        _vulkan_cache_written_slots(kv_cache).update(int(slot) for slot in slots)
+    except Exception as exc:
+        logger.debug("Vulkan KV cache mirror skipped: %s", exc)
+
+
+def _vulkan_cache_has_sequences(
+    layout: VulkanPagedKVLayout,
+    kv_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+) -> bool:
+    written_slots = _vulkan_cache_written_slots(kv_cache)
+    spec = layout.layer_spec(0)
+    for req_idx, seq_len_tensor in enumerate(seq_lens):
+        seq_len = int(seq_len_tensor)
+        row = block_table[req_idx]
+        for token_pos in range(seq_len):
+            logical_block_id = token_pos // spec.block_size
+            token_offset = token_pos % spec.block_size
+            physical_block_id = int(row[logical_block_id])
+            slot = physical_block_id * spec.block_size + token_offset
+            if slot not in written_slots:
+                return False
+    return True
+
+
+def _vulkan_cache_written_slots(kv_cache: torch.Tensor) -> set[int]:
+    entry = _VULKAN_KV_CACHES.get(_kv_cache_storage_key(kv_cache))
+    if entry is None:
+        return set()
+    return entry.written_slots
 
 
 def _get_vulkan_context() -> VulkanContext | None:
@@ -305,14 +377,13 @@ def _get_or_create_vulkan_kv_cache(
     ctx: VulkanContext,
     kv_cache: torch.Tensor,
 ) -> tuple[VulkanPagedKVLayout, GpuTensor]:
-    storage = kv_cache.untyped_storage()
-    key = id(storage)
+    key = _kv_cache_storage_key(kv_cache)
     shape = tuple(int(dim) for dim in kv_cache.shape)
     entry = _VULKAN_KV_CACHES.get(key)
 
     if (
         entry is not None
-        and entry.storage_ref() is not None
+        and entry.storage_key == key
         and entry.shape == shape
         and entry.dtype == kv_cache.dtype
     ):
@@ -343,14 +414,19 @@ def _get_or_create_vulkan_kv_cache(
     ctx.update_activation(gpu_cache, bytes(layout.total_bytes))
 
     _VULKAN_KV_CACHES[key] = _VulkanKVCacheEntry(
-        storage_ref=weakref.ref(storage),
+        storage_key=key,
         layout=layout,
         cache=gpu_cache,
         shape=shape,
         dtype=kv_cache.dtype,
+        written_slots=set(),
     )
 
     return layout, gpu_cache
+
+
+def _kv_cache_storage_key(kv_cache: torch.Tensor) -> int:
+    return int(kv_cache.untyped_storage().data_ptr())
 
 
 def _kv_cache_dtype_size(dtype: torch.dtype) -> int:

--- a/vllm_vulkan/attention.py
+++ b/vllm_vulkan/attention.py
@@ -9,6 +9,7 @@ Vulkan paged KV cache. Unsupported cases fall back to CPU_ATTN.
 from __future__ import annotations
 
 import logging
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -28,6 +29,12 @@ if TYPE_CHECKING:
     from vllm_vulkan._rs import GpuTensor, VulkanContext
 
 logger = logging.getLogger(__name__)
+
+# vLLM passes a per-layer KV cache tensor into each Attention.forward call.
+# The Vulkan mirror therefore contains exactly that one layer, represented as
+# layer 0 in our VulkanPagedKVLayout.
+_PER_LAYER_KV_CACHE_INDEX = 0
+_MAX_VERIFIED_SEQUENCE_KEYS = 4096
 
 
 class VulkanAttentionBackend(CPUAttentionBackend):
@@ -55,7 +62,8 @@ class _VulkanKVCacheEntry:
     cache: GpuTensor
     shape: tuple[int, ...]
     dtype: torch.dtype
-    written_slots: set[int]
+    written_slots: bytearray
+    verified_prefix_by_blocks: OrderedDict[tuple[int, ...], int]
 
 
 _VULKAN_KV_CACHES: dict[int, _VulkanKVCacheEntry] = {}
@@ -95,6 +103,7 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
             return output
 
         num_actual_tokens = attn_metadata.num_actual_tokens
+        allow_vulkan_decode = True
         if self.attn_type in (AttentionType.ENCODER_ONLY, AttentionType.ENCODER):
             return self._run_sdpa_forward(
                 query[:num_actual_tokens],
@@ -131,6 +140,7 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
             )
 
         if attn_metadata.use_sdpa_prefill:
+            allow_vulkan_decode = False
             assert self.sinks is None, "Attention sink is unsupported in SDPA prefill"
             num_decode_tokens = attn_metadata.num_decode_tokens
             self._run_sdpa_forward(
@@ -144,7 +154,7 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
             num_actual_tokens = num_decode_tokens
 
         if num_actual_tokens > 0:
-            if not self._try_vulkan_decode(
+            if not allow_vulkan_decode or not self._try_vulkan_decode(
                 query=query,
                 key=key,
                 value=value,
@@ -201,7 +211,7 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
             if ctx is None:
                 return False
 
-            layout, gpu_cache = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
+            entry = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
             if kv_cache.dtype == torch.float16:
                 from vllm_vulkan.kv_ops import (  # noqa: PLC0415
                     paged_attn_decode_f16,
@@ -217,7 +227,7 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
 
             seq_lens = attn_metadata.seq_lens[:num_actual_tokens].to("cpu")
             block_table = attn_metadata.block_table[:num_actual_tokens].to("cpu")
-            if not _vulkan_cache_has_sequences(layout, kv_cache, block_table, seq_lens):
+            if not _vulkan_cache_has_sequences(entry, block_table, seq_lens):
                 return False
 
             outs = []
@@ -225,9 +235,9 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
                 outs.append(
                     decode(
                         ctx,
-                        layout,
-                        gpu_cache,
-                        0,
+                        entry.layout,
+                        entry.cache,
+                        _PER_LAYER_KV_CACHE_INDEX,
                         query[token_idx].detach().to("cpu"),
                         block_table[token_idx],
                         int(seq_lens[token_idx]),
@@ -266,7 +276,7 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
         """Return True for the conservative decode-only path we can run."""
         if self.attn_type != AttentionType.DECODER:
             return False
-        if attn_metadata.use_sdpa_prefill or not attn_metadata.causal:
+        if not attn_metadata.causal:
             return False
         if self.kv_sharing_target_layer_name is not None:
             return False
@@ -306,7 +316,7 @@ def _try_write_tokens_to_vulkan_cache(
         if ctx is None:
             return
 
-        layout, gpu_cache = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
+        entry = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
         if kv_cache.dtype == torch.float16:
             from vllm_vulkan.kv_ops import (  # noqa: PLC0415
                 paged_kv_write_f16 as write_kv,
@@ -324,48 +334,86 @@ def _try_write_tokens_to_vulkan_cache(
         )
         write_kv(
             ctx,
-            layout,
-            gpu_cache,
-            0,
+            entry.layout,
+            entry.cache,
+            _PER_LAYER_KV_CACHE_INDEX,
             key[:num_tokens],
             value[:num_tokens],
             slots,
         )
-        _vulkan_cache_written_slots(kv_cache).update(int(slot) for slot in slots)
+        _mark_vulkan_cache_slots_written(entry, slots)
     except Exception as exc:
         logger.debug("Vulkan KV cache mirror skipped: %s", exc)
 
 
 def _vulkan_cache_has_sequences(
-    layout: VulkanPagedKVLayout,
-    kv_cache: torch.Tensor,
+    entry: _VulkanKVCacheEntry,
     block_table: torch.Tensor,
     seq_lens: torch.Tensor,
 ) -> bool:
-    written_slots = _vulkan_cache_written_slots(kv_cache)
-    spec = layout.layer_spec(0)
+    layout = entry.layout
+    spec = layout.layer_spec(_PER_LAYER_KV_CACHE_INDEX)
     for req_idx, seq_len_tensor in enumerate(seq_lens):
         seq_len = int(seq_len_tensor)
         row = block_table[req_idx]
-        for token_pos in range(seq_len):
+        needed_blocks = (seq_len + spec.block_size - 1) // spec.block_size
+        active_blocks = _active_block_ids(row, needed_blocks, layout.num_blocks)
+        if active_blocks is None:
+            return False
+
+        start_pos = min(_verified_prefix_len(entry, active_blocks), seq_len)
+        for token_pos in range(start_pos, seq_len):
             logical_block_id = token_pos // spec.block_size
-            if logical_block_id >= row.numel():
-                return False
             token_offset = token_pos % spec.block_size
-            physical_block_id = int(row[logical_block_id])
-            if not 0 <= physical_block_id < layout.num_blocks:
-                return False
+            physical_block_id = active_blocks[logical_block_id]
             slot = physical_block_id * spec.block_size + token_offset
-            if slot not in written_slots:
+            if not entry.written_slots[slot]:
                 return False
+        _remember_verified_prefix(entry, active_blocks, seq_len)
+
     return True
 
 
-def _vulkan_cache_written_slots(kv_cache: torch.Tensor) -> set[int]:
-    entry = _VULKAN_KV_CACHES.get(_kv_cache_storage_key(kv_cache))
-    if entry is None:
-        return set()
-    return entry.written_slots
+def _mark_vulkan_cache_slots_written(
+    entry: _VulkanKVCacheEntry, slots: torch.Tensor
+) -> None:
+    capacity = len(entry.written_slots)
+    for slot_tensor in slots:
+        slot = int(slot_tensor)
+        if 0 <= slot < capacity:
+            entry.written_slots[slot] = 1
+
+
+def _active_block_ids(
+    row: torch.Tensor, needed_blocks: int, num_blocks: int
+) -> tuple[int, ...] | None:
+    if row.numel() < needed_blocks:
+        return None
+
+    block_ids = tuple(int(block_id) for block_id in row[:needed_blocks])
+    if any(block_id < 0 or block_id >= num_blocks for block_id in block_ids):
+        return None
+    return block_ids
+
+
+def _verified_prefix_len(
+    entry: _VulkanKVCacheEntry, active_blocks: tuple[int, ...]
+) -> int:
+    verified = entry.verified_prefix_by_blocks.get(active_blocks)
+    if verified is not None:
+        return verified
+    if len(active_blocks) > 1:
+        return entry.verified_prefix_by_blocks.get(active_blocks[:-1], 0)
+    return 0
+
+
+def _remember_verified_prefix(
+    entry: _VulkanKVCacheEntry, active_blocks: tuple[int, ...], seq_len: int
+) -> None:
+    entry.verified_prefix_by_blocks[active_blocks] = seq_len
+    entry.verified_prefix_by_blocks.move_to_end(active_blocks)
+    while len(entry.verified_prefix_by_blocks) > _MAX_VERIFIED_SEQUENCE_KEYS:
+        entry.verified_prefix_by_blocks.popitem(last=False)
 
 
 def _get_vulkan_context() -> VulkanContext | None:
@@ -386,7 +434,7 @@ def _get_vulkan_context() -> VulkanContext | None:
 def _get_or_create_vulkan_kv_cache(
     ctx: VulkanContext,
     kv_cache: torch.Tensor,
-) -> tuple[VulkanPagedKVLayout, GpuTensor]:
+) -> _VulkanKVCacheEntry:
     key = _kv_cache_storage_key(kv_cache)
     shape = tuple(int(dim) for dim in kv_cache.shape)
     entry = _VULKAN_KV_CACHES.get(key)
@@ -397,7 +445,7 @@ def _get_or_create_vulkan_kv_cache(
         and entry.shape == shape
         and entry.dtype == kv_cache.dtype
     ):
-        return entry.layout, entry.cache
+        return entry
 
     if entry is not None:
         _VULKAN_KV_CACHES.pop(key, None)
@@ -411,7 +459,7 @@ def _get_or_create_vulkan_kv_cache(
     layout = VulkanPagedKVLayout(
         (
             KVCacheLayerSpec(
-                layer_index=0,
+                layer_index=_PER_LAYER_KV_CACHE_INDEX,
                 num_kv_heads=num_kv_heads,
                 head_size=head_size,
                 block_size=block_size,
@@ -423,16 +471,18 @@ def _get_or_create_vulkan_kv_cache(
     gpu_cache = ctx.alloc_activation(layout.total_bytes)
     ctx.update_activation(gpu_cache, bytes(layout.total_bytes))
 
-    _VULKAN_KV_CACHES[key] = _VulkanKVCacheEntry(
+    entry = _VulkanKVCacheEntry(
         storage_key=key,
         layout=layout,
         cache=gpu_cache,
         shape=shape,
         dtype=kv_cache.dtype,
-        written_slots=set(),
+        written_slots=bytearray(layout.capacity_tokens_per_layer),
+        verified_prefix_by_blocks=OrderedDict(),
     )
+    _VULKAN_KV_CACHES[key] = entry
 
-    return layout, gpu_cache
+    return entry
 
 
 def _kv_cache_storage_key(kv_cache: torch.Tensor) -> int:

--- a/vllm_vulkan/envs.py
+++ b/vllm_vulkan/envs.py
@@ -17,13 +17,15 @@ import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+_VLLM_VULKAN_RUST_MODEL_DEFAULT = True
+
 if TYPE_CHECKING:
     VLLM_VULKAN_MEMORY_FRACTION: float = 0.9
     VLLM_VULKAN_BLOCK_SIZE: str = "16"
     VLLM_VULKAN_DEBUG: bool = False
     VLLM_VULKAN_DEVICE_INDEX: int = 0
     VLLM_VULKAN_DISABLE_ATTN: bool = False
-    VLLM_VULKAN_RUST_MODEL: bool = True
+    VLLM_VULKAN_RUST_MODEL: bool = _VLLM_VULKAN_RUST_MODEL_DEFAULT
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of device memory to use for KV cache (0, 1].
@@ -41,7 +43,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_VULKAN_DISABLE_ATTN", "0") == "1"
     ),
     # Use the Rust VulkanModel / Vulkan module hooks during model execution.
-    "VLLM_VULKAN_RUST_MODEL": lambda: os.getenv("VLLM_VULKAN_RUST_MODEL", "1") == "1",
+    "VLLM_VULKAN_RUST_MODEL": lambda: (
+        os.getenv(
+            "VLLM_VULKAN_RUST_MODEL",
+            "1" if _VLLM_VULKAN_RUST_MODEL_DEFAULT else "0",
+        )
+        == "1"
+    ),
 }
 
 

--- a/vllm_vulkan/envs.py
+++ b/vllm_vulkan/envs.py
@@ -17,61 +17,34 @@ import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-_VLLM_VULKAN_MEMORY_FRACTION_DEFAULT = 0.9
-_VLLM_VULKAN_BLOCK_SIZE_DEFAULT = "16"
-_VLLM_VULKAN_DEBUG_DEFAULT = False
-_VLLM_VULKAN_DEVICE_INDEX_DEFAULT = 0
-_VLLM_VULKAN_DISABLE_ATTN_DEFAULT = False
-_VLLM_VULKAN_RUST_MODEL_DEFAULT = True
-
-
-def _bool_env(name: str, default: bool) -> Callable[[], bool]:
-    default_value = "1" if default else "0"
-    return lambda: os.getenv(name, default_value) == "1"
-
-
-def _float_env(name: str, default: float) -> Callable[[], float]:
-    return lambda: float(os.getenv(name, str(default)))
-
-
-def _int_env(name: str, default: int) -> Callable[[], int]:
-    return lambda: int(os.getenv(name, str(default)))
-
-
-def _str_env(name: str, default: str) -> Callable[[], str]:
-    return lambda: os.getenv(name, default)
-
+_VLLM_VULKAN_RUST_MODEL_DEFAULT = "1"
 
 if TYPE_CHECKING:
-    VLLM_VULKAN_MEMORY_FRACTION: float = _VLLM_VULKAN_MEMORY_FRACTION_DEFAULT
-    VLLM_VULKAN_BLOCK_SIZE: str = _VLLM_VULKAN_BLOCK_SIZE_DEFAULT
-    VLLM_VULKAN_DEBUG: bool = _VLLM_VULKAN_DEBUG_DEFAULT
-    VLLM_VULKAN_DEVICE_INDEX: int = _VLLM_VULKAN_DEVICE_INDEX_DEFAULT
-    VLLM_VULKAN_DISABLE_ATTN: bool = _VLLM_VULKAN_DISABLE_ATTN_DEFAULT
-    VLLM_VULKAN_RUST_MODEL: bool = _VLLM_VULKAN_RUST_MODEL_DEFAULT
+    VLLM_VULKAN_MEMORY_FRACTION: float = 0.9
+    VLLM_VULKAN_BLOCK_SIZE: str = "16"
+    VLLM_VULKAN_DEBUG: bool = False
+    VLLM_VULKAN_DEVICE_INDEX: int = 0
+    VLLM_VULKAN_DISABLE_ATTN: bool = False
+    VLLM_VULKAN_RUST_MODEL: bool = _VLLM_VULKAN_RUST_MODEL_DEFAULT == "1"
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of device memory to use for KV cache (0, 1].
-    "VLLM_VULKAN_MEMORY_FRACTION": _float_env(
-        "VLLM_VULKAN_MEMORY_FRACTION", _VLLM_VULKAN_MEMORY_FRACTION_DEFAULT
+    "VLLM_VULKAN_MEMORY_FRACTION": lambda: float(
+        os.getenv("VLLM_VULKAN_MEMORY_FRACTION", "0.9")
     ),
     # Tokens per KV-cache block (default 16).
-    "VLLM_VULKAN_BLOCK_SIZE": _str_env(
-        "VLLM_VULKAN_BLOCK_SIZE", _VLLM_VULKAN_BLOCK_SIZE_DEFAULT
-    ),
+    "VLLM_VULKAN_BLOCK_SIZE": lambda: os.getenv("VLLM_VULKAN_BLOCK_SIZE", "16"),
     # Enable verbose debug logging (default False).
-    "VLLM_VULKAN_DEBUG": _bool_env("VLLM_VULKAN_DEBUG", _VLLM_VULKAN_DEBUG_DEFAULT),
+    "VLLM_VULKAN_DEBUG": lambda: os.getenv("VLLM_VULKAN_DEBUG", "0") == "1",
     # Which Vulkan physical device index to use (default 0).
-    "VLLM_VULKAN_DEVICE_INDEX": _int_env(
-        "VLLM_VULKAN_DEVICE_INDEX", _VLLM_VULKAN_DEVICE_INDEX_DEFAULT
-    ),
+    "VLLM_VULKAN_DEVICE_INDEX": lambda: int(os.getenv("VLLM_VULKAN_DEVICE_INDEX", "0")),
     # Disable the experimental Vulkan attention decode path.
-    "VLLM_VULKAN_DISABLE_ATTN": _bool_env(
-        "VLLM_VULKAN_DISABLE_ATTN", _VLLM_VULKAN_DISABLE_ATTN_DEFAULT
+    "VLLM_VULKAN_DISABLE_ATTN": lambda: (
+        os.getenv("VLLM_VULKAN_DISABLE_ATTN", "0") == "1"
     ),
     # Use the Rust VulkanModel / Vulkan module hooks during model execution.
-    "VLLM_VULKAN_RUST_MODEL": _bool_env(
-        "VLLM_VULKAN_RUST_MODEL", _VLLM_VULKAN_RUST_MODEL_DEFAULT
+    "VLLM_VULKAN_RUST_MODEL": lambda: (
+        os.getenv("VLLM_VULKAN_RUST_MODEL", _VLLM_VULKAN_RUST_MODEL_DEFAULT) == "1"
     ),
 }
 

--- a/vllm_vulkan/envs.py
+++ b/vllm_vulkan/envs.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     VLLM_VULKAN_BLOCK_SIZE: str = "16"
     VLLM_VULKAN_DEBUG: bool = False
     VLLM_VULKAN_DEVICE_INDEX: int = 0
+    VLLM_VULKAN_DISABLE_ATTN: bool = False
+    VLLM_VULKAN_RUST_MODEL: bool = True
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of device memory to use for KV cache (0, 1].
@@ -34,6 +36,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_VULKAN_DEBUG": lambda: os.getenv("VLLM_VULKAN_DEBUG", "0") == "1",
     # Which Vulkan physical device index to use (default 0).
     "VLLM_VULKAN_DEVICE_INDEX": lambda: int(os.getenv("VLLM_VULKAN_DEVICE_INDEX", "0")),
+    # Disable the experimental Vulkan attention decode path.
+    "VLLM_VULKAN_DISABLE_ATTN": lambda: os.getenv("VLLM_VULKAN_DISABLE_ATTN", "0")
+    == "1",
+    # Use the Rust VulkanModel / Vulkan module hooks during model execution.
+    "VLLM_VULKAN_RUST_MODEL": lambda: os.getenv("VLLM_VULKAN_RUST_MODEL", "1") == "1",
 }
 
 

--- a/vllm_vulkan/envs.py
+++ b/vllm_vulkan/envs.py
@@ -17,30 +17,62 @@ import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+_VLLM_VULKAN_MEMORY_FRACTION_DEFAULT = 0.9
+_VLLM_VULKAN_BLOCK_SIZE_DEFAULT = "16"
+_VLLM_VULKAN_DEBUG_DEFAULT = False
+_VLLM_VULKAN_DEVICE_INDEX_DEFAULT = 0
+_VLLM_VULKAN_DISABLE_ATTN_DEFAULT = False
+_VLLM_VULKAN_RUST_MODEL_DEFAULT = True
+
+
+def _bool_env(name: str, default: bool) -> Callable[[], bool]:
+    default_value = "1" if default else "0"
+    return lambda: os.getenv(name, default_value) == "1"
+
+
+def _float_env(name: str, default: float) -> Callable[[], float]:
+    return lambda: float(os.getenv(name, str(default)))
+
+
+def _int_env(name: str, default: int) -> Callable[[], int]:
+    return lambda: int(os.getenv(name, str(default)))
+
+
+def _str_env(name: str, default: str) -> Callable[[], str]:
+    return lambda: os.getenv(name, default)
+
+
 if TYPE_CHECKING:
-    VLLM_VULKAN_MEMORY_FRACTION: float = 0.9
-    VLLM_VULKAN_BLOCK_SIZE: str = "16"
-    VLLM_VULKAN_DEBUG: bool = False
-    VLLM_VULKAN_DEVICE_INDEX: int = 0
-    VLLM_VULKAN_DISABLE_ATTN: bool = False
-    VLLM_VULKAN_RUST_MODEL: bool = True
+    VLLM_VULKAN_MEMORY_FRACTION: float = _VLLM_VULKAN_MEMORY_FRACTION_DEFAULT
+    VLLM_VULKAN_BLOCK_SIZE: str = _VLLM_VULKAN_BLOCK_SIZE_DEFAULT
+    VLLM_VULKAN_DEBUG: bool = _VLLM_VULKAN_DEBUG_DEFAULT
+    VLLM_VULKAN_DEVICE_INDEX: int = _VLLM_VULKAN_DEVICE_INDEX_DEFAULT
+    VLLM_VULKAN_DISABLE_ATTN: bool = _VLLM_VULKAN_DISABLE_ATTN_DEFAULT
+    VLLM_VULKAN_RUST_MODEL: bool = _VLLM_VULKAN_RUST_MODEL_DEFAULT
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of device memory to use for KV cache (0, 1].
-    "VLLM_VULKAN_MEMORY_FRACTION": lambda: float(
-        os.getenv("VLLM_VULKAN_MEMORY_FRACTION", "0.9")
+    "VLLM_VULKAN_MEMORY_FRACTION": _float_env(
+        "VLLM_VULKAN_MEMORY_FRACTION", _VLLM_VULKAN_MEMORY_FRACTION_DEFAULT
     ),
     # Tokens per KV-cache block (default 16).
-    "VLLM_VULKAN_BLOCK_SIZE": lambda: os.getenv("VLLM_VULKAN_BLOCK_SIZE", "16"),
+    "VLLM_VULKAN_BLOCK_SIZE": _str_env(
+        "VLLM_VULKAN_BLOCK_SIZE", _VLLM_VULKAN_BLOCK_SIZE_DEFAULT
+    ),
     # Enable verbose debug logging (default False).
-    "VLLM_VULKAN_DEBUG": lambda: os.getenv("VLLM_VULKAN_DEBUG", "0") == "1",
+    "VLLM_VULKAN_DEBUG": _bool_env("VLLM_VULKAN_DEBUG", _VLLM_VULKAN_DEBUG_DEFAULT),
     # Which Vulkan physical device index to use (default 0).
-    "VLLM_VULKAN_DEVICE_INDEX": lambda: int(os.getenv("VLLM_VULKAN_DEVICE_INDEX", "0")),
+    "VLLM_VULKAN_DEVICE_INDEX": _int_env(
+        "VLLM_VULKAN_DEVICE_INDEX", _VLLM_VULKAN_DEVICE_INDEX_DEFAULT
+    ),
     # Disable the experimental Vulkan attention decode path.
-    "VLLM_VULKAN_DISABLE_ATTN": lambda: os.getenv("VLLM_VULKAN_DISABLE_ATTN", "0")
-    == "1",
+    "VLLM_VULKAN_DISABLE_ATTN": _bool_env(
+        "VLLM_VULKAN_DISABLE_ATTN", _VLLM_VULKAN_DISABLE_ATTN_DEFAULT
+    ),
     # Use the Rust VulkanModel / Vulkan module hooks during model execution.
-    "VLLM_VULKAN_RUST_MODEL": lambda: os.getenv("VLLM_VULKAN_RUST_MODEL", "1") == "1",
+    "VLLM_VULKAN_RUST_MODEL": _bool_env(
+        "VLLM_VULKAN_RUST_MODEL", _VLLM_VULKAN_RUST_MODEL_DEFAULT
+    ),
 }
 
 

--- a/vllm_vulkan/envs.py
+++ b/vllm_vulkan/envs.py
@@ -17,15 +17,13 @@ import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-_VLLM_VULKAN_RUST_MODEL_DEFAULT = "1"
-
 if TYPE_CHECKING:
     VLLM_VULKAN_MEMORY_FRACTION: float = 0.9
     VLLM_VULKAN_BLOCK_SIZE: str = "16"
     VLLM_VULKAN_DEBUG: bool = False
     VLLM_VULKAN_DEVICE_INDEX: int = 0
     VLLM_VULKAN_DISABLE_ATTN: bool = False
-    VLLM_VULKAN_RUST_MODEL: bool = _VLLM_VULKAN_RUST_MODEL_DEFAULT == "1"
+    VLLM_VULKAN_RUST_MODEL: bool = True
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of device memory to use for KV cache (0, 1].
@@ -43,9 +41,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_VULKAN_DISABLE_ATTN", "0") == "1"
     ),
     # Use the Rust VulkanModel / Vulkan module hooks during model execution.
-    "VLLM_VULKAN_RUST_MODEL": lambda: (
-        os.getenv("VLLM_VULKAN_RUST_MODEL", _VLLM_VULKAN_RUST_MODEL_DEFAULT) == "1"
-    ),
+    "VLLM_VULKAN_RUST_MODEL": lambda: os.getenv("VLLM_VULKAN_RUST_MODEL", "1") == "1",
 }
 
 

--- a/vllm_vulkan/kv_layout.py
+++ b/vllm_vulkan/kv_layout.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Paged KV-cache layout contract for the Vulkan backend.
+
+The first Vulkan attention kernels need a stable byte layout before they can
+read or write paged KV blocks.  This module defines that contract in one place
+and keeps it aligned with vLLM's block-table/slot mapping:
+
+    slot = physical_block_id * block_size + token_offset_in_block
+
+Each layer owns a contiguous region.  Inside a layer, each physical block stores
+one K plane followed by one V plane:
+
+    [layer][physical block][K tokens][V tokens]
+
+Within each K/V plane, data is token-major:
+
+    [token_offset_in_block][kv_head][head_element]
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+KVPlane = Literal["k", "v"]
+
+_DTYPE_SIZE_BYTES = {
+    "float16": 2,
+    "half": 2,
+    "bfloat16": 2,
+    "bf16": 2,
+    "float32": 4,
+    "float": 4,
+    "fp32": 4,
+    "float64": 8,
+    "double": 8,
+    "fp8": 1,
+    "float8": 1,
+    "float8_e4m3fn": 1,
+    "float8_e5m2": 1,
+}
+
+
+def dtype_size_bytes(dtype: Any) -> int:
+    """Return the byte width used for KV cache dtype names or dtype objects."""
+    if isinstance(dtype, int):
+        if dtype <= 0:
+            raise ValueError("dtype byte width must be positive")
+        return dtype
+
+    name = str(dtype).lower()
+    if name.startswith("torch."):
+        name = name.removeprefix("torch.")
+
+    if name in _DTYPE_SIZE_BYTES:
+        return _DTYPE_SIZE_BYTES[name]
+
+    itemsize = getattr(dtype, "itemsize", None)
+    if isinstance(itemsize, int) and itemsize > 0:
+        return itemsize
+
+    raise ValueError(f"Unsupported KV cache dtype {dtype!r}")
+
+
+@dataclass(frozen=True)
+class KVCacheLayerSpec:
+    """Shape of one layer's paged KV-cache blocks."""
+
+    layer_index: int
+    num_kv_heads: int
+    head_size: int
+    block_size: int
+    dtype_size: int
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "layer_index",
+            "num_kv_heads",
+            "head_size",
+            "block_size",
+            "dtype_size",
+        ):
+            value = getattr(self, field_name)
+            if field_name == "layer_index":
+                if value < 0:
+                    raise ValueError("layer_index must be >= 0")
+            elif value <= 0:
+                raise ValueError(f"{field_name} must be > 0")
+
+    @property
+    def elements_per_token(self) -> int:
+        return self.num_kv_heads * self.head_size
+
+    @property
+    def bytes_per_token_per_plane(self) -> int:
+        return self.elements_per_token * self.dtype_size
+
+    @property
+    def bytes_per_token(self) -> int:
+        return 2 * self.bytes_per_token_per_plane
+
+    @property
+    def plane_bytes_per_block(self) -> int:
+        return self.block_size * self.bytes_per_token_per_plane
+
+    @property
+    def bytes_per_block(self) -> int:
+        return 2 * self.plane_bytes_per_block
+
+
+@dataclass(frozen=True)
+class KVAttentionPlaneStrides:
+    """Byte strides an attention shader uses to scan one K or V block."""
+
+    base_offset: int
+    token_stride: int
+    kv_head_stride: int
+    head_element_stride: int
+
+
+@dataclass(frozen=True)
+class VulkanPagedKVLayout:
+    """Byte-addressable paged KV-cache layout for Vulkan attention kernels."""
+
+    layer_specs: tuple[KVCacheLayerSpec, ...]
+    num_blocks: int
+
+    def __post_init__(self) -> None:
+        if self.num_blocks <= 0:
+            raise ValueError("num_blocks must be > 0")
+        if not self.layer_specs:
+            raise ValueError("at least one layer spec is required")
+
+        ordered = tuple(sorted(self.layer_specs, key=lambda spec: spec.layer_index))
+        for expected, spec in enumerate(ordered):
+            if spec.layer_index != expected:
+                raise ValueError(
+                    "layer specs must be contiguous and start at 0; "
+                    f"expected layer {expected}, got {spec.layer_index}"
+                )
+
+        block_size = ordered[0].block_size
+        if any(spec.block_size != block_size for spec in ordered):
+            raise ValueError("all layer specs must use the same block_size")
+
+        offsets: list[int] = []
+        cursor = 0
+        for spec in ordered:
+            offsets.append(cursor)
+            cursor += self.num_blocks * spec.bytes_per_block
+
+        object.__setattr__(self, "layer_specs", ordered)
+        object.__setattr__(self, "_layer_base_offsets", tuple(offsets))
+        object.__setattr__(self, "_total_bytes", cursor)
+
+    @property
+    def num_layers(self) -> int:
+        return len(self.layer_specs)
+
+    @property
+    def block_size(self) -> int:
+        return self.layer_specs[0].block_size
+
+    @property
+    def capacity_tokens_per_layer(self) -> int:
+        return self.num_blocks * self.block_size
+
+    @property
+    def total_bytes(self) -> int:
+        return self._total_bytes
+
+    @property
+    def bytes_per_token(self) -> int:
+        return sum(spec.bytes_per_token for spec in self.layer_specs)
+
+    def layer_spec(self, layer_index: int) -> KVCacheLayerSpec:
+        try:
+            return self.layer_specs[layer_index]
+        except IndexError as exc:
+            raise ValueError(f"layer_index {layer_index} out of range") from exc
+
+    def layer_base_offset(self, layer_index: int) -> int:
+        self.layer_spec(layer_index)
+        return self._layer_base_offsets[layer_index]
+
+    def block_base_offset(self, layer_index: int, physical_block_id: int) -> int:
+        spec = self.layer_spec(layer_index)
+        if not 0 <= physical_block_id < self.num_blocks:
+            raise ValueError(
+                f"physical_block_id {physical_block_id} out of range "
+                f"for {self.num_blocks} block(s)"
+            )
+        return (
+            self.layer_base_offset(layer_index)
+            + physical_block_id * spec.bytes_per_block
+        )
+
+    def plane_base_offset(
+        self, layer_index: int, physical_block_id: int, plane: KVPlane
+    ) -> int:
+        spec = self.layer_spec(layer_index)
+        block_base = self.block_base_offset(layer_index, physical_block_id)
+        if plane == "k":
+            return block_base
+        if plane == "v":
+            return block_base + spec.plane_bytes_per_block
+        raise ValueError(f"unknown KV plane {plane!r}")
+
+    def token_offset(
+        self,
+        layer_index: int,
+        physical_block_id: int,
+        token_offset_in_block: int,
+        kv_head: int,
+        head_element: int,
+        plane: KVPlane,
+    ) -> int:
+        """Return byte offset for one scalar in the paged KV cache."""
+        spec = self.layer_spec(layer_index)
+        if not 0 <= token_offset_in_block < spec.block_size:
+            raise ValueError(
+                f"token_offset_in_block {token_offset_in_block} out of range "
+                f"for block_size {spec.block_size}"
+            )
+        if not 0 <= kv_head < spec.num_kv_heads:
+            raise ValueError(
+                f"kv_head {kv_head} out of range for {spec.num_kv_heads} head(s)"
+            )
+        if not 0 <= head_element < spec.head_size:
+            raise ValueError(
+                f"head_element {head_element} out of range for head_size "
+                f"{spec.head_size}"
+            )
+
+        scalar_index = (
+            token_offset_in_block * spec.num_kv_heads + kv_head
+        ) * spec.head_size + head_element
+        return (
+            self.plane_base_offset(layer_index, physical_block_id, plane)
+            + scalar_index * spec.dtype_size
+        )
+
+    def slot_offset(
+        self,
+        layer_index: int,
+        slot: int,
+        kv_head: int,
+        head_element: int,
+        plane: KVPlane,
+    ) -> int:
+        """Return byte offset from vLLM slot mapping output."""
+        if slot < 0:
+            raise ValueError("slot must be >= 0")
+        physical_block_id, token_offset_in_block = divmod(slot, self.block_size)
+        return self.token_offset(
+            layer_index,
+            physical_block_id,
+            token_offset_in_block,
+            kv_head,
+            head_element,
+            plane,
+        )
+
+    def plane_strides_for_attn_load(
+        self,
+        layer_index: int,
+        physical_block_id: int,
+        plane: KVPlane,
+    ) -> KVAttentionPlaneStrides:
+        """Return byte strides for K/V[token, kv_head, head_element] loads."""
+        spec = self.layer_spec(layer_index)
+        return KVAttentionPlaneStrides(
+            base_offset=self.plane_base_offset(layer_index, physical_block_id, plane),
+            token_stride=spec.bytes_per_token_per_plane,
+            kv_head_stride=spec.head_size * spec.dtype_size,
+            head_element_stride=spec.dtype_size,
+        )
+
+    def k_plane_strides_for_attn_load(
+        self, layer_index: int, physical_block_id: int
+    ) -> KVAttentionPlaneStrides:
+        """Return byte strides for attention K loads from one physical block."""
+        return self.plane_strides_for_attn_load(layer_index, physical_block_id, "k")
+
+    def v_plane_strides_for_attn_load(
+        self, layer_index: int, physical_block_id: int
+    ) -> KVAttentionPlaneStrides:
+        """Return byte strides for attention V loads from one physical block."""
+        return self.plane_strides_for_attn_load(layer_index, physical_block_id, "v")
+
+    @classmethod
+    def from_layer_specs(
+        cls,
+        layer_specs: list[KVCacheLayerSpec] | tuple[KVCacheLayerSpec, ...],
+        num_blocks: int,
+    ) -> VulkanPagedKVLayout:
+        return cls(tuple(layer_specs), num_blocks)
+
+
+def infer_kv_layer_specs(
+    hf_config: Any, block_size: int, dtype: Any
+) -> tuple[KVCacheLayerSpec, ...]:
+    """Infer per-layer KV-cache block shapes from a Hugging Face config."""
+    text_cfg = _cfg_get(hf_config, "text_config") or hf_config
+    num_layers = int(_cfg_get(text_cfg, "num_hidden_layers", 1))
+    num_attention_heads = int(_cfg_get(text_cfg, "num_attention_heads", 1))
+    num_kv_heads = int(_cfg_get(text_cfg, "num_key_value_heads", num_attention_heads))
+    hidden_size = _cfg_get(text_cfg, "hidden_size")
+    head_size = _cfg_get(text_cfg, "head_dim")
+    if head_size is None:
+        if hidden_size is None:
+            raise ValueError("cannot infer KV head size from model config")
+        head_size = int(hidden_size) // num_attention_heads
+    else:
+        head_size = int(head_size)
+
+    global_head_size = _cfg_get(text_cfg, "global_head_dim")
+    global_num_kv_heads = _cfg_get(text_cfg, "num_global_key_value_heads")
+    layer_types = _cfg_get(text_cfg, "layer_types")
+    dtype_size = dtype_size_bytes(dtype)
+
+    specs: list[KVCacheLayerSpec] = []
+    for layer_index in range(num_layers):
+        layer_type = ""
+        if layer_types is not None and layer_index < len(layer_types):
+            layer_type = str(layer_types[layer_index]).lower()
+
+        use_global = (
+            "full" in layer_type
+            and global_head_size is not None
+            and global_num_kv_heads is not None
+        )
+        specs.append(
+            KVCacheLayerSpec(
+                layer_index=layer_index,
+                num_kv_heads=int(global_num_kv_heads if use_global else num_kv_heads),
+                head_size=int(global_head_size if use_global else head_size),
+                block_size=block_size,
+                dtype_size=dtype_size,
+            )
+        )
+    return tuple(specs)
+
+
+def layout_from_hf_config(
+    hf_config: Any, block_size: int, num_blocks: int, dtype: Any
+) -> VulkanPagedKVLayout:
+    """Build a paged KV layout directly from model config and block count."""
+    return VulkanPagedKVLayout(
+        infer_kv_layer_specs(hf_config, block_size=block_size, dtype=dtype),
+        num_blocks=num_blocks,
+    )
+
+
+def _cfg_get(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)

--- a/vllm_vulkan/kv_ops.py
+++ b/vllm_vulkan/kv_ops.py
@@ -19,6 +19,8 @@ _PAGED_KV_WRITE_SHADER = "paged_kv_write_f32"
 _PAGED_ATTN_DECODE_SHADER = "paged_attn_decode_f32"
 _PAGED_KV_WRITE_F16_SHADER = "paged_kv_write_f16"
 _PAGED_ATTN_DECODE_F16_SHADER = "paged_attn_decode_f16"
+_PAGED_ATTN_DECODE_COOP_SHADER = "paged_attn_decode_f32_coop"
+_PAGED_ATTN_DECODE_F16_COOP_SHADER = "paged_attn_decode_f16_coop"
 _PAGED_KV_WRITE_WORKGROUP_SIZE = 256
 _PAGED_ATTN_DECODE_WORKGROUP_SIZE = 256
 
@@ -178,6 +180,7 @@ def paged_attn_decode_f16(
         seq_len=seq_len,
         scale=scale,
         shader_name=_PAGED_ATTN_DECODE_F16_SHADER,
+        coop_shader_name=_PAGED_ATTN_DECODE_F16_COOP_SHADER,
         dtype_size=2,
     )
 
@@ -209,6 +212,7 @@ def paged_attn_decode_f32(
         seq_len=seq_len,
         scale=scale,
         shader_name=_PAGED_ATTN_DECODE_SHADER,
+        coop_shader_name=_PAGED_ATTN_DECODE_COOP_SHADER,
         dtype_size=4,
     )
 
@@ -223,9 +227,14 @@ def _paged_attn_decode(
     seq_len: int,
     scale: float | None,
     shader_name: str,
+    coop_shader_name: str,
     dtype_size: int,
 ) -> torch.Tensor:
-    if shader_name not in ctx.available_shaders():
+    available_shaders = ctx.available_shaders()
+    dispatch_shader_name = (
+        coop_shader_name if coop_shader_name in available_shaders else shader_name
+    )
+    if dispatch_shader_name not in available_shaders:
         raise RuntimeError(f"{shader_name} shader is not available")
 
     spec = layout.layer_spec(layer_index)
@@ -273,17 +282,24 @@ def _paged_attn_decode(
         scale=scale if scale is not None else 1.0 / math.sqrt(spec.head_size),
     )
     total_elements = num_q_heads * spec.head_size
-    workgroups = (
-        math.ceil(total_elements / _PAGED_ATTN_DECODE_WORKGROUP_SIZE),
-        1,
-        1,
-    )
+    if dispatch_shader_name == coop_shader_name:
+        workgroups = (
+            num_q_heads,
+            math.ceil(spec.head_size / _PAGED_ATTN_DECODE_WORKGROUP_SIZE),
+            1,
+        )
+    else:
+        workgroups = (
+            math.ceil(total_elements / _PAGED_ATTN_DECODE_WORKGROUP_SIZE),
+            1,
+            1,
+        )
     output_nbytes = total_elements * np.dtype(np.float32).itemsize
 
     results = ctx.execute_batch(
         [
             (
-                shader_name,
+                dispatch_shader_name,
                 [
                     _tensor_to_bytes(q_f32),
                     blocks.tobytes(),

--- a/vllm_vulkan/kv_ops.py
+++ b/vllm_vulkan/kv_ops.py
@@ -23,6 +23,7 @@ _PAGED_ATTN_DECODE_COOP_SHADER = "paged_attn_decode_f32_coop"
 _PAGED_ATTN_DECODE_F16_COOP_SHADER = "paged_attn_decode_f16_coop"
 _PAGED_KV_WRITE_WORKGROUP_SIZE = 256
 _PAGED_ATTN_DECODE_WORKGROUP_SIZE = 256
+_F32_NBYTES = np.dtype(np.float32).itemsize
 
 
 def paged_kv_write_f16(
@@ -97,19 +98,10 @@ def _paged_kv_write(
     dtype: torch.dtype,
     dtype_size: int,
 ) -> None:
-    if shader_name not in ctx.available_shaders():
-        raise RuntimeError(f"{shader_name} shader is not available")
-
     spec = layout.layer_spec(layer_index)
-    if spec.dtype_size != dtype_size:
-        raise ValueError(
-            f"{shader_name} requires a {dtype_size}-byte KV-cache layout"
-        )
-    if cache.nbytes < layout.total_bytes:
-        raise ValueError(
-            f"cache buffer has {cache.nbytes} bytes, "
-            f"expected at least {layout.total_bytes}"
-        )
+    _require_shader(ctx, shader_name)
+    _validate_cache_buffer(cache, layout)
+    _validate_layout_dtype(spec.dtype_size, dtype_size, shader_name)
 
     k_cpu = k.detach().to(dtype=dtype, device="cpu").contiguous()
     v_cpu = v.detach().to(dtype=dtype, device="cpu").contiguous()
@@ -230,23 +222,10 @@ def _paged_attn_decode(
     coop_shader_name: str,
     dtype_size: int,
 ) -> torch.Tensor:
-    available_shaders = ctx.available_shaders()
-    dispatch_shader_name = (
-        coop_shader_name if coop_shader_name in available_shaders else shader_name
-    )
-    if dispatch_shader_name not in available_shaders:
-        raise RuntimeError(f"{shader_name} shader is not available")
-
     spec = layout.layer_spec(layer_index)
-    if spec.dtype_size != dtype_size:
-        raise ValueError(
-            f"{shader_name} requires a {dtype_size}-byte KV-cache layout"
-        )
-    if cache.nbytes < layout.total_bytes:
-        raise ValueError(
-            f"cache buffer has {cache.nbytes} bytes, "
-            f"expected at least {layout.total_bytes}"
-        )
+    dispatch_shader_name = _select_decode_shader(ctx, shader_name, coop_shader_name)
+    _validate_cache_buffer(cache, layout)
+    _validate_layout_dtype(spec.dtype_size, dtype_size, shader_name)
     if seq_len <= 0:
         raise ValueError("seq_len must be > 0")
     if seq_len > layout.capacity_tokens_per_layer:
@@ -259,10 +238,9 @@ def _paged_attn_decode(
         raise ValueError(f"Q must be rank-2, got rank {q_f32.ndim}")
 
     num_q_heads = q_f32.shape[0]
-    expected_shape = (num_q_heads, spec.head_size)
-    if tuple(q_f32.shape) != expected_shape:
+    if q_f32.shape[1] != spec.head_size:
         raise ValueError(
-            f"Q shape {tuple(q_f32.shape)} does not match {expected_shape}"
+            f"Q head size {q_f32.shape[1]} does not match {spec.head_size}"
         )
     if num_q_heads <= 0:
         raise ValueError("Q must contain at least one query head")
@@ -294,7 +272,7 @@ def _paged_attn_decode(
             1,
             1,
         )
-    output_nbytes = total_elements * np.dtype(np.float32).itemsize
+    output_nbytes = total_elements * _F32_NBYTES
 
     results = ctx.execute_batch(
         [
@@ -314,6 +292,39 @@ def _paged_attn_decode(
     )
     output = np.frombuffer(results[0][0], dtype=np.float32).copy()
     return torch.from_numpy(output.reshape(num_q_heads, spec.head_size))
+
+
+def _require_shader(ctx: VulkanContext, shader_name: str) -> None:
+    if shader_name not in ctx.available_shaders():
+        raise RuntimeError(f"{shader_name} shader is not available")
+
+
+def _select_decode_shader(
+    ctx: VulkanContext, shader_name: str, coop_shader_name: str
+) -> str:
+    available_shaders = ctx.available_shaders()
+    if coop_shader_name in available_shaders:
+        return coop_shader_name
+    if shader_name in available_shaders:
+        return shader_name
+    raise RuntimeError(f"{shader_name} shader is not available")
+
+
+def _validate_cache_buffer(cache: GpuTensor, layout: VulkanPagedKVLayout) -> None:
+    if cache.nbytes < layout.total_bytes:
+        raise ValueError(
+            f"cache buffer has {cache.nbytes} bytes, "
+            f"expected at least {layout.total_bytes}"
+        )
+
+
+def _validate_layout_dtype(
+    actual_dtype_size: int, expected_dtype_size: int, shader_name: str
+) -> None:
+    if actual_dtype_size != expected_dtype_size:
+        raise ValueError(
+            f"{shader_name} requires a {expected_dtype_size}-byte KV-cache layout"
+        )
 
 
 def _paged_kv_write_pc(

--- a/vllm_vulkan/kv_ops.py
+++ b/vllm_vulkan/kv_ops.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Python-facing Vulkan paged KV-cache operations."""
+
+from __future__ import annotations
+
+import math
+import struct
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+
+from vllm_vulkan.kv_layout import VulkanPagedKVLayout
+
+if TYPE_CHECKING:
+    from vllm_vulkan._rs import GpuTensor, VulkanContext
+
+_PAGED_KV_WRITE_SHADER = "paged_kv_write_f32"
+_PAGED_ATTN_DECODE_SHADER = "paged_attn_decode_f32"
+_PAGED_KV_WRITE_F16_SHADER = "paged_kv_write_f16"
+_PAGED_ATTN_DECODE_F16_SHADER = "paged_attn_decode_f16"
+_PAGED_KV_WRITE_WORKGROUP_SIZE = 256
+_PAGED_ATTN_DECODE_WORKGROUP_SIZE = 256
+
+
+def paged_kv_write_f16(
+    ctx: VulkanContext,
+    layout: VulkanPagedKVLayout,
+    cache: GpuTensor,
+    layer_index: int,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    slot_mapping: torch.Tensor | list[int] | tuple[int, ...],
+) -> None:
+    """Write f16 K/V tensors into a paged Vulkan KV-cache buffer."""
+    _paged_kv_write(
+        ctx=ctx,
+        layout=layout,
+        cache=cache,
+        layer_index=layer_index,
+        k=k,
+        v=v,
+        slot_mapping=slot_mapping,
+        shader_name=_PAGED_KV_WRITE_F16_SHADER,
+        dtype=torch.float16,
+        dtype_size=2,
+    )
+
+
+def paged_kv_write_f32(
+    ctx: VulkanContext,
+    layout: VulkanPagedKVLayout,
+    cache: GpuTensor,
+    layer_index: int,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    slot_mapping: torch.Tensor | list[int] | tuple[int, ...],
+) -> None:
+    """Write f32 K/V tensors into a paged Vulkan KV-cache buffer.
+
+    Args:
+        ctx: Live Vulkan context.
+        layout: Paged KV layout contract.
+        cache: Persistent cache buffer allocated with at least
+            ``layout.total_bytes`` bytes.
+        layer_index: Layer whose K/V planes should be updated.
+        k: ``[num_tokens, num_kv_heads, head_size]`` float tensor.
+        v: ``[num_tokens, num_kv_heads, head_size]`` float tensor.
+        slot_mapping: vLLM slots, where
+            ``slot = physical_block_id * block_size + token_offset_in_block``.
+    """
+    _paged_kv_write(
+        ctx=ctx,
+        layout=layout,
+        cache=cache,
+        layer_index=layer_index,
+        k=k,
+        v=v,
+        slot_mapping=slot_mapping,
+        shader_name=_PAGED_KV_WRITE_SHADER,
+        dtype=torch.float32,
+        dtype_size=4,
+    )
+
+
+def _paged_kv_write(
+    ctx: VulkanContext,
+    layout: VulkanPagedKVLayout,
+    cache: GpuTensor,
+    layer_index: int,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    slot_mapping: torch.Tensor | list[int] | tuple[int, ...],
+    shader_name: str,
+    dtype: torch.dtype,
+    dtype_size: int,
+) -> None:
+    if shader_name not in ctx.available_shaders():
+        raise RuntimeError(f"{shader_name} shader is not available")
+
+    spec = layout.layer_spec(layer_index)
+    if spec.dtype_size != dtype_size:
+        raise ValueError(
+            f"{shader_name} requires a {dtype_size}-byte KV-cache layout"
+        )
+    if cache.nbytes < layout.total_bytes:
+        raise ValueError(
+            f"cache buffer has {cache.nbytes} bytes, "
+            f"expected at least {layout.total_bytes}"
+        )
+
+    k_cpu = k.detach().to(dtype=dtype, device="cpu").contiguous()
+    v_cpu = v.detach().to(dtype=dtype, device="cpu").contiguous()
+    if k_cpu.shape != v_cpu.shape:
+        raise ValueError(
+            f"K and V shapes must match, got {k_cpu.shape} and {v_cpu.shape}"
+        )
+    if k_cpu.ndim != 3:
+        raise ValueError(f"K/V must be rank-3, got rank {k_cpu.ndim}")
+
+    num_tokens = k_cpu.shape[0]
+    if num_tokens <= 0:
+        raise ValueError("K/V must contain at least one token")
+    expected_shape = (num_tokens, spec.num_kv_heads, spec.head_size)
+    if tuple(k_cpu.shape) != expected_shape:
+        raise ValueError(
+            f"K/V shape {tuple(k_cpu.shape)} does not match {expected_shape}"
+        )
+
+    slots = _slot_mapping_to_u32(
+        slot_mapping, num_tokens, layout.capacity_tokens_per_layer
+    )
+    pc = _paged_kv_write_pc(layout, spec.layer_index, num_tokens)
+    total_elements = num_tokens * spec.num_kv_heads * spec.head_size
+    workgroups = (
+        math.ceil(total_elements / _PAGED_KV_WRITE_WORKGROUP_SIZE),
+        1,
+        1,
+    )
+
+    ctx.execute_batch(
+        [
+            (
+                shader_name,
+                [
+                    _tensor_to_bytes(k_cpu),
+                    _tensor_to_bytes(v_cpu),
+                    slots.tobytes(),
+                    cache,
+                ],
+                [],
+                pc,
+                workgroups,
+                False,
+            )
+        ]
+    )
+
+
+def paged_attn_decode_f16(
+    ctx: VulkanContext,
+    layout: VulkanPagedKVLayout,
+    cache: GpuTensor,
+    layer_index: int,
+    q: torch.Tensor,
+    block_table: torch.Tensor | list[int] | tuple[int, ...],
+    seq_len: int,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Decode one sequence with f16 KV cache and f32 accumulation/output."""
+    return _paged_attn_decode(
+        ctx=ctx,
+        layout=layout,
+        cache=cache,
+        layer_index=layer_index,
+        q=q,
+        block_table=block_table,
+        seq_len=seq_len,
+        scale=scale,
+        shader_name=_PAGED_ATTN_DECODE_F16_SHADER,
+        dtype_size=2,
+    )
+
+
+def paged_attn_decode_f32(
+    ctx: VulkanContext,
+    layout: VulkanPagedKVLayout,
+    cache: GpuTensor,
+    layer_index: int,
+    q: torch.Tensor,
+    block_table: torch.Tensor | list[int] | tuple[int, ...],
+    seq_len: int,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Decode one sequence with f32 paged attention on Vulkan.
+
+    This is the first correctness-oriented paged attention primitive.  It
+    handles one query token and one sequence, reads K/V from the paged cache via
+    ``block_table``, and returns ``[num_q_heads, head_size]``.  Batched variable
+    length serving and optimized FlashAttention tiling are follow-up work.
+    """
+    return _paged_attn_decode(
+        ctx=ctx,
+        layout=layout,
+        cache=cache,
+        layer_index=layer_index,
+        q=q,
+        block_table=block_table,
+        seq_len=seq_len,
+        scale=scale,
+        shader_name=_PAGED_ATTN_DECODE_SHADER,
+        dtype_size=4,
+    )
+
+
+def _paged_attn_decode(
+    ctx: VulkanContext,
+    layout: VulkanPagedKVLayout,
+    cache: GpuTensor,
+    layer_index: int,
+    q: torch.Tensor,
+    block_table: torch.Tensor | list[int] | tuple[int, ...],
+    seq_len: int,
+    scale: float | None,
+    shader_name: str,
+    dtype_size: int,
+) -> torch.Tensor:
+    if shader_name not in ctx.available_shaders():
+        raise RuntimeError(f"{shader_name} shader is not available")
+
+    spec = layout.layer_spec(layer_index)
+    if spec.dtype_size != dtype_size:
+        raise ValueError(
+            f"{shader_name} requires a {dtype_size}-byte KV-cache layout"
+        )
+    if cache.nbytes < layout.total_bytes:
+        raise ValueError(
+            f"cache buffer has {cache.nbytes} bytes, "
+            f"expected at least {layout.total_bytes}"
+        )
+    if seq_len <= 0:
+        raise ValueError("seq_len must be > 0")
+    if seq_len > layout.capacity_tokens_per_layer:
+        raise ValueError(
+            f"seq_len {seq_len} exceeds capacity {layout.capacity_tokens_per_layer}"
+        )
+
+    q_f32 = q.detach().to(dtype=torch.float32, device="cpu").contiguous()
+    if q_f32.ndim != 2:
+        raise ValueError(f"Q must be rank-2, got rank {q_f32.ndim}")
+
+    num_q_heads = q_f32.shape[0]
+    expected_shape = (num_q_heads, spec.head_size)
+    if tuple(q_f32.shape) != expected_shape:
+        raise ValueError(
+            f"Q shape {tuple(q_f32.shape)} does not match {expected_shape}"
+        )
+    if num_q_heads <= 0:
+        raise ValueError("Q must contain at least one query head")
+    if num_q_heads % spec.num_kv_heads != 0:
+        raise ValueError(
+            f"num_q_heads {num_q_heads} must be divisible by "
+            f"num_kv_heads {spec.num_kv_heads}"
+        )
+
+    needed_blocks = math.ceil(seq_len / spec.block_size)
+    blocks = _block_table_to_u32(block_table, needed_blocks, layout.num_blocks)
+    pc = _paged_attn_decode_pc(
+        layout=layout,
+        layer_index=layer_index,
+        seq_len=seq_len,
+        num_q_heads=num_q_heads,
+        scale=scale if scale is not None else 1.0 / math.sqrt(spec.head_size),
+    )
+    total_elements = num_q_heads * spec.head_size
+    workgroups = (
+        math.ceil(total_elements / _PAGED_ATTN_DECODE_WORKGROUP_SIZE),
+        1,
+        1,
+    )
+    output_nbytes = total_elements * np.dtype(np.float32).itemsize
+
+    results = ctx.execute_batch(
+        [
+            (
+                shader_name,
+                [
+                    _tensor_to_bytes(q_f32),
+                    blocks.tobytes(),
+                    cache,
+                ],
+                [output_nbytes],
+                pc,
+                workgroups,
+                False,
+            )
+        ]
+    )
+    output = np.frombuffer(results[0][0], dtype=np.float32).copy()
+    return torch.from_numpy(output.reshape(num_q_heads, spec.head_size))
+
+
+def _paged_kv_write_pc(
+    layout: VulkanPagedKVLayout,
+    layer_index: int,
+    num_tokens: int,
+) -> bytes:
+    spec = layout.layer_spec(layer_index)
+    return struct.pack(
+        "<7I",
+        num_tokens,
+        spec.num_kv_heads,
+        spec.head_size,
+        spec.block_size,
+        layout.layer_base_offset(layer_index) // spec.dtype_size,
+        spec.plane_bytes_per_block // spec.dtype_size,
+        spec.bytes_per_block // spec.dtype_size,
+    )
+
+
+def _paged_attn_decode_pc(
+    layout: VulkanPagedKVLayout,
+    layer_index: int,
+    seq_len: int,
+    num_q_heads: int,
+    scale: float,
+) -> bytes:
+    spec = layout.layer_spec(layer_index)
+    return struct.pack(
+        "<8If",
+        seq_len,
+        num_q_heads,
+        spec.num_kv_heads,
+        spec.head_size,
+        spec.block_size,
+        layout.layer_base_offset(layer_index) // spec.dtype_size,
+        spec.plane_bytes_per_block // spec.dtype_size,
+        spec.bytes_per_block // spec.dtype_size,
+        scale,
+    )
+
+
+def _slot_mapping_to_u32(
+    slot_mapping: torch.Tensor | list[int] | tuple[int, ...],
+    num_tokens: int,
+    capacity_tokens: int,
+) -> np.ndarray:
+    if isinstance(slot_mapping, torch.Tensor):
+        slots = slot_mapping.detach().to(device="cpu", dtype=torch.int64).contiguous()
+        slot_values = slots.numpy()
+    else:
+        slot_values = np.asarray(slot_mapping, dtype=np.int64)
+
+    if slot_values.shape != (num_tokens,):
+        raise ValueError(
+            f"slot_mapping shape {slot_values.shape} does not match ({num_tokens},)"
+        )
+    if np.any(slot_values < 0):
+        raise ValueError("slot_mapping must not contain negative slots")
+    if np.any(slot_values >= capacity_tokens):
+        raise ValueError(
+            f"slot_mapping contains a slot outside capacity {capacity_tokens}"
+        )
+    return slot_values.astype(np.uint32, copy=False)
+
+
+def _block_table_to_u32(
+    block_table: torch.Tensor | list[int] | tuple[int, ...],
+    needed_blocks: int,
+    num_blocks: int,
+) -> np.ndarray:
+    if isinstance(block_table, torch.Tensor):
+        blocks = block_table.detach().to(device="cpu", dtype=torch.int64).contiguous()
+        block_values = blocks.numpy()
+    else:
+        block_values = np.asarray(block_table, dtype=np.int64)
+
+    if block_values.ndim != 1:
+        raise ValueError(f"block_table must be rank-1, got shape {block_values.shape}")
+    if block_values.shape[0] < needed_blocks:
+        raise ValueError(
+            f"block_table has {block_values.shape[0]} block(s), "
+            f"expected at least {needed_blocks}"
+        )
+    active_blocks = block_values[:needed_blocks]
+    if np.any(active_blocks < 0):
+        raise ValueError("block_table must not contain negative block ids")
+    if np.any(active_blocks >= num_blocks):
+        raise ValueError(
+            f"block_table contains a block id outside {num_blocks} block(s)"
+        )
+    return active_blocks.astype(np.uint32, copy=False)
+
+
+def _tensor_to_bytes(tensor: torch.Tensor) -> bytes:
+    return tensor.numpy().tobytes()

--- a/vllm_vulkan/model_runner.py
+++ b/vllm_vulkan/model_runner.py
@@ -15,10 +15,15 @@ import os
 import torch
 import torch.nn as nn
 
+from vllm_vulkan import envs
+
 logger = logging.getLogger(__name__)
 
-_USE_RUST_MODEL = os.environ.get("VLLM_VULKAN_RUST_MODEL", "1") == "1"
 _RUST_MODEL_SINGLETON = None  # lazy-initialised
+
+
+def _use_rust_model() -> bool:
+    return envs.VLLM_VULKAN_RUST_MODEL
 
 
 class VulkanWorker:
@@ -111,7 +116,7 @@ def _safe_init_device(self) -> None:
     set_random_seed(self.model_config.seed)
 
     # Model runner: use our Rust-native runner if enabled.
-    if _USE_RUST_MODEL:
+    if _use_rust_model():
         from vllm_vulkan.model_runner import _VulkanCPUModelRunner  # noqa: PLC0415
 
         self.model_runner = _VulkanCPUModelRunner(self.vllm_config, torch.device("cpu"))
@@ -143,7 +148,7 @@ class _VulkanCPUModelRunner:
         """Load PyTorch model, then load Rust VulkanModel and patch forward."""
         self._runner.load_model(**kwargs)
 
-        if not _USE_RUST_MODEL:
+        if not _use_rust_model():
             return
 
         try:

--- a/vllm_vulkan/platform.py
+++ b/vllm_vulkan/platform.py
@@ -21,6 +21,7 @@ import psutil
 import torch
 
 from vllm_vulkan.config import get_config
+from vllm_vulkan.kv_layout import infer_kv_layer_specs
 
 # vllm is an optional runtime dependency when using the plugin standalone
 # (e.g. running unit tests without a full vllm install).  Import the base
@@ -232,41 +233,17 @@ class VulkanPlatform(Platform):
                 cache_config.cpu_kvcache_space_bytes is not None
                 and model_config.max_model_len is not None
             ):
-                # Estimate KV cache bytes per token for this model.
-                # Each token needs (num_layers × num_kv_heads × head_dim × 2 × dtype_bytes)
-                # bytes for key + value.
+                # Estimate KV cache bytes per token using the same paged KV
+                # layout contract that Vulkan attention kernels will consume.
                 try:
-                    text_cfg = (
-                        getattr(model_config.hf_config, "text_config", None)
-                        or model_config.hf_config
+                    specs = infer_kv_layer_specs(
+                        model_config.hf_config,
+                        block_size=cache_config.block_size or config.block_size,
+                        dtype=model_config.dtype,
                     )
-                    num_layers = getattr(text_cfg, "num_hidden_layers", None) or 60
-                    num_kv_heads = getattr(text_cfg, "num_key_value_heads", None) or 16
-                    head_dim = getattr(text_cfg, "head_dim", None) or 256
-                    # bfloat16 = 2 bytes
-                    dtype_bytes = (
-                        2 if model_config.dtype in ("bfloat16", "float16") else 4
+                    bytes_per_token = sum(
+                        spec.bytes_per_token for spec in specs
                     )
-                    bytes_per_token = (
-                        num_layers * num_kv_heads * head_dim * 2 * dtype_bytes
-                    )
-                    # Also account for global heads if heterogeneous
-                    global_head_dim = getattr(text_cfg, "global_head_dim", None)
-                    num_global_kv_heads = getattr(
-                        text_cfg, "num_global_key_value_heads", None
-                    )
-                    layer_types = getattr(text_cfg, "layer_types", None)
-                    if global_head_dim and num_global_kv_heads and layer_types:
-                        n_sliding = sum(1 for lt in layer_types if "sliding" in lt)
-                        n_full = sum(1 for lt in layer_types if "full" in lt)
-                        bytes_per_token = (
-                            n_sliding * num_kv_heads * head_dim * 2 * dtype_bytes
-                            + n_full
-                            * num_global_kv_heads
-                            * global_head_dim
-                            * 2
-                            * dtype_bytes
-                        )
                     max_tokens_in_kv = int(
                         cache_config.cpu_kvcache_space_bytes / bytes_per_token
                     )

--- a/vllm_vulkan/platform.py
+++ b/vllm_vulkan/platform.py
@@ -318,7 +318,7 @@ class VulkanPlatform(Platform):
             raise NotImplementedError("MLA attention is not supported on Vulkan.")
         if attn_selector_config.use_sparse:
             raise NotImplementedError("Sparse attention is not supported on Vulkan.")
-        return AttentionBackendEnum.CPU_ATTN.get_path()
+        return "vllm_vulkan.attention.VulkanAttentionBackend"
 
     @classmethod
     def _vllm_c_available(cls) -> bool:

--- a/vllm_vulkan/platform.py
+++ b/vllm_vulkan/platform.py
@@ -241,9 +241,7 @@ class VulkanPlatform(Platform):
                         block_size=cache_config.block_size or config.block_size,
                         dtype=model_config.dtype,
                     )
-                    bytes_per_token = sum(
-                        spec.bytes_per_token for spec in specs
-                    )
+                    bytes_per_token = sum(spec.bytes_per_token for spec in specs)
                     max_tokens_in_kv = int(
                         cache_config.cpu_kvcache_space_bytes / bytes_per_token
                     )


### PR DESCRIPTION
Adds the first Vulkan-backed attention path for decode.

## Summary

For now it keeps vLLM's CPU attention metadata and CPU KV cache as the source of truth, then mirrors supported K/V updates into a Vulkan paged KV cache. For safe single-token decoder steps, it dispatches Vulkan paged decode attention. Unsupported cases continue to fall back to vLLM's CPU attention path.

Includes:
- Vulkan paged KV layout helpers
- f16/f32 paged KV write and decode wrappers
- f16/f32 GLSL shaders for KV write and correctness-first decode attention
- platform/model-runner wiring for the backend
- tests for KV layout, KV write, decode correctness, and prefill-then-decode behavior
- debug logging when Vulkan decode attention is used

This is not a full production FlashAttention implementation yet, the focus here on the correctness first and since it's only at the start it doesn't make sense to keep large PRs for long periods of time as to me.

## Testing

Unit testing and manual testing.