### PR TITLE
fix: avoid broken subgroup-reduce matvec shaders on KosmicKrisp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1078,7 +1078,7 @@ impl VulkanModel {
                 let cb = eng.begin_batch().unwrap();
                 let inp_ref = inp_p as *const compute::Buffer;
                 unsafe {
-                    eng.record_to(cb, "mul_mat_vec_f32_f32_f32_subgroup",
+                    eng.record_to(cb, "mul_mat_vec_f32_f32_f32",
                         &[&*lm_w_ptr, &*inp_ref, &*logit_p],
                         &pc, (vocab as u32, 1, 1)).unwrap();
                 }
@@ -1153,7 +1153,7 @@ impl VulkanModel {
         let x = model::cpu_rms_norm(hidden, &inln_w, eps);
 
         let xb = f32_slice_to_bytes(&x);
-        let shader = "mul_mat_vec_f16_f32_f32_subgroup";
+        let shader = "mul_mat_vec_f16_f32_f32";
 
         // Init persistent activation buffers on first call.
         let use_gpu = self.engine.is_some()
@@ -1491,7 +1491,7 @@ impl VulkanModel {
             let out_p = &out as *const compute::Buffer;
             let cb = eng.begin_batch().unwrap();
             unsafe {
-                eng.record_to(cb, "mul_mat_vec_f16_f32_f32_subgroup",
+                eng.record_to(cb, "mul_mat_vec_f16_f32_f32",
                     &[&*w_ptr, &*inp_p, &*out_p], pc, (n as u32, t as u32, 1)).unwrap();
             }
             eng.submit_batch(cb).unwrap();
@@ -1524,7 +1524,7 @@ impl VulkanModel {
             let out2_p = &out2 as *const compute::Buffer;
             let cb = eng.begin_batch().unwrap();
             unsafe {
-                let sh = "mul_mat_vec_f16_f32_f32_subgroup";
+                let sh = "mul_mat_vec_f16_f32_f32";
                 eng.record_to(cb, sh, &[&*w1_ptr, &*inp_p, &*out1_p], pc, (n as u32, t as u32, 1)).unwrap();
                 eng.record_barrier_to(cb);
                 eng.record_to(cb, sh, &[&*w2_ptr, &*inp_p, &*out2_p], pc, (n as u32, t as u32, 1)).unwrap();

--- a/vllm_vulkan/server.py
+++ b/vllm_vulkan/server.py
@@ -20,6 +20,7 @@ import logging
 import os
 import time
 import uuid
+from pathlib import Path
 
 from transformers import AutoTokenizer
 
@@ -268,6 +269,22 @@ def main():
     # Load the model.
     logger.info("Loading tokenizer for %s...", args.model)
     tokenizer = AutoTokenizer.from_pretrained(args.model)
+
+    if getattr(tokenizer, "chat_template", None) is None:
+        # Base models (e.g. google/gemma-4-E2B) ship without a chat template.
+        # Fall back to the packaged instruction-tuned template so that
+        # /v1/chat/completions still works.
+        template_path = Path(__file__).parent / "template_gemma4.jinja"
+        if not template_path.exists():
+            raise FileNotFoundError(
+                f"Tokenizer has no chat template, and the fallback template "
+                f"was not found at {template_path}. Chat completions will fail."
+            )
+        logger.info(
+            "Tokenizer has no chat template; using packaged fallback from %s",
+            template_path,
+        )
+        tokenizer.chat_template = template_path.read_text(encoding="utf-8")
 
     logger.info("Finding safetensors file...")
     st_path = find_safetensors(args.model)


### PR DESCRIPTION
## Summary

Running `google/gemma-4-E2B` end-to-end via vllm-vulkan on macOS with KosmicKrisp produced complete gibberish output from the GPU decode path, even though the model loaded successfully and reported `GPU=True`.

## Root cause

`VulkanModel::forward_gpu` / `forward_layer_gpu_matmuls` dispatch the `_subgroup` variants of the `mul_mat_vec` compute shaders (`mul_mat_vec_f16_f32_f32_subgroup`, `mul_mat_vec_f32_f32_f32_subgroup`), which reduce partial dot-product sums via `subgroupAdd`. On KosmicKrisp (Mesa's Vulkan-on-Metal driver used on macOS), these variants return numerically wrong results once K reaches the sizes used by real model weights (e.g. K=1536), while the plain shared-memory-reduction variants (`mul_mat_vec_f16_f32_f32` / `mul_mat_vec_f32_f32_f32`) produce correct output.

### How this was diagnosed
1. Confirmed the project's own CPU reference implementation (`Gemma4Model::forward`) produces coherent generations ("The capital of France is" → " Paris.").
2. Added temporary debug hooks to compare GPU vs. CPU hidden states layer-by-layer — divergence started at layer 0's very first matvec (Q projection), before any norm/RoPE/attention logic even ran.
3. Wrote a synthetic matvec test (arbitrary weight/input data, bypassing model weights and all Gemma4-specific logic) and swept K — the `_subgroup` shader gave systematically wrong (and suspiciously K-independent) results for K ≳ 1024, while the non-subgroup variant matched the CPU reference to float precision for the same K/N/dtype combinations.

This points to a `subgroupAdd`/`GL_KHR_shader_subgroup_arithmetic` correctness bug in KosmicKrisp's young NIR→Metal compute backend, not a bug in this project's math.

## Fix

Swap every real matvec dispatch (QKV, o_proj, gate/up/down, LM head) from the `_subgroup` shader names to the plain shared-memory-reduction shader names. No shader source changes — both variants already existed and are compiled by `compile_shaders.sh`, only the runtime shader selection changes.

Verified GPU vs. CPU hidden states now agree to ~1e-5 across all 35 decoder layers, and end-to-end generation is coherent:
- "The capital of France is" → " Paris."
- "The largest planet in our solar system is" → " Jupiter."
- "2 + 2 =" → " 4."

Throughput is unaffected (~13-14 tok/s on Apple M4 Max via KosmicKrisp).

Also fixed `vllm_vulkan/server.py` to fall back to the packaged `template_gemma4.jinja` chat template when the tokenizer doesn't ship one (base models like `google/gemma-4-E2B` have no `chat_template`), matching the fallback already applied for the full vLLM integration path in `patches.py`. Without this, `python -m vllm_vulkan.server` would raise on `/v1/chat/completions` for base models. Per review feedback, this now fails fast at startup with a clear error if the fallback template file is missing (instead of failing later on the first request), and reads the template file with explicit UTF-8 encoding.

## Testing

- `pytest -m "not slow" tests/python/` — 44 passed.
- Manual layer-by-layer GPU/CPU hidden-state comparison across all 35 layers (diff ~1e-5, down from complete divergence).
- Manual end-to-end generation via `VulkanModel` directly and via `python -m vllm_vulkan.server` `/v1/chat/completions`, both on Apple Silicon with KosmicKrisp.