### PR TITLE
Update vLLM KV cache memory config field

### DIFF
--- a/tests/python/test_platform.py
+++ b/tests/python/test_platform.py
@@ -2,6 +2,7 @@
 """Tests for VulkanPlatform."""
 
 import platform as py_platform
+from types import SimpleNamespace
 
 import pytest
 
@@ -84,3 +85,36 @@ def test_register_returns_class_path_or_none():
 
     result = vllm_vulkan._register()
     assert result is None or result == "vllm_vulkan.platform.VulkanPlatform"
+
+
+def test_check_and_update_config_sets_kv_cache_memory_bytes(monkeypatch):
+    monkeypatch.setenv("VLLM_CPU_KVCACHE_SPACE", "5")
+    monkeypatch.setenv("VLLM_VULKAN_ALLOW_COMPILE", "1")
+
+    cache_config = SimpleNamespace(
+        block_size=None,
+        kv_cache_memory_bytes=None,
+    )
+    parallel_config = SimpleNamespace(
+        worker_cls="auto",
+        distributed_executor_backend="auto",
+        disable_custom_all_reduce=False,
+    )
+    scheduler_config = SimpleNamespace(async_scheduling=True)
+    compilation_config = SimpleNamespace(mode=None)
+    vllm_config = SimpleNamespace(
+        parallel_config=parallel_config,
+        cache_config=cache_config,
+        model_config=None,
+        scheduler_config=scheduler_config,
+        compilation_config=compilation_config,
+    )
+
+    VulkanPlatform.check_and_update_config(vllm_config)
+
+    assert cache_config.kv_cache_memory_bytes == 5 * 1024**3
+    assert cache_config.block_size == 16
+    assert parallel_config.worker_cls == "vllm_vulkan.worker.VulkanWorker"
+    assert parallel_config.distributed_executor_backend == "uni"
+    assert parallel_config.disable_custom_all_reduce is True
+    assert scheduler_config.async_scheduling is False

--- a/vllm_vulkan/platform.py
+++ b/vllm_vulkan/platform.py
@@ -195,16 +195,16 @@ class VulkanPlatform(Platform):
         # We reserve memory for:
         #   - Model weights in PyTorch (fp16/bf16):  ~model_params * 2 bytes
         #   - Vulkan weight copies (fp32):            ~model_params * 4 bytes
-        #   - OS + Python runtime overhead:           ~4 GB
+        #   - OS + Python runtime overhead:           ~4 GiB
         # KV cache gets the remainder × safety_fraction.
         if cache_config.kv_cache_memory_bytes is None:
             kv_env = os.environ.get("VLLM_CPU_KVCACHE_SPACE")
             if kv_env is not None:
-                kv_gb = float(kv_env)
+                kv_gib = float(kv_env)
             else:
                 import psutil as _psutil  # noqa: PLC0415
 
-                total_ram_gb = _psutil.virtual_memory().total / (1024**3)
+                total_ram_gib = _psutil.virtual_memory().total / (1024**3)
 
                 # Estimate model weight memory:
                 # bf16 weights (already loaded) + float32 Vulkan copies
@@ -213,14 +213,14 @@ class VulkanPlatform(Platform):
                     for p in getattr(vllm_config, "model_config", None) and [] or []
                 )
                 # Rough estimate: 6 bytes/param (2 bf16 + 4 f32)
-                # For E2B ~2B params: 12 GB; for 31B: ~186 GB
+                # For E2B ~2B params: 12 GiB; for 31B: ~186 GiB
                 # Use a conservative 35% of total RAM for KV cache
-                # Reserve memory for: PyTorch weights (~4GB), Vulkan weight
-                # copies (~10GB), OS (~4GB). KV cache gets the rest up to cap.
-                # 115GB total - 4 - 10 - 4 = ~97GB, but use conservative 8GB
-                kv_gb = max(4.0, min(total_ram_gb * 0.07, 8.0))  # cap at 8 GB
-            cache_config.kv_cache_memory_bytes = int(kv_gb * 1024**3)
-            logger.info("Vulkan/CPU KV cache space: %.1f GB", kv_gb)
+                # Reserve memory for: PyTorch weights (~4 GiB), Vulkan weight
+                # copies (~10 GiB), OS (~4 GiB). KV cache gets the rest up to cap.
+                # 115 GiB total - 4 - 10 - 4 = ~97 GiB, but use conservative 8 GiB
+                kv_gib = max(4.0, min(total_ram_gib * 0.07, 8.0))  # cap at 8 GiB
+            cache_config.kv_cache_memory_bytes = int(kv_gib * 1024**3)
+            logger.info("Vulkan/CPU KV cache space: %.1f GiB", kv_gib)
 
         if model_config is not None:
             model_config.disable_cascade_attn = True
