### PR TITLE
fix: apply tensor-parallel collectives in the Vulkan linear hook

### DIFF
--- a/vllm_vulkan/model_runner.py
+++ b/vllm_vulkan/model_runner.py
@@ -402,23 +402,29 @@ def _wrap_linear(module: nn.Module) -> None:
         try:
             result = vulkan_ops.linear(x.float(), weight.float(), matmul_bias)
             result = result.to(x.dtype)
-            if row_reduce:
-                from vllm.distributed import (  # noqa: PLC0415
-                    tensor_model_parallel_all_reduce,
-                )
-
-                result = tensor_model_parallel_all_reduce(result)
-                if bias is not None and not skip_bias:
-                    result = result + bias
-            elif getattr(module, "gather_output", False) and tp_size > 1:
-                from vllm.distributed import (  # noqa: PLC0415
-                    tensor_model_parallel_all_gather,
-                )
-
-                result = tensor_model_parallel_all_gather(result)
         except Exception as exc:
             logger.debug("Vulkan linear failed (%s)", exc)
             return orig(x, *args, **kwargs)
+
+        # Collectives run outside the try/except, and only on the success path. A
+        # rank whose matmul failed has already returned orig(), which runs the
+        # same collective, so every rank performs exactly one collective and stays
+        # in lockstep. Catching a collective here and re-running it via orig()
+        # would issue it twice on that rank and deadlock the group.
+        if row_reduce:
+            from vllm.distributed import (  # noqa: PLC0415
+                tensor_model_parallel_all_reduce,
+            )
+
+            result = tensor_model_parallel_all_reduce(result)
+            if bias is not None and not skip_bias:
+                result = result + bias
+        elif getattr(module, "gather_output", False) and tp_size > 1:
+            from vllm.distributed import (  # noqa: PLC0415
+                tensor_model_parallel_all_gather,
+            )
+
+            result = tensor_model_parallel_all_gather(result)
 
         if _returns_tuple:
             output_bias = module.bias if skip_bias else None

--- a/vllm_vulkan/model_runner.py
+++ b/vllm_vulkan/model_runner.py
@@ -391,17 +391,37 @@ def _wrap_linear(module: nn.Module) -> None:
             return orig(x, *args, **kwargs)
 
         bias = getattr(module, "bias", None)
+        skip_bias = getattr(module, "skip_bias_add", False)
+        tp_size = getattr(module, "tp_size", 1)
+        # RowParallelLinear sums partial results across tensor-parallel ranks and
+        # applies bias after the reduction, not inside the (sharded) matmul. The
+        # bare matmul below produces only this rank's partial sum, so without the
+        # all-reduce the model emits garbage under tensor parallelism.
+        row_reduce = getattr(module, "reduce_results", False) and tp_size > 1
+        matmul_bias = None if (row_reduce or skip_bias) else bias
         try:
-            result = vulkan_ops.linear(x.float(), weight.float(), bias)
+            result = vulkan_ops.linear(x.float(), weight.float(), matmul_bias)
             result = result.to(x.dtype)
+            if row_reduce:
+                from vllm.distributed import (  # noqa: PLC0415
+                    tensor_model_parallel_all_reduce,
+                )
+
+                result = tensor_model_parallel_all_reduce(result)
+                if bias is not None and not skip_bias:
+                    result = result + bias
+            elif getattr(module, "gather_output", False) and tp_size > 1:
+                from vllm.distributed import (  # noqa: PLC0415
+                    tensor_model_parallel_all_gather,
+                )
+
+                result = tensor_model_parallel_all_gather(result)
         except Exception as exc:
             logger.debug("Vulkan linear failed (%s)", exc)
             return orig(x, *args, **kwargs)
 
         if _returns_tuple:
-            output_bias = (
-                module.bias if getattr(module, "skip_bias_add", False) else None
-            )
+            output_bias = module.bias if skip_bias else None
             return result, output_bias
         return result
 


### PR DESCRIPTION
## Problem

Under tensor parallelism, generation is garbage. The model loads and runs, but
every token is wrong.

`_wrap_linear` swaps a Linear module's `forward` for a bare Vulkan matmul on the
module's (sharded) weight. For a plain Linear that's fine, but vLLM's
parallel Linear layers do more than a matmul:

- **RowParallelLinear** shards the input dim, so each rank computes a *partial*
  sum and the layer finishes with `tensor_model_parallel_all_reduce`. It also
  defers bias to *after* the reduction (bias must be added once, not folded into
  every shard).
- **ColumnParallelLinear** with `gather_output=True` finishes with an all-gather.

The hook dropped these collectives, so a RowParallelLinear returned only this
rank's partial result (with bias added on every shard) - hence garbage as soon
as `tensor_parallel_size > 1`.

## Fix

Mirror the original layer after the Vulkan matmul:

- `reduce_results and tp_size > 1` -> all-reduce, then add bias post-reduction.
- `gather_output and tp_size > 1` -> all-gather.
- Single-GPU (`tp_size == 1`) and `gather_output=False` paths are unchanged, so
  there's no behavior change off tensor parallelism.

Bias is kept out of the sharded matmul for the row-parallel/skip-bias cases and
applied where the original layer applies it.

## Verification

`tensor-parallel-size=2` across two AMD GPUs on separate nodes (RX 7900 XTX /
gfx1100 and RX 6900 XT / gfx1030), Qwen2.5-0.5B:

```
before: "The capital of France is" -> "ẫ-isc-e淘Jpestere,施cathhe De"
after:  "The capital of France is" -> " A. Paris B. London C. Moscow"
        "2 + 2 ="                  -> " 4"
        "The opposite of hot is"   -> " A. Cold B. Warm"
```
