### PR TITLE
feat: enable the ray distributed executor (multi-GPU / multi-node)

### DIFF
--- a/vllm_vulkan/platform.py
+++ b/vllm_vulkan/platform.py
@@ -68,6 +68,10 @@ class VulkanPlatform(Platform):
     device_name: str = "cpu"
     device_type: str = "cpu"
     dispatch_key: str = "CPU"
+    # Vulkan is a GPU backend (compute offloaded to the device) even though
+    # device_type is "cpu"; advertise GPU placement so vLLM's ray distributed
+    # executor will schedule workers (it rejects platforms with no ray_device_key).
+    ray_device_key: str = "GPU"
 
     # ─── Device queries ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

The plugin can only run single-node. Asking for the ray executor
(`--distributed-executor-backend ray`, which is also what vLLM auto-selects for
TP across nodes) fails immediately:

```
ValueError: current platform cpu does not support ray.
```

vLLM's `ray_utils` rejects any platform whose `ray_device_key` is empty, and the
base `Platform` (and therefore a `device_type="cpu"` platform) defaults it to `""`.

## Fix

Set `ray_device_key = "GPU"` on `VulkanPlatform`, exactly as `cuda`, `rocm`, and
`xpu` do. The plugin is a GPU backend — compute is offloaded to the Vulkan
device — so advertising GPU placement is correct even though `device_type` stays
`"cpu"` (the worker rides vLLM's CPU worker path).

That single attribute is all the ray path needs:

- Per-worker device selection already goes through `VLLM_VULKAN_DEVICE_INDEX` /
  `local_rank`, not `device_control_env_var`, so the latter is left at its base
  default.

## Verification

Single-node TP=1 over the ray executor (`--distributed-executor-backend ray`):
serves and generates correctly ("The capital of France is ... Paris ..."). With
the attribute reverted, the same command raises "does not support ray".