@@ -253,10 +253,10 @@ class VulkanPlatform(Platform):
                         if safe_max > 0 and safe_max < model_config.max_model_len:
                             logger.info(
                                 "Vulkan/CPU: capping max_model_len from %d to %d "
-                                "based on %.1f GB KV cache budget.",
+                                "based on %.1f GiB KV cache budget.",
                                 model_config.max_model_len,
                                 safe_max,
-                                cache_config.kv_cache_memory_bytes / 1e9,
+                                cache_config.kv_cache_memory_bytes / 1024**3,
                             )
                             model_config.max_model_len = safe_max
                 except Exception as exc:

--- a/vllm_vulkan/platform.py
+++ b/vllm_vulkan/platform.py
@@ -191,13 +191,13 @@ class VulkanPlatform(Platform):
         ):
             cache_config.block_size = config.block_size
 
-        # CPU KV cache space (required by CPUWorker).
+        # KV cache memory budget (required by CPUWorker).
         # We reserve memory for:
         #   - Model weights in PyTorch (fp16/bf16):  ~model_params * 2 bytes
         #   - Vulkan weight copies (fp32):            ~model_params * 4 bytes
         #   - OS + Python runtime overhead:           ~4 GB
         # KV cache gets the remainder × safety_fraction.
-        if cache_config.cpu_kvcache_space_bytes is None:
+        if cache_config.kv_cache_memory_bytes is None:
             kv_env = os.environ.get("VLLM_CPU_KVCACHE_SPACE")
             if kv_env is not None:
                 kv_gb = float(kv_env)
@@ -219,7 +219,7 @@ class VulkanPlatform(Platform):
                 # copies (~10GB), OS (~4GB). KV cache gets the rest up to cap.
                 # 115GB total - 4 - 10 - 4 = ~97GB, but use conservative 8GB
                 kv_gb = max(4.0, min(total_ram_gb * 0.07, 8.0))  # cap at 8 GB
-            cache_config.cpu_kvcache_space_bytes = int(kv_gb * 1024**3)
+            cache_config.kv_cache_memory_bytes = int(kv_gb * 1024**3)
             logger.info("Vulkan/CPU KV cache space: %.1f GB", kv_gb)
 
         if model_config is not None:
@@ -230,7 +230,7 @@ class VulkanPlatform(Platform):
             # "220 GiB KV cache needed" error on machines with limited RAM.
             # Users can always pass --max-model-len explicitly to override.
             if (
-                cache_config.cpu_kvcache_space_bytes is not None
+                cache_config.kv_cache_memory_bytes is not None
                 and model_config.max_model_len is not None
             ):
                 # Estimate KV cache bytes per token using the same paged KV
@@ -243,7 +243,7 @@ class VulkanPlatform(Platform):
                     )
                     bytes_per_token = sum(spec.bytes_per_token for spec in specs)
                     max_tokens_in_kv = int(
-                        cache_config.cpu_kvcache_space_bytes / bytes_per_token
+                        cache_config.kv_cache_memory_bytes / bytes_per_token
                     )
                     if max_tokens_in_kv < model_config.max_model_len:
                         # Leave 20% headroom and cap at a multiple of block_size
@@ -256,7 +256,7 @@ class VulkanPlatform(Platform):
                                 "based on %.1f GB KV cache budget.",
                                 model_config.max_model_len,
                                 safe_max,
-                                cache_config.cpu_kvcache_space_bytes / 1e9,
+                                cache_config.kv_cache_memory_bytes / 1e9,
                             )
                             model_config.max_model_len = safe_max
                 except Exception as exc:


### PR DESCRIPTION
vLLM 0.20.1 uses `kv_cache_memory_bytes` on `CacheConfig`; `cpu_kvcache_space_bytes` no longer exists. This updates the Vulkan platform config path to use the current field name when setting and reading the KV cache memory budget.
Fixes #12.