### PR TITLE
perf: read-only GPU dispatch outputs skip the read_f32_buf copy

### DIFF
--- a/examples/bench_activation_read.rs
+++ b/examples/bench_activation_read.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Micro-benchmark for the GPU→CPU activation-tensor read-back path.
+//!
+//! `forward_layer_gpu_matmuls` (src/lib.rs) reads a GPU dispatch's output
+//! out of a persistent, host-coherent, permanently-mapped Vulkan buffer
+//! after every submit. Three of these reads per decoder layer (o_proj
+//! output, FFN down_proj output, PLE contribution output) are only ever
+//! *read* afterwards — passed straight into `cpu_rms_norm(&x, ...)`, never
+//! mutated in place — yet the old code still went through `read_f32_buf`,
+//! which allocates a fresh `Vec<f32>` and copies every element out of the
+//! mapped buffer via `.to_vec()`, purely so its type would match the
+//! CPU-fallback branch's owned `Vec<f32>` return value.
+//!
+//! Since the buffer is already mapped, permanent, host-coherent memory —
+//! and outlives the local scope that reads it — that copy is unnecessary
+//! for the read-only cases: an `FBuf` (owned-or-borrowed enum, see
+//! `src/lib.rs`) lets the GPU branch hand back a zero-copy `RawSlice` view
+//! directly into the mapped buffer instead, while the CPU-fallback branch
+//! still returns an owned `Vec<f32>` — both unified behind one `Deref<Target
+//! = [f32]>` type so the call site doesn't need to know which one it got.
+//!
+//! This harness reproduces both approaches standalone (no Vulkan device
+//! required — a `Vec<u8>` stands in for the mapped buffer) and times them
+//! at the tensor width actually used by all three read-only sites in the
+//! Gemma4-E2B decode loop (`hidden_size` = 1536), so the improvement is
+//! measurable without needing model weights, a GPU, or network access.
+//!
+//! Run with:
+//!     cargo run --release --example bench_activation_read
+
+use std::time::Instant;
+
+/// Stand-in for a permanently-mapped, host-coherent Vulkan buffer that a GPU
+/// dispatch has just written its output into.
+///
+/// Real `compute::Buffer::mapped_ptr` is a `*mut u8` from `vkMapMemory`,
+/// which the Vulkan spec guarantees is suitably aligned for the mapped
+/// range's usage. A plain `Vec<u8>`'s allocation is only guaranteed aligned
+/// to `align_of::<u8>() == 1`, so reinterpreting *that* as `*const f32`
+/// would be unsound (the allocator may happen to hand back a 4-byte-aligned
+/// pointer in practice, but nothing guarantees it). Storing `Vec<f32>`
+/// directly sidesteps the question entirely — its allocation is guaranteed
+/// aligned to `align_of::<f32>()` by construction — while still exercising
+/// exactly the pointer-based read paths being compared.
+struct FakeMappedBuffer {
+    data: Vec<f32>,
+}
+
+impl FakeMappedBuffer {
+    fn new(count: usize) -> Self {
+        let data: Vec<f32> = (0..count).map(|i| i as f32 * 0.5).collect();
+        FakeMappedBuffer { data }
+    }
+}
+
+/// Old behaviour: `read_f32_buf` — allocate a fresh `Vec<f32>` and copy the
+/// mapped buffer's contents into it.
+fn read_f32_buf_old(buf: &FakeMappedBuffer, count: usize) -> Vec<f32> {
+    let ptr = buf.data.as_ptr();
+    unsafe { std::slice::from_raw_parts(ptr, count).to_vec() }
+}
+
+/// New behaviour: a zero-copy borrowed view directly into the mapped buffer
+/// (what `FBuf::Borrowed(RawSlice { .. })` does in src/lib.rs).
+fn read_f32_buf_new(buf: &FakeMappedBuffer, count: usize) -> &[f32] {
+    let ptr = buf.data.as_ptr();
+    unsafe { std::slice::from_raw_parts(ptr, count) }
+}
+
+/// What the read result is actually used for at all three call sites this
+/// change applies to: `cpu_rms_norm(&x, weight, eps)`, a read-only pass over
+/// the slice. Kept trivial here since we're isolating the read-back cost,
+/// not RMSNorm itself (unchanged by this optimization).
+fn consume(x: &[f32]) -> f32 {
+    x.iter().fold(0.0f32, |acc, &v| acc + v)
+}
+
+fn bench_one(label: &str, count: usize, iters: usize) {
+    let buf = FakeMappedBuffer::new(count);
+
+    // Correctness check: both paths must read identical data.
+    assert_eq!(read_f32_buf_old(&buf, count), read_f32_buf_new(&buf, count));
+
+    let t0 = Instant::now();
+    let mut acc = 0.0f32;
+    for _ in 0..iters {
+        let v = read_f32_buf_old(std::hint::black_box(&buf), count);
+        acc += consume(&v);
+    }
+    std::hint::black_box(acc);
+    let old_elapsed = t0.elapsed();
+
+    let t0 = Instant::now();
+    let mut acc = 0.0f32;
+    for _ in 0..iters {
+        let v = read_f32_buf_new(std::hint::black_box(&buf), count);
+        acc += consume(v);
+    }
+    std::hint::black_box(acc);
+    let new_elapsed = t0.elapsed();
+
+    let old_ns = old_elapsed.as_nanos() as f64 / iters as f64;
+    let new_ns = new_elapsed.as_nanos() as f64 / iters as f64;
+    let speedup = old_ns / new_ns;
+
+    println!(
+        "{label:<32} ({count:>6} f32) old: {old_ns:>8.1} ns/op   new: {new_ns:>8.1} ns/op   speedup: {speedup:>5.2}x"
+    );
+}
+
+fn main() {
+    println!("Activation read-back: old (read_f32_buf alloc+copy) vs new (FBuf zero-copy borrow)\n");
+
+    let iters = 50_000;
+    // hidden_size = 1536 — the width used by all three read-only-after-read
+    // sites this change applies to (o_proj output, FFN down_proj output, PLE
+    // contribution output). Also bench a couple of neighbouring widths from
+    // the same model (src/model.rs) for context.
+    bench_one("ple_dim", 256, iters);
+    bench_one("hidden_size (o_proj/down/PLE-out)", 1536, iters);
+    bench_one("intermediate_size", 6144, iters);
+
+    println!(
+        "\no_proj, FFN down_proj, and PLE contribution outputs are all read exactly \
+once (into cpu_rms_norm) and never mutated afterwards, so the GPU-dispatch \
+branch can hand back a borrowed view straight into the persistent mapped \
+buffer instead of paying for read_f32_buf's Vec<f32> allocation + copy. \
+That's 3 of these per decoder layer, 35 layers per decode step."
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1292,10 +1292,10 @@ impl VulkanModel {
             }
             eng.submit_batch(cb).unwrap();
             if layer_idx == 0 { log::debug!("L{layer_idx} o_proj submit: {}µs total since layer start", _t_layer.elapsed().as_micros()); }
-            read_f32_buf(unsafe { &*oo }, t * h)
+            FBuf::Borrowed(RawSlice { ptr: self.act_ptr_f32(ACT_O_OUT), len: t * h })
         } else {
             let ow = self.inner.weights.f32_slice(&ln("self_attn.o_proj.weight"));
-            model::cpu_matmul(&attn_out, ow, 1, q_dim, h)
+            FBuf::Owned(model::cpu_matmul(&attn_out, ow, 1, q_dim, h))
         };
 
         // CPU: post_attn_norm + residual (using pre-extracted weight)
@@ -1380,7 +1380,7 @@ impl VulkanModel {
             eng.submit_batch(cb).unwrap();  // ONE fence wait for all FFN ops
             if layer_idx == 0 { log::debug!("L{layer_idx} FFN submit: {}µs total since layer start", _t_layer.elapsed().as_micros()); }
 
-            read_f32_buf(unsafe { &*down_p }, t * h)
+            FBuf::Borrowed(RawSlice { ptr: self.act_ptr_f32(ACT_DOWN), len: t * h })
         } else {
             // CPU fallback
             let gate_w = self.inner.weights.f32_slice(&ln("mlp.gate_proj.weight")).to_vec();
@@ -1389,7 +1389,7 @@ impl VulkanModel {
             let up   = model::cpu_matmul(&ff_in, &up_w,   1, h, ffn_inter);
             let gate_act = model::cpu_gelu(&gate);
             let mid: Vec<f32> = gate_act.iter().zip(up.iter()).map(|(&g, &u)| g * u).collect();
-            self.gpu_matmul_or_cpu(&ln("mlp.down_proj.weight"), &mid, t, ffn_inter, h, &mv_pc(ffn_inter, h))
+            FBuf::Owned(self.gpu_matmul_or_cpu(&ln("mlp.down_proj.weight"), &mid, t, ffn_inter, h, &mv_pc(ffn_inter, h)))
         };
 
         // CPU: post_ffn_norm + residual (using pre-extracted weight)
@@ -1454,7 +1454,7 @@ impl VulkanModel {
                 eng.record_to(cb, shader, &[&*ppw, &*mid_p, &*pc_p], &mv_pc(ple_dim, h), (h as u32, t as u32, 1)).unwrap();
             }
             eng.submit_batch(cb).unwrap();  // ONE fence wait for the whole PLE branch
-            read_f32_buf(unsafe { &*pc_p }, t * h)
+            FBuf::Borrowed(RawSlice { ptr: self.act_ptr_f32(ACT_PLE_C), len: t * h })
         } else {
             let pgw = self.inner.weights.f32_slice(&ln("per_layer_input_gate.weight"));
             let gate_ple = model::cpu_matmul(&hidden3, pgw, 1, h, ple_dim);
@@ -1462,7 +1462,7 @@ impl VulkanModel {
             let gated: Vec<f32> = gate_ple_act.iter().zip(layer_ple.iter())
                 .map(|(&g, &p)| g * p).collect();
             let ppw = self.inner.weights.f32_slice(&ln("per_layer_projection.weight"));
-            model::cpu_matmul(&gated, ppw, 1, ple_dim, h)
+            FBuf::Owned(model::cpu_matmul(&gated, ppw, 1, ple_dim, h))
         };
         let contrib_normed = model::cpu_rms_norm(&contrib, &ple_norm_w, eps);
         hidden3.iter_mut().zip(contrib_normed.iter()).for_each(|(hv, &c)| *hv += c);
@@ -1531,6 +1531,16 @@ impl VulkanModel {
 
     fn act_ptr_mut(&mut self, slot: usize) -> *mut compute::Buffer {
         &mut self.act_bufs[slot] as *mut compute::Buffer
+    }
+
+    /// Raw pointer to a persistent activation buffer's mapped memory, viewed
+    /// as `f32`. Used with `RawSlice`/`FBuf` to read a GPU dispatch's output
+    /// directly out of the mapped buffer without the `Vec<f32>` allocation +
+    /// copy that `read_f32_buf` does, for call sites that only need to *read*
+    /// the result (see `FBuf` doc comment). Detached from `self`'s borrow —
+    /// same rationale as `act_ptr`/`act_ptr_mut` above.
+    fn act_ptr_f32(&self, slot: usize) -> *const f32 {
+        self.act_bufs[slot].mapped_ptr.unwrap() as *const f32
     }
 
     fn gpu_matmul_or_cpu(&mut self, weight_name: &str, x: &[f32],
@@ -1633,6 +1643,33 @@ impl std::ops::Deref for RawSlice {
         // SAFETY: see struct docs — the backing Vec<f32> outlives every
         // RawSlice derived from it and is never mutated in between.
         unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+/// Either a borrowed activation-buffer view (`RawSlice`, GPU dispatch path)
+/// or an owned `Vec<f32>` (CPU-fallback path), unified behind one type so
+/// call sites like `forward_layer_gpu_matmuls`'s `let x = if use_gpu {...}
+/// else {...};` — which must produce the same type from both branches — can
+/// read a GPU dispatch's output directly out of its persistent, mapped
+/// buffer with no allocation, instead of both branches always paying for a
+/// `read_f32_buf` heap allocation + copy just to satisfy the CPU fallback's
+/// `Vec<f32>` return type. Only usable where the result is read, never
+/// mutated in place, after construction (RoPE/RMSNorm's in-place update
+/// paths still go through owned `Vec<f32>`, since those aren't valid
+/// `RawSlice` targets — mutating a `Buffer` still in flight for other reads
+/// would be unsound).
+enum FBuf {
+    Borrowed(RawSlice),
+    Owned(Vec<f32>),
+}
+
+impl std::ops::Deref for FBuf {
+    type Target = [f32];
+    fn deref(&self) -> &[f32] {
+        match self {
+            FBuf::Borrowed(s) => s,
+            FBuf::Owned(v) => v,
+        }
     }
 }
 


### PR DESCRIPTION
## What

Companion to #24 (read side, that one was the write side): three GPU
dispatch outputs per decoder layer in `forward_layer_gpu_matmuls()` —
o_proj, FFN down_proj, and the PLE contribution — are read straight into
`cpu_rms_norm(&x, ...)` and never mutated afterwards, yet all three still
went through `read_f32_buf`, which allocates a fresh `Vec<f32>` and copies
the mapped buffer's contents into it. That copy only existed to make the
GPU branch's type match the CPU-fallback branch's owned `Vec<f32>` return
value in the same `if use_gpu {...} else {...}` expression.

Adds `FBuf`, a small owned-or-borrowed enum mirroring the existing
`RawSlice` pattern already used in this file for weight tensors: the GPU
branch now hands back a zero-copy `RawSlice` view directly into the
already-mapped, host-coherent, persistent activation buffer, while the
CPU-fallback branch still returns an owned `Vec<f32>` — unified behind one
`Deref<Target = [f32]>` type so callers don't need to know which one they
got.

Q/K/V are untouched by this change — they're mutated in place (Q/K-norm,
RoPE), which would be unsound to do directly on a `Buffer` via a borrowed
view, so they keep going through owned, copied `Vec<f32>` as before.

## Verification

- `cargo build --release` — clean, same 28 warnings as `main` (diffed the
  full warning list against `main`, byte-for-byte identical).
- `cargo clippy --release --all-targets` — clean, same 47 warnings as
  `main`.
- New standalone microbenchmark, `examples/bench_activation_read.rs`
  (CPU-only, no GPU/model checkpoint needed, mirrors
  `examples/bench_activation_write.rs` from #24): asserts the old and new
  reads return byte-identical data, then times both at the tensor widths
  actually used by these three call sites:

  ```
  ple_dim (256):                                       218.7ns -> 176.1ns  (1.24x)
  hidden_size (1536, o_proj/down_proj/PLE-out width):  1681.7ns -> 1408.7ns (1.19x)
  intermediate_size (6144):                            6521.2ns -> 6041.8ns  (1.08x)
  ```

  Run it yourself with `cargo run --release --example bench_activation_read`.

Note the speedup here is more modest than #24's write-side fix — the
downstream consumer (`cpu_rms_norm`) already touches every element
regardless, so this only removes the one extra allocation + bulk copy that
`read_f32_buf` did on top of that, rather than avoiding a slow per-element
conversion loop. Still a real, measured reduction, and 3 fewer heap
allocations per decoder layer (105/token for Gemma4-E2B's 35 layers) reduce
allocator pressure beyond just the raw per-call time shown above.

As with #24, I did not run a full end-to-end tok/s benchmark against a
real checkpoint — this sandbox has no cached HF model and limited disk.
