### PR TITLE
perf: tune the Vulkan decode engine for KosmicKrisp, remove a dead duplicate model load

### DIFF
--- a/scripts/bench_vulkan_model.py
+++ b/scripts/bench_vulkan_model.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Tokens/sec benchmark for the Rust VulkanModel decode path.
+
+Loads the safetensors checkpoint for a local HF model (e.g.
+``google/gemma-4-E2B``) directly into ``vllm_vulkan._rs.VulkanModel`` and
+drives greedy autoregressive decoding, bypassing vLLM's scheduler entirely.
+This isolates the GPU compute engine (KosmicKrisp / Vulkan) so its raw
+tokens/sec can be measured and compared across optimizations without noise
+from unrelated vLLM engine-orchestration overhead.
+
+Usage:
+    python scripts/bench_vulkan_model.py \
+        --model google/gemma-4-E2B \
+        --prompt "The capital of France is" \
+        --max-new-tokens 64
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import time
+
+import huggingface_hub
+
+
+def find_safetensors(model: str) -> str:
+    local_dir = huggingface_hub.snapshot_download(
+        model, local_files_only=True, ignore_patterns=["*.bin", "*.gguf"]
+    )
+    files = sorted(glob.glob(f"{local_dir}/*.safetensors"))
+    if not files:
+        raise SystemExit(
+            f"No safetensors file found for {model} (looked in {local_dir})"
+        )
+    return files[0]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="google/gemma-4-E2B")
+    ap.add_argument("--prompt", default="The capital of France is")
+    ap.add_argument("--max-new-tokens", type=int, default=64)
+    ap.add_argument("--max-seq-len", type=int, default=512)
+    ap.add_argument("--device-idx", type=int, default=0)
+    ap.add_argument(
+        "--repeat", type=int, default=1, help="repeat the decode loop N times"
+    )
+    args = ap.parse_args()
+
+    from transformers import AutoTokenizer
+    from vllm_vulkan._rs import VulkanModel, is_available
+
+    if not is_available():
+        raise SystemExit("Vulkan is not available on this system.")
+
+    st_path = find_safetensors(args.model)
+    print(f"Loading weights from {st_path}")
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    prompt_ids = tokenizer.encode(args.prompt)
+
+    t0 = time.perf_counter()
+    model = VulkanModel(
+        st_path, max_seq_len=args.max_seq_len, device_idx=args.device_idx
+    )
+    load_s = time.perf_counter() - t0
+    print(
+        f"Model load: {load_s:.2f}s, GPU={model.has_gpu()}, layers={model.num_layers()}"
+    )
+
+    all_prefill = []
+    all_decode = []
+    text_out = ""
+
+    for _rep in range(args.repeat):
+        model.reset_kv_cache()
+
+        # ── Prefill: feed prompt tokens one at a time (API is per-token). ──
+        t0 = time.perf_counter()
+        logits = None
+        for pos, tok in enumerate(prompt_ids):
+            logits = model.forward(tok, pos)
+        prefill_s = time.perf_counter() - t0
+        all_prefill.append(prefill_s)
+
+        # ── Decode: greedy sampling for max_new_tokens steps. ──
+        generated = []
+        pos = len(prompt_ids)
+        next_tok = max(range(len(logits)), key=lambda i: logits[i])
+        generated.append(next_tok)
+
+        t0 = time.perf_counter()
+        for _step in range(args.max_new_tokens - 1):
+            logits = model.forward(next_tok, pos)
+            pos += 1
+            next_tok = max(range(len(logits)), key=lambda i: logits[i])
+            generated.append(next_tok)
+        decode_s = time.perf_counter() - t0
+        all_decode.append(decode_s)
+
+        text_out = tokenizer.decode(generated)
+
+    n_decode_tokens = args.max_new_tokens - 1
+    best_decode = min(all_decode)
+    tok_per_s = n_decode_tokens / best_decode if best_decode > 0 else float("inf")
+    all_tok_s = sorted(n_decode_tokens / d for d in all_decode)
+    median_tok_s = all_tok_s[len(all_tok_s) // 2]
+
+    print()
+    print(f"Prompt:     {args.prompt!r}")
+    print(f"Generated:  {text_out!r}")
+    print()
+    print(
+        f"Prefill:    {len(prompt_ids)} tokens in {min(all_prefill):.4f}s "
+        f"({len(prompt_ids) / min(all_prefill):.2f} tok/s)"
+    )
+    print(
+        f"Decode:     {n_decode_tokens} tokens in {best_decode:.4f}s "
+        f"({tok_per_s:.2f} tok/s)  [best of {args.repeat}]"
+    )
+    print(
+        f"Decode all-runs tok/s: {[round(v, 2) for v in all_tok_s]}  median={median_tok_s:.2f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_vulkan_ops.py
+++ b/scripts/bench_vulkan_ops.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Micro-benchmark for the Python-facing ``vulkan_ops`` dispatch path.
+
+This exercises the exact same ``VulkanContext`` / ``ComputeEngine`` (Rust)
+used by ``model_runner.py``'s per-module hook path (``VLLM_VULKAN_RUST_MODEL=0``,
+and as a fallback within the default mode too) — i.e. the code that fires on
+every ``nn.Linear`` / ``RMSNorm`` call during vLLM decode. It isolates the
+Rust dispatch engine from vLLM's scheduler/KV-cache so the effect of engine
+level changes (e.g. command-buffer reuse) can be measured directly against
+representative google/gemma-4-E2B tensor shapes, without needing a full vLLM
+server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import torch
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--hidden", type=int, default=1536, help="gemma-4-E2B hidden_size")
+    ap.add_argument(
+        "--out-features", type=int, default=2048, help="e.g. q_proj out dim"
+    )
+    ap.add_argument("--iters", type=int, default=500)
+    ap.add_argument("--warmup", type=int, default=20)
+    ap.add_argument("--device-idx", type=int, default=0)
+    args = ap.parse_args()
+
+    from vllm_vulkan._rs import VulkanContext, is_available
+
+    from vllm_vulkan import vulkan_ops
+
+    if not is_available():
+        raise SystemExit("Vulkan is not available on this system.")
+
+    ctx = VulkanContext(args.device_idx)
+    vulkan_ops.set_context(ctx)
+    if not vulkan_ops.is_ready():
+        raise SystemExit("Vulkan context not ready (software renderer detected?).")
+
+    torch.manual_seed(0)
+    x = torch.randn(1, args.hidden, dtype=torch.float32)
+    w = torch.randn(args.out_features, args.hidden, dtype=torch.float32)
+
+    for _ in range(args.warmup):
+        vulkan_ops.linear(x, w)
+
+    t0 = time.perf_counter()
+    for _ in range(args.iters):
+        vulkan_ops.linear(x, w)
+    dt = time.perf_counter() - t0
+
+    per_call_us = dt / args.iters * 1e6
+    print(
+        f"vulkan_ops.linear: [1,{args.hidden}] x [{args.out_features},{args.hidden}]^T"
+    )
+    print(
+        f"{args.iters} calls in {dt:.4f}s  ->  {per_call_us:.1f}us/call  "
+        f"({args.iters / dt:.1f} calls/s)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -258,6 +258,17 @@ pub struct ComputeEngine {
     pipeline_cache: PipelineCache,
 
     command_pool: vk::CommandPool,
+    /// Single persistent command buffer, reused for every dispatch/batch via
+    /// reset + begin instead of allocating (and freeing) a fresh command
+    /// buffer from the pool on every call. vkAllocateCommandBuffers /
+    /// vkFreeCommandBuffers involve driver bookkeeping on every call — on a
+    /// translation layer such as KosmicKrisp (Vulkan-on-Metal) that cost is
+    /// paid per decode-step dispatch, so reusing one command buffer removes
+    /// it from the hot path entirely. Only one command buffer is ever in
+    /// flight at a time (dispatches are fully synchronous, see
+    /// `end_and_submit`), so a single persistent buffer is always safe to
+    /// reset here.
+    cmd_buf: vk::CommandBuffer,
     fence: vk::Fence,
 
     descriptor_pools: Vec<vk::DescriptorPool>,
@@ -289,6 +300,13 @@ impl ComputeEngine {
         let command_pool = unsafe { device.create_command_pool(&cmd_pool_ci, None) }
             .map_err(|e| format!("create_command_pool: {e}"))?;
 
+        let cmd_buf_alloc = vk::CommandBufferAllocateInfo::default()
+            .command_pool(command_pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(1);
+        let cmd_buf = unsafe { device.allocate_command_buffers(&cmd_buf_alloc) }
+            .map_err(|e| format!("allocate_command_buffers: {e}"))?[0];
+
         let fence_ci = vk::FenceCreateInfo::default();
         let fence = unsafe { device.create_fence(&fence_ci, None) }
             .map_err(|e| format!("create_fence: {e}"))?;
@@ -301,6 +319,7 @@ impl ComputeEngine {
             compute_queue_family,
             pipeline_cache,
             command_pool,
+            cmd_buf,
             fence,
             descriptor_pools: Vec::new(),
             descriptor_sets: Vec::new(),
@@ -424,20 +443,22 @@ impl ComputeEngine {
         Ok(())
     }
 
+    /// Reset and begin the single persistent command buffer for a new
+    /// recording. Avoids a vkAllocateCommandBuffers call on every dispatch —
+    /// see the `cmd_buf` field doc comment for why this matters here.
     fn begin_one_shot(&self) -> Result<vk::CommandBuffer, String> {
-        let alloc = vk::CommandBufferAllocateInfo::default()
-            .command_pool(self.command_pool)
-            .level(vk::CommandBufferLevel::PRIMARY)
-            .command_buffer_count(1);
-        let cbs = unsafe { self.device.allocate_command_buffers(&alloc) }
-            .map_err(|e| format!("allocate_command_buffers: {e}"))?;
+        unsafe {
+            self.device
+                .reset_command_buffer(self.cmd_buf, vk::CommandBufferResetFlags::empty())
+        }
+        .map_err(|e| format!("reset_command_buffer: {e}"))?;
 
         let begin = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
-        unsafe { self.device.begin_command_buffer(cbs[0], &begin) }
+        unsafe { self.device.begin_command_buffer(self.cmd_buf, &begin) }
             .map_err(|e| format!("begin_command_buffer: {e}"))?;
 
-        Ok(cbs[0])
+        Ok(self.cmd_buf)
     }
 
     fn end_and_submit(&self, cb: vk::CommandBuffer) -> Result<(), String> {
@@ -460,10 +481,8 @@ impl ComputeEngine {
         unsafe { self.device.reset_fences(&[self.fence]) }
             .map_err(|e| format!("reset_fences: {e}"))?;
 
-        unsafe {
-            self.device
-                .free_command_buffers(self.command_pool, &[cb]);
-        }
+        // Command buffer is NOT freed — it's a persistent handle owned by
+        // `self.cmd_buf`, reset and reused on the next `begin_one_shot`.
 
         Ok(())
     }
@@ -591,6 +610,7 @@ impl Drop for ComputeEngine {
                 self.device.destroy_descriptor_pool(pool, None);
             }
             self.device.destroy_fence(self.fence, None);
+            // destroy_command_pool implicitly frees self.cmd_buf too.
             self.device.destroy_command_pool(self.command_pool, None);
             // pipeline_cache and device are dropped after this.
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -788,7 +788,10 @@ const ACT_DOWN:    usize = 10;
 const ACT_GELU:    usize = 11; // gelu(gate) output           [ffn_inter]
 const ACT_PLE_G:   usize = 12; // PLE gate output             [ple_dim]
 const ACT_PLE_C:   usize = 13; // PLE contribution output     [H]
-const ACT_COUNT:   usize = 14;
+const ACT_PLE_LAYER: usize = 14; // PLE per-layer embed input [ple_dim]
+const ACT_PLE_GELU:  usize = 15; // gelu(PLE gate) output     [ple_dim]
+const ACT_PLE_MID:   usize = 16; // gelu(gate) * layer_ple    [ple_dim]
+const ACT_COUNT:   usize = 17;
 
 ///   logits = vk_model.forward(token_id, position)
 #[pyclass]
@@ -993,6 +996,7 @@ impl VulkanModel {
 impl VulkanModel {
     /// GPU-accelerated forward pass: matmuls on GPU, norms + attention on CPU.
     fn forward_gpu(&mut self, token_id: u32, position: usize) -> Vec<f32> {
+        let _t_total = std::time::Instant::now();
         let cfg = self.inner.config.clone();
         let h = cfg.hidden_size;
         let eps = cfg.rms_norm_eps;
@@ -1020,10 +1024,21 @@ impl VulkanModel {
         let ple_inputs: Vec<f32> = ple_proj_normed.iter().zip(ple_embeds_flat.iter())
             .map(|(&p, &e)| (p + e) * cfg.per_layer_input_scale).collect();
 
+        if log::log_enabled!(log::Level::Debug) {
+            log::debug!("PROFILE embed+ple: {}us", _t_total.elapsed().as_micros());
+        }
+
         // ── 35 Decoder Layers ────────────────────────────────────────────────
         for layer_idx in 0..cfg.num_hidden_layers {
+            let _t_layer_all = (layer_idx == 0).then(std::time::Instant::now);
             let layer_ple = &ple_inputs[layer_idx * ple_dim..(layer_idx + 1) * ple_dim];
             hidden = self.forward_layer_gpu_matmuls(layer_idx, &hidden, position, layer_ple);
+            if let Some(t) = _t_layer_all {
+                log::debug!("L0 total (incl. PLE): {}us", t.elapsed().as_micros());
+            }
+        }
+        if log::log_enabled!(log::Level::Debug) {
+            log::debug!("PROFILE after layers: {}us", _t_total.elapsed().as_micros());
         }
 
         // ── Final norm + LM head (GPU) ────────────────────────────────────────
@@ -1091,6 +1106,7 @@ impl VulkanModel {
         };
 
         logits.iter_mut().for_each(|l| *l = (*l / cap).tanh() * cap);
+        log::debug!("PROFILE total forward: {}us", _t_total.elapsed().as_micros());
         logits
     }
 
@@ -1130,9 +1146,18 @@ impl VulkanModel {
             v
         };
 
-        // Pre-extract all needed weight slices (avoids borrow conflicts later).
+        // Pre-extract all needed weight slices as raw-pointer handles (avoids
+        // borrow conflicts with the later `&mut self` GPU calls below without
+        // paying for a heap allocation + memcpy on every single decode step).
+        // SAFETY: `self.inner.weights` is never mutated for the lifetime of
+        // `self`, so the underlying `Vec<f32>` backing storage never moves or
+        // is freed while `self` is alive — these pointers stay valid for as
+        // long as the `RawSlice` values derived from them are in scope here.
         macro_rules! w {
-            ($name:expr) => { self.inner.weights.f32_slice(&ln($name)).to_vec() };
+            ($name:expr) => {{
+                let s = self.inner.weights.f32_slice(&ln($name));
+                RawSlice { ptr: s.as_ptr(), len: s.len() }
+            }};
         }
 
         let inln_w   = w!("input_layernorm.weight");
@@ -1372,42 +1397,70 @@ impl VulkanModel {
         let mut hidden3: Vec<f32> = residual2.iter().zip(ff_normed.iter())
             .map(|(&r, &f)| r + f).collect();
 
-        // PLE: gate_ple matmul [H→ple_dim] on GPU (persistent buf), then CPU gelu+elementwise,
-        //      then proj [ple_dim→H] on GPU (persistent buf)
-        let gate_ple = if use_gpu && self.gpu_weights.contains_key(&ln("per_layer_input_gate.weight")) {
+        // PLE (per-layer embedding) contribution: gate_proj → gelu → ×layer_ple → proj,
+        // all four steps fused into ONE command buffer / vkQueueSubmit (mirrors the
+        // FFN fusion above). Previously this was 2 separate submits with a CPU
+        // gelu + elementwise-multiply round trip in between; fusing it into a
+        // single GPU submit removes one fence-wait per layer from the decode step.
+        let contrib = if use_gpu
+            && self.gpu_weights.contains_key(&ln("per_layer_input_gate.weight"))
+            && self.gpu_weights.contains_key(&ln("per_layer_projection.weight"))
+        {
             let h3b = f32_slice_to_bytes(&hidden3);
             unsafe { (*self.act_ptr_mut(ACT_FFIN)).write(&h3b).unwrap(); }  // reuse ACT_FFIN as PLE input
-            let inp_p = self.act_ptr(ACT_FFIN);
-            let pg_p  = self.act_ptr(ACT_PLE_G);
-            let pgw   = &self.gpu_weights[&ln("per_layer_input_gate.weight")] as *const compute::Buffer;
+            let lpb = f32_slice_to_bytes(layer_ple);
+            unsafe { (*self.act_ptr_mut(ACT_PLE_LAYER)).write(&lpb).unwrap(); }
+
+            let inp_p   = self.act_ptr(ACT_FFIN);
+            let pg_p    = self.act_ptr(ACT_PLE_G);
+            let gelu_p  = self.act_ptr(ACT_PLE_GELU);
+            let layer_p = self.act_ptr(ACT_PLE_LAYER);
+            let mid_p   = self.act_ptr(ACT_PLE_MID);
+            let pc_p    = self.act_ptr(ACT_PLE_C);
+
+            let pgw = &self.gpu_weights[&ln("per_layer_input_gate.weight")] as *const compute::Buffer;
+            let ppw = &self.gpu_weights[&ln("per_layer_projection.weight")] as *const compute::Buffer;
+
+            let gelu_wg_ple = ((ple_dim + 511) / 512) as u32;
+            let mul_wg_ple  = ((ple_dim + 255) / 256) as u32;
+            let gelu_pc_ple = {
+                use std::io::Write;
+                let mut v = Vec::with_capacity(6 * 4);
+                v.write_all(&(ple_dim as u32).to_le_bytes()).unwrap();
+                v.write_all(&1u32.to_le_bytes()).unwrap();
+                for _ in 0..4 { v.write_all(&0u32.to_le_bytes()).unwrap(); }
+                v
+            };
+            let mul_pc_ple = {
+                use std::io::Write;
+                let n = ple_dim as u32;
+                let mut v = Vec::with_capacity(29 * 4);
+                for &x in &[n, n,1u32,1,1, 1u32,n,n,n] { v.write_all(&x.to_le_bytes()).unwrap(); }
+                for &x in &[n, 1u32,1,1, 1u32,n,n,n] { v.write_all(&x.to_le_bytes()).unwrap(); }
+                for &x in &[n, 1u32,1,1, 1u32,n,n,n] { v.write_all(&x.to_le_bytes()).unwrap(); }
+                for &x in &[0u32, 0u32, 0u32, 0u32] { v.write_all(&x.to_le_bytes()).unwrap(); }
+                v
+            };
+
             let eng = self.engine.as_mut().unwrap();
             let cb = eng.begin_batch().unwrap();
             unsafe {
                 eng.record_to(cb, shader, &[&*pgw, &*inp_p, &*pg_p], &mv_pc(h, ple_dim), (ple_dim as u32, t as u32, 1)).unwrap();
+                eng.record_barrier_to(cb);
+                eng.record_to(cb, "gelu_f32", &[&*pg_p, &*gelu_p], &gelu_pc_ple, (gelu_wg_ple, 1, 1)).unwrap();
+                eng.record_barrier_to(cb);
+                eng.record_to(cb, "mul_f32_f32_f32", &[&*gelu_p, &*layer_p, &*mid_p], &mul_pc_ple, (mul_wg_ple, 1, 1)).unwrap();
+                eng.record_barrier_to(cb);
+                eng.record_to(cb, shader, &[&*ppw, &*mid_p, &*pc_p], &mv_pc(ple_dim, h), (h as u32, t as u32, 1)).unwrap();
             }
-            eng.submit_batch(cb).unwrap();
-            read_f32_buf(unsafe { &*pg_p }, t * ple_dim)
-        } else {
-            let pgw = self.inner.weights.f32_slice(&ln("per_layer_input_gate.weight"));
-            model::cpu_matmul(&hidden3, pgw, 1, h, ple_dim)
-        };
-        let gate_ple_act = model::cpu_gelu(&gate_ple);
-        let gated: Vec<f32> = gate_ple_act.iter().zip(layer_ple.iter())
-            .map(|(&g, &p)| g * p).collect();
-        let contrib = if use_gpu && self.gpu_weights.contains_key(&ln("per_layer_projection.weight")) {
-            let gb = f32_slice_to_bytes(&gated);
-            unsafe { (*self.act_ptr_mut(ACT_PLE_G)).write(&gb).unwrap(); }  // reuse ACT_PLE_G as gated input
-            let gat_p = self.act_ptr(ACT_PLE_G);
-            let pc_p  = self.act_ptr(ACT_PLE_C);
-            let ppw   = &self.gpu_weights[&ln("per_layer_projection.weight")] as *const compute::Buffer;
-            let eng = self.engine.as_mut().unwrap();
-            let cb = eng.begin_batch().unwrap();
-            unsafe {
-                eng.record_to(cb, shader, &[&*ppw, &*gat_p, &*pc_p], &mv_pc(ple_dim, h), (h as u32, t as u32, 1)).unwrap();
-            }
-            eng.submit_batch(cb).unwrap();
+            eng.submit_batch(cb).unwrap();  // ONE fence wait for the whole PLE branch
             read_f32_buf(unsafe { &*pc_p }, t * h)
         } else {
+            let pgw = self.inner.weights.f32_slice(&ln("per_layer_input_gate.weight"));
+            let gate_ple = model::cpu_matmul(&hidden3, pgw, 1, h, ple_dim);
+            let gate_ple_act = model::cpu_gelu(&gate_ple);
+            let gated: Vec<f32> = gate_ple_act.iter().zip(layer_ple.iter())
+                .map(|(&g, &p)| g * p).collect();
             let ppw = self.inner.weights.f32_slice(&ln("per_layer_projection.weight"));
             model::cpu_matmul(&gated, ppw, 1, ple_dim, h)
         };
@@ -1447,6 +1500,9 @@ impl VulkanModel {
             (ffn_inter * 4) as u64,  // ACT_GELU
             (ple_dim * 4) as u64,    // ACT_PLE_G
             (h * 4) as u64,          // ACT_PLE_C
+            (ple_dim * 4) as u64,    // ACT_PLE_LAYER
+            (ple_dim * 4) as u64,    // ACT_PLE_GELU
+            (ple_dim * 4) as u64,    // ACT_PLE_MID
         ];
 
         self.act_bufs.clear();
@@ -1552,6 +1608,33 @@ impl VulkanModel {
 
 
 // ─── Helper functions for VulkanModel ────────────────────────────────────────
+
+/// A non-owning handle to an `[f32]` slice, identified by raw pointer + len.
+///
+/// Used to reference small per-layer weight tensors (norm weights, scalars)
+/// across a sequence of `&mut self` calls (GPU dispatch, buffer writes) that
+/// the borrow checker cannot otherwise reconcile with a live `&self.inner`
+/// borrow, without resorting to a heap allocation + memcpy on every decode
+/// step. `Deref<Target = [f32]>` gives it the same call-site ergonomics as
+/// `Vec<f32>` (e.g. `&inln_w`, `inln_w[0]`) via deref coercion.
+#[derive(Clone, Copy)]
+struct RawSlice {
+    ptr: *const f32,
+    len: usize,
+}
+
+// SAFETY: RawSlice is only ever constructed from a `&[f32]` borrowed out of
+// `VulkanModel::inner.weights`, which is immutable and pinned for the whole
+// lifetime of the model. Values are used only on the thread that created
+// them (Vulkan buffer handles are already !Send in this crate).
+impl std::ops::Deref for RawSlice {
+    type Target = [f32];
+    fn deref(&self) -> &[f32] {
+        // SAFETY: see struct docs — the backing Vec<f32> outlives every
+        // RawSlice derived from it and is never mutated in between.
+        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
 
 /// Returns true if this weight tensor should be uploaded to GPU as f16.
 /// Norm weights, scalars, and embeddings stay as f32 for precision.

--- a/vllm_vulkan/model_runner.py
+++ b/vllm_vulkan/model_runner.py
@@ -1,12 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 """VulkanModelRunner — GPU-accelerated model runner.
 
-Two modes:
-  1. VLLM_VULKAN_RUST_MODEL=1 (default): Use the Rust VulkanModel for the
-     forward pass. Much faster than mode 2 due to batched GPU dispatch.
+``VLLM_VULKAN_RUST_MODEL`` gates whether Vulkan dispatch hooks (RMSNorm,
+Linear -> Rust ``vulkan_ops`` via ``vllm_vulkan._rs``) are installed on the
+loaded PyTorch model:
 
-  2. VLLM_VULKAN_RUST_MODEL=0: Patch individual PyTorch modules (RMSNorm,
-     Linear) to dispatch to Vulkan via Python. Slower but useful for debugging.
+  1. VLLM_VULKAN_RUST_MODEL=1 (default): patch individual PyTorch modules
+     (RMSNorm, Linear) to dispatch to Vulkan.
+
+  2. VLLM_VULKAN_RUST_MODEL=0: no Vulkan dispatch; the model runs unmodified
+     on the CPU backend. Useful for isolating CPU-only behaviour when
+     debugging numerical differences.
+
+Note: the standalone Rust ``VulkanModel`` (a from-scratch, fully-fused
+Gemma4 forward pass, see ``vllm_vulkan._rs.VulkanModel`` / ``src/model_gpu.rs``
+/ ``src/lib.rs``) is a separate, complete GPU decode engine — it is not
+wired into vLLM's scheduler/paged-KV-cache here (that would require bypassing
+vLLM's attention backend entirely). It is exercised directly via
+``scripts/bench_vulkan_model.py``. An earlier version of this module loaded
+that Rust model on every startup and then discarded it after logging its
+metadata (nothing here ever called its ``forward()``), which cost ~25-30s of
+extra startup latency and ~7GB of duplicate GPU-resident weight memory for
+zero benefit. That dead load has been removed.
 """
 
 import logging
@@ -19,147 +34,39 @@ from vllm_vulkan import envs
 
 logger = logging.getLogger(__name__)
 
-_RUST_MODEL_SINGLETON = None  # lazy-initialised
-
 
 def _use_rust_model() -> bool:
     return envs.VLLM_VULKAN_RUST_MODEL
 
 
-class VulkanWorker:
-    """CPUWorker subclass that uses our Rust VulkanModel for GPU inference."""
-
-    def __new__(cls, vllm_config, device):
-        import types  # noqa: PLC0415
-
-        from vllm.v1.worker.cpu_worker import CPUWorker  # noqa: PLC0415
-
-        worker = CPUWorker.__new__(CPUWorker)
-        CPUWorker.__init__(worker, vllm_config, device)
-
-        # Patch init_device to skip vllm._C thread-affinity binding.
-        worker.init_device = types.MethodType(_safe_init_device, worker)
-
-        return worker
-
-
-def _safe_init_device(self) -> None:
-    """Same as CPUWorker.init_device but skips the vllm._C call."""
-    import platform  # noqa: PLC0415
-    import sys  # noqa: PLC0415
-
-    from vllm import envs  # noqa: PLC0415
-    from vllm.platforms import CpuArchEnum, current_platform  # noqa: PLC0415
-    from vllm.utils.torch_utils import set_random_seed  # noqa: PLC0415
-
-    def check_preloaded_libs(name: str) -> None:
-        if name not in os.environ.get("LD_PRELOAD", ""):
-            logger.warning("%s is not found in LD_PRELOAD.", name)
-
-    if sys.platform.startswith("linux"):
-        check_preloaded_libs("libtcmalloc")
-        if current_platform.get_cpu_architecture() == CpuArchEnum.X86:
-            check_preloaded_libs("libiomp")
-
-    omp_cpuids = envs.VLLM_CPU_OMP_THREADS_BIND
-    if omp_cpuids == "auto" and platform.system() == "Linux":
-        cpu_arch = current_platform.get_cpu_architecture()
-        if cpu_arch in (CpuArchEnum.POWERPC, CpuArchEnum.S390X):
-            self.local_omp_cpuid = self._get_autobind_cpu_ids(
-                lambda cpus: [cpu for cpu in cpus if cpu.id % 8 < 4]
-            )
-        elif cpu_arch == CpuArchEnum.X86:
-            self.local_omp_cpuid = self._get_autobind_cpu_ids(lambda cpus: cpus[-1:])
-        elif cpu_arch == CpuArchEnum.ARM:
-            self.local_omp_cpuid = self._get_autobind_cpu_ids(lambda cpus: cpus)
-        else:
-            self.local_omp_cpuid = "nobind"
-    elif omp_cpuids == "nobind":
-        self.local_omp_cpuid = "nobind"
-    else:
-        local_dp_rank = self.parallel_config.data_parallel_rank_local
-        omp_cpuids_list = omp_cpuids.split("|")
-        if local_dp_rank is not None:
-            world_size = self.parallel_config.world_size
-            omp_cpuids_list = omp_cpuids_list[
-                local_dp_rank * world_size : (local_dp_rank + 1) * world_size
-            ]
-        self.local_omp_cpuid = omp_cpuids_list[self.rank]
-
-    if self.local_omp_cpuid != "nobind":
-        try:
-            torch.ops._C.init_cpu_threads_env(self.local_omp_cpuid)
-        except AttributeError:
-            logger.info("vllm._C not available; skipping CPU thread-affinity binding.")
-
-    def skip_set_num_threads(x: int) -> None:
-        logger.warning(
-            "CPU backend doesn't allow `torch.set_num_threads` after binding."
-        )
-
-    torch.set_num_threads = skip_set_num_threads
-
-    os.environ["VLLM_DIST_IDENT"] = self.distributed_init_method.split(":")[-1]
-
-    from vllm.v1.worker.gpu_worker import (
-        init_worker_distributed_environment,  # noqa: PLC0415
-    )
-
-    init_worker_distributed_environment(
-        self.vllm_config,
-        self.rank,
-        self.distributed_init_method,
-        self.local_rank,
-        current_platform.dist_backend,
-    )
-
-    set_random_seed(self.model_config.seed)
-
-    # Model runner: use our Rust-native runner if enabled.
-    if _use_rust_model():
-        from vllm_vulkan.model_runner import _VulkanCPUModelRunner  # noqa: PLC0415
-
-        self.model_runner = _VulkanCPUModelRunner(self.vllm_config, torch.device("cpu"))
-    else:
-        from vllm.v1.worker.cpu_model_runner import CPUModelRunner  # noqa: PLC0415
-
-        self.model_runner = CPUModelRunner(self.vllm_config, torch.device("cpu"))
-
-
 class _VulkanCPUModelRunner:
-    """CPUModelRunner that patches the loaded model for Rust+Vulkan inference.
+    """CPUModelRunner that patches the loaded model for Vulkan dispatch.
 
-    Wraps CPUModelRunner and intercepts load_model to additionally load the
-    Rust VulkanModel.  After loading, patches the PyTorch model's forward
-    method to call our Rust model for the forward pass instead of PyTorch ops.
+    Wraps CPUModelRunner and intercepts load_model to additionally patch the
+    PyTorch model's RMSNorm/Linear modules to dispatch to Vulkan (via
+    ``vllm_vulkan._rs``) instead of running on CPU.
     """
 
     def __init__(self, vllm_config, device):
         from vllm.v1.worker.cpu_model_runner import CPUModelRunner  # noqa: PLC0415
 
         self._runner = CPUModelRunner(vllm_config, device)
-        self._rust_model = None
         self._vllm_config = vllm_config
 
     def __getattr__(self, name: str):
         return getattr(self._runner, name)
 
     def load_model(self, **kwargs) -> None:
-        """Load PyTorch model, then load Rust VulkanModel and patch forward."""
+        """Load the PyTorch model, then patch it for Vulkan dispatch."""
         self._runner.load_model(**kwargs)
 
         if not _use_rust_model():
             return
 
         try:
-            self._rust_model = _load_rust_vulkan_model(self._vllm_config)
-            if self._rust_model is not None:
-                _patch_model_with_rust_forward(
-                    self._runner.model, self._rust_model, self._vllm_config
-                )
-                logger.info("Rust VulkanModel patched into PyTorch model forward.")
+            _apply_module_hooks(self._runner.model)
         except Exception as exc:
-            logger.warning("Failed to load Rust VulkanModel: %s", exc)
+            logger.warning("Failed to install Vulkan dispatch hooks: %s", exc)
 
     # Delegate all other methods to the underlying runner.
     def warming_up_model(self) -> None:
@@ -234,61 +141,18 @@ class _VulkanCPUModelRunner:
         return self._runner.determine_available_memory(*args, **kwargs)
 
 
-def _load_rust_vulkan_model(vllm_config):
-    """Load the Rust VulkanModel for the given vLLM config."""
-    from vllm_vulkan._rs import VulkanModel, is_available  # noqa: PLC0415
+def _apply_module_hooks(model: nn.Module) -> None:
+    """Apply Vulkan dispatch hooks to RMSNorm and Linear modules.
 
-    if not is_available():
-        return None
-
-    model_name = vllm_config.model_config.model
-    try:
-        import huggingface_hub  # noqa: PLC0415
-
-        local_dir = huggingface_hub.snapshot_download(
-            model_name, local_files_only=True, ignore_patterns=["*.bin", "*.gguf"]
-        )
-        import glob  # noqa: PLC0415
-
-        st_files = sorted(glob.glob(f"{local_dir}/*.safetensors"))
-    except Exception:
-        st_files = []
-
-    if not st_files:
-        logger.warning("No safetensors for %s; skipping Rust model.", model_name)
-        return None
-
-    st_path = st_files[0]
-    max_seq = min(int(vllm_config.model_config.max_model_len or 512), 2048)
-    logger.info("Loading Rust VulkanModel from %s (max_seq=%d)", st_path, max_seq)
-
-    rust_model = VulkanModel(st_path, max_seq_len=max_seq, device_idx=0)
-    logger.info(
-        "Rust VulkanModel: %d layers, GPU=%s",
-        rust_model.num_layers(),
-        rust_model.has_gpu(),
-    )
-    return rust_model
-
-
-def _patch_model_with_rust_forward(pytorch_model, rust_model, vllm_config):
-    """Patch the PyTorch model's forward to use Rust VulkanModel.
-
-    The PyTorch model is still used for the KV cache and attention backends.
-    We intercept the outermost model forward and route it to Rust for the
-    compute-intensive parts (embed → 35 layers → norm → lm_head).
-
-    The KV cache management in vLLM works at the attention layer level.
-    For now, we can't fully bypass vLLM's attention backend.
-    Instead, we install forward hooks that measure what's happening.
+    Note: there is a separate, complete Rust decode engine
+    (``vllm_vulkan._rs.VulkanModel``, see ``src/model_gpu.rs``) that fuses an
+    entire Gemma4 forward pass into a handful of GPU submits per token. It is
+    not used here — wiring it in would mean bypassing vLLM's own paged
+    KV-cache/attention backend for this model, which this hook-based
+    per-module approach deliberately avoids so it keeps working with vLLM's
+    scheduler, sampler, and KV-cache management unmodified. See
+    ``scripts/bench_vulkan_model.py`` to exercise that engine directly.
     """
-    # For now: install per-module Vulkan hooks (the original approach)
-    # This gives partial GPU utilization for norms and decode-path linears.
-    _apply_module_hooks(pytorch_model, rust_model)
-
-
-def _apply_module_hooks(model: nn.Module, rust_model) -> None:
-    """Apply Vulkan dispatch hooks to RMSNorm and Linear modules."""
     counts = {"rms_norm": 0, "linear": 0}
     for _name, module in model.named_modules():
         cls_name = type(module).__name__


### PR DESCRIPTION
## Summary

Optimizes tokens/sec for `vllm_vulkan._rs.VulkanModel` — the Rust/Vulkan
decode engine this plugin ships — measured against `google/gemma-4-E2B` on
an Apple M4 Max via KosmicKrisp, and removes a real startup-time/memory
regression found while profiling `model_runner.py`.

All changes were validated on real KosmicKrisp hardware (not just compiled);
methodology and numbers below.

## What changed

1. **`ComputeEngine` reuses one persistent command buffer** (`src/compute.rs`).
   Every GPU dispatch allocated a fresh `vkCommandBuffer` and freed it right
   after, on top of the submit+fence-wait that's already required to keep a
   decode step synchronous. On KosmicKrisp (Vulkan-on-Metal) that alloc/free
   pair is measurable overhead paid on every single dispatch. Now allocated
   once, reused via `vkResetCommandBuffer` + `vkBeginCommandBuffer`. Safe
   because dispatches are always fully synchronous (exactly one command
   buffer in flight).

2. **PLE (per-layer-embedding) dispatch fused into one GPU submit**
   (`src/lib.rs`). Previously: `gate_proj` submit → CPU gelu → CPU
   elementwise-multiply → `proj` submit (two fence waits + a CPU round trip).
   Now fused into one command buffer (`gate_proj → gelu → multiply → proj`),
   mirroring the FFN fusion already present in the same function. One fewer
   fence wait per layer.

3. **Removed per-token weight-slice clones** (`src/lib.rs`). Each decode step
   re-`.to_vec()`'d 8 small per-layer weight tensors (norm weights, the layer
   scalar) purely to satisfy the borrow checker across later `&mut self` GPU
   calls in the same function. Replaced with a small `RawSlice` handle (raw
   pointer + len, `Deref<Target = [f32]>`) — sound because the weights
   `HashMap` is never mutated for the model's lifetime — removing the
   allocation + memcpy from the hot path entirely.

4. **Removed a dead duplicate model load** (`vllm_vulkan/model_runner.py`).
   `_VulkanCPUModelRunner.load_model()` called `_load_rust_vulkan_model()`,
   which re-parses the safetensors checkpoint and uploads a *second* full
   copy of the weights to the GPU (~7GB for gemma-4-E2B, ~25-30s), then
   handed the result to `_patch_model_with_rust_forward()` — which only ever
   called `_apply_module_hooks()`, a function that doesn't take that argument
   and never referenced it. So every `VLLM_VULKAN_RUST_MODEL=1` startup (the
   default) paid the full cost of loading and GPU-uploading the model twice
   for zero behavioural effect. Also removed `model_runner.VulkanWorker` /
   `_safe_init_device`, an unused near-duplicate of `vllm_vulkan.worker.VulkanWorker`
   (the platform plugin's actual `worker_cls`, see `platform.py`) that vLLM
   never instantiates.

5. **New benchmark scripts** (`scripts/bench_vulkan_model.py`,
   `scripts/bench_vulkan_ops.py`) to drive the engine directly (prefill +
   greedy decode loop, and single-op dispatch latency) without needing a
   full vLLM server, so these optimizations — and future ones — can be
   measured reproducibly.

## Methodology & results

This machine (shared, thermally-limited laptop) has substantial run-to-run
variance from separate process launches (Vulkan/KosmicKrisp init, page
cache, thermal state). Comparing single runs across separate invocations was
not reliable — I saw swings of 10.9–14.1 tok/s for *identical* unmodified
code across 5 separate process launches.

To get a trustworthy comparison I benchmarked **within a single process**
(one model load, one Vulkan context), running the greedy decode loop 15
times back-to-back for both the pre-optimization baseline and the optimized
version, using `scripts/bench_vulkan_model.py --repeat 15`:

```
git stash (baseline)       -> maturin develop --release
python3 scripts/bench_vulkan_model.py --model google/gemma-4-E2B \
    --prompt "The capital of France is" --max-new-tokens 32 --repeat 15
# all-runs tok/s: [11.01, 11.02, 11.12, 11.30, 11.35, 11.35, 11.37, 11.37,
#                  11.43, 11.61, 11.62, 11.65, 11.65, 11.92, 11.98]
# median = 11.37 tok/s

git stash pop (optimized)  -> maturin develop --release
python3 scripts/bench_vulkan_model.py --model google/gemma-4-E2B \
    --prompt "The capital of France is" --max-new-tokens 32 --repeat 15
# all-runs tok/s: [11.66, 11.69, 11.72, 11.77, 11.86, 11.88, 11.94, 12.00,
#                  12.01, 12.03, 12.07, 12.10, 12.13, 12.20, 12.51]
# median = 12.00 tok/s
```

Median decode throughput: **11.37 -> 12.00 tok/s (+5.5%)**, with a visibly
tighter distribution (11.66–12.51 vs. baseline's 11.01–11.98) — i.e. more
consistent per-token latency, not just a better best-case.

Generated text is byte-for-byte identical before and after (same greedy
tokens, deterministic sampling) — these are pure engine-level speedups, not
numerical changes:

```
Prompt:    'The capital of France is'
Generated: ' Paris.\n\nThe capital of France is Paris.\n\nThe capital of
            France is Paris.\n\nThe capital of France is Paris...'
```

I also attempted to validate the dead-code removal (#4) against a full
`vllm serve` run of `google/gemma-4-E2B`, but the dev venv on this machine
has `vllm==0.19.1` installed while `.vllm-version` pins `0.20.1` (a
pre-existing mismatch, not something I introduced), and 0.19.1's
`CPUWorker.determine_available_memory` reads a config field this plugin no
longer populates under that older version, so `vllm serve` fails at KV-cache
sizing before any request is served. That's an unrelated environment/version
issue — rebuilding vLLM 0.20.1 from source for macOS was out of scope for
this change. I validated #4 directly instead: `_load_rust_vulkan_model()`'s
cost (~25-30s, ~7GB GPU upload) is fully reproducible in isolation, and
`_apply_module_hooks()`'s signature/body confirms the `rust_model` argument
it receives is never used.

## Testing

- `pytest -m "not slow" tests/python/` — 44 passed
- `ruff check` / `ruff format --check` / `mypy vllm_vulkan` — clean
- `maturin develop --release` — builds clean (pre-existing `cargo build`
  warnings only; no new ones)
- Manual end-to-end runs of `scripts/bench_vulkan_model.py` against
  `google/gemma-4-E2B` confirming intelligible, unchanged output at each
  commit

## Not in this PR

The Python per-module hook path (`model_runner.py`'s `_apply_module_hooks`,
used for actual vLLM serving) shares the same `ComputeEngine`/`VulkanContext`
as the standalone `VulkanModel` engine, so it benefits from commit 1 (command
buffer reuse) too, but I didn't have a working end-to-end `vllm serve` on
this machine to benchmark it there (see version-mismatch note above).
Wiring the fully-fused Rust `VulkanModel.forward()` into vLLM's actual
scheduler/paged-KV-cache as a full replacement for the per-module hook path
would be a substantially larger, riskier change (it means bypassing vLLM's
attention backend for this model) and is left as follow-up work rather than
something I could respokibly validate within this change.