### PR TITLE
perf: in-place per-head RMSNorm, drop redundant clones in CPU fallback

### DIFF
--- a/examples/bench_rms_norm_inplace.rs
+++ b/examples/bench_rms_norm_inplace.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Micro-benchmark for per-head RMSNorm in the decode hot path.
+//!
+//! `forward_layer_gpu_matmuls` (src/lib.rs) and `Gemma4Model::forward_layer`
+//! (src/model.rs, the pure-CPU fallback used when no Vulkan device is
+//! available) both normalise Q/K/V per attention head with the same
+//! pattern:
+//!
+//! ```ignore
+//! let s = &mut q[hi * head_dim..(hi + 1) * head_dim];
+//! let n = model::cpu_rms_norm(s, &q_norm_w, eps);  // allocates a new Vec<f32>
+//! s.copy_from_slice(&n);                            // ...then copies it back
+//! ```
+//!
+//! `cpu_rms_norm` always allocates a fresh output `Vec<f32>`, even though
+//! every one of these call sites immediately copies the result back over
+//! the exact slice it read from — paying for a heap allocation *and* a
+//! redundant copy just to mutate a buffer in place. `cpu_rms_norm_inplace`
+//! does the same math directly over `&mut [f32]`, with neither.
+//!
+//! Gemma4-E2B calls this up to 10 times per decoder layer (8 query heads +
+//! up to 1 key head + 1 value head, when K/V aren't KV-shared), 35 layers
+//! per decode step — so this is squarely on the per-token hot path.
+//!
+//! This harness reproduces both approaches standalone (no GPU/model
+//! checkpoint required) and times them at the two head widths Gemma4-E2B
+//! actually uses (`head_dim` = 256 for sliding-window layers, 512 for
+//! full-attention layers).
+//!
+//! Run with:
+//!     cargo run --release --example bench_rms_norm_inplace
+
+use std::time::Instant;
+
+/// Old behaviour: allocate a normalised copy, then copy it back over `x`.
+fn rms_norm_alloc_then_copy_back(x: &mut [f32], weight: &[f32], eps: f32) {
+    let n = weight.len();
+    let mut out = vec![0.0f32; x.len()];
+    let rms = (x.iter().map(|&v| v * v).sum::<f32>() / n as f32 + eps).sqrt();
+    let scale = 1.0 / rms;
+    for i in 0..n {
+        out[i] = x[i] * scale * weight[i];
+    }
+    x.copy_from_slice(&out);
+}
+
+/// New behaviour: `cpu_rms_norm_inplace` — normalise `x` directly, no
+/// allocation.
+fn rms_norm_inplace(x: &mut [f32], weight: &[f32], eps: f32) {
+    let n = weight.len();
+    let rms = (x.iter().map(|&v| v * v).sum::<f32>() / n as f32 + eps).sqrt();
+    let scale = 1.0 / rms;
+    for (v, &w) in x.iter_mut().zip(weight.iter()) {
+        *v = *v * scale * w;
+    }
+}
+
+fn bench_one(label: &str, head_dim: usize, iters: usize) {
+    let weight: Vec<f32> = (0..head_dim).map(|i| 1.0 + i as f32 * 0.001).collect();
+    let base: Vec<f32> = (0..head_dim).map(|i| (i as f32 * 0.37).sin()).collect();
+    let eps = 1e-6f32;
+
+    // Correctness check: both paths must produce the same result.
+    let mut a = base.clone();
+    let mut b = base.clone();
+    rms_norm_alloc_then_copy_back(&mut a, &weight, eps);
+    rms_norm_inplace(&mut b, &weight, eps);
+    for (x, y) in a.iter().zip(b.iter()) {
+        assert!((x - y).abs() < 1e-6, "mismatch for {label}: {x} vs {y}");
+    }
+
+    let mut buf = base.clone();
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        rms_norm_alloc_then_copy_back(std::hint::black_box(&mut buf), &weight, eps);
+    }
+    let old_elapsed = t0.elapsed();
+
+    let mut buf = base.clone();
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        rms_norm_inplace(std::hint::black_box(&mut buf), &weight, eps);
+    }
+    let new_elapsed = t0.elapsed();
+
+    let old_ns = old_elapsed.as_nanos() as f64 / iters as f64;
+    let new_ns = new_elapsed.as_nanos() as f64 / iters as f64;
+    let speedup = old_ns / new_ns;
+
+    println!(
+        "{label:<28} (head_dim={head_dim:>4}) old: {old_ns:>7.1} ns/op   new: {new_ns:>7.1} ns/op   speedup: {speedup:>5.2}x"
+    );
+}
+
+fn main() {
+    println!("Per-head RMSNorm: old (alloc + copy-back) vs new (cpu_rms_norm_inplace)\n");
+
+    let iters = 200_000;
+    bench_one("sliding-window layer", 256, iters);
+    bench_one("full-attention layer", 512, iters);
+
+    println!(
+        "\nQ-norm alone runs this up to 8 times per decoder layer (one per query \
+head), plus up to 2 more for K-norm/V-norm when not KV-shared; Gemma4-E2B \
+has 35 layers per decode step."
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1236,23 +1236,21 @@ impl VulkanModel {
         let mut k_final = k_vec;
         let mut v_final = v_vec;
 
-        // CPU: Q-norm, K-norm, V-norm (using pre-extracted weights)
+        // CPU: Q-norm, K-norm, V-norm (using pre-extracted weights), in place —
+        // no per-head allocation + copy-back (see cpu_rms_norm_inplace doc).
         for hi in 0..num_q {
             let s = &mut q[hi * head_dim..(hi + 1) * head_dim];
-            let n = model::cpu_rms_norm(s, &q_norm_w, eps);
-            s.copy_from_slice(&n);
+            model::cpu_rms_norm_inplace(s, &q_norm_w, eps);
         }
         if !is_kv_shared {
             let k_norm = k_norm_w.as_ref().unwrap();
             for hi in 0..num_kv {
                 let s = &mut k_final[hi * head_dim..(hi + 1) * head_dim];
-                let n = model::cpu_rms_norm(s, k_norm, eps);
-                s.copy_from_slice(&n);
+                model::cpu_rms_norm_inplace(s, k_norm, eps);
             }
             for hi in 0..num_kv {
                 let s = &mut v_final[hi * head_dim..(hi + 1) * head_dim];
-                let n = model::cpu_rms_norm_no_weight(s, head_dim, eps);
-                s.copy_from_slice(&n);
+                model::cpu_rms_norm_no_weight_inplace(s, head_dim, eps);
             }
         }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -174,34 +174,67 @@ impl KvCache {
 
 // ─── CPU op primitives (used before full GPU pipeline is wired) ───────────────
 
-/// RMS normalisation in f32: out = x / rms(x) * weight
-pub fn cpu_rms_norm(x: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
+/// RMS normalisation in place: `x[i] = x[i] / rms(x) * weight[i]`.
+///
+/// Several call sites (per-head Q-norm/K-norm/V-norm in the decode hot path)
+/// used to call the allocating `cpu_rms_norm` and immediately
+/// `copy_from_slice` the result back over the same slice they read from —
+/// paying for a heap allocation *and* a redundant copy just to mutate a
+/// buffer in place. This does the same math directly over `x`, with no
+/// allocation.
+pub fn cpu_rms_norm_inplace(x: &mut [f32], weight: &[f32], eps: f32) {
     let n = weight.len();
+    assert!(n > 0, "cpu_rms_norm_inplace: weight must be non-empty");
+    assert_eq!(
+        x.len() % n,
+        0,
+        "cpu_rms_norm_inplace: x.len() ({}) must be a multiple of weight.len() ({n})",
+        x.len(),
+    );
     let chunks = x.len() / n;
-    let mut out = vec![0.0f32; x.len()];
     for c in 0..chunks {
-        let row = &x[c * n..(c + 1) * n];
+        let row = &mut x[c * n..(c + 1) * n];
         let rms = (row.iter().map(|&v| v * v).sum::<f32>() / n as f32 + eps).sqrt();
         let scale = 1.0 / rms;
-        for i in 0..n {
-            out[c * n + i] = row[i] * scale * weight[i];
+        for (v, &w) in row.iter_mut().zip(weight.iter()) {
+            *v = *v * scale * w;
         }
     }
+}
+
+/// RMS normalisation without weight, in place (has_weight=False, e.g.
+/// v_norm). See `cpu_rms_norm_inplace` doc comment for why this exists
+/// alongside the allocating `cpu_rms_norm_no_weight`.
+pub fn cpu_rms_norm_no_weight_inplace(x: &mut [f32], n: usize, eps: f32) {
+    assert!(n > 0, "cpu_rms_norm_no_weight_inplace: n must be greater than zero");
+    assert_eq!(
+        x.len() % n,
+        0,
+        "cpu_rms_norm_no_weight_inplace: x.len() ({}) must be a multiple of n ({n})",
+        x.len(),
+    );
+    let chunks = x.len() / n;
+    for c in 0..chunks {
+        let row = &mut x[c * n..(c + 1) * n];
+        let rms = (row.iter().map(|&v| v * v).sum::<f32>() / n as f32 + eps).sqrt();
+        let scale = 1.0 / rms;
+        for v in row.iter_mut() {
+            *v *= scale;
+        }
+    }
+}
+
+/// RMS normalisation in f32: out = x / rms(x) * weight
+pub fn cpu_rms_norm(x: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
+    let mut out = x.to_vec();
+    cpu_rms_norm_inplace(&mut out, weight, eps);
     out
 }
 
 /// RMS normalisation without weight (has_weight=False, e.g. v_norm).
 pub fn cpu_rms_norm_no_weight(x: &[f32], n: usize, eps: f32) -> Vec<f32> {
-    let chunks = x.len() / n;
-    let mut out = vec![0.0f32; x.len()];
-    for c in 0..chunks {
-        let row = &x[c * n..(c + 1) * n];
-        let rms = (row.iter().map(|&v| v * v).sum::<f32>() / n as f32 + eps).sqrt();
-        let scale = 1.0 / rms;
-        for i in 0..n {
-            out[c * n + i] = row[i] * scale;
-        }
-    }
+    let mut out = x.to_vec();
+    cpu_rms_norm_no_weight_inplace(&mut out, n, eps);
     out
 }
 
@@ -437,40 +470,35 @@ impl Gemma4Model {
         // 3. Q-norm and K-norm
         let q_norm_w = self.weights.f32_slice(&ln("self_attn.q_norm.weight")).to_vec();
         let k_norm_w = self.weights.f32_slice(&ln("self_attn.k_norm.weight")).to_vec();
-        // Apply q_norm per head
-        let mut q_heads = q.clone();
+        // Apply q_norm per head, in place (no clone, no allocate-then-copy-back).
         for h_idx in 0..num_q_heads {
-            let slice = &mut q_heads[h_idx * head_dim..(h_idx + 1) * head_dim];
-            let normed = cpu_rms_norm(slice, &q_norm_w, eps);
-            slice.copy_from_slice(&normed);
+            let slice = &mut q[h_idx * head_dim..(h_idx + 1) * head_dim];
+            cpu_rms_norm_inplace(slice, &q_norm_w, eps);
         }
-        q = q_heads;
 
         let mut k_final: Vec<f32>;
         let mut v_final: Vec<f32>;
 
         if !is_kv_shared {
-            let mut k_heads = k_raw.clone();
+            let mut k_heads = k_raw;
             for h_idx in 0..num_kv_heads {
                 let slice = &mut k_heads[h_idx * head_dim..(h_idx + 1) * head_dim];
-                let normed = cpu_rms_norm(slice, &k_norm_w, eps);
-                slice.copy_from_slice(&normed);
+                cpu_rms_norm_inplace(slice, &k_norm_w, eps);
             }
 
             // V-norm (no weight)
-            let mut v_heads = v_raw.clone();
+            let mut v_heads = v_raw;
             for h_idx in 0..num_kv_heads {
                 let slice = &mut v_heads[h_idx * head_dim..(h_idx + 1) * head_dim];
-                let normed = cpu_rms_norm_no_weight(slice, head_dim, eps);
-                slice.copy_from_slice(&normed);
+                cpu_rms_norm_no_weight_inplace(slice, head_dim, eps);
             }
             k_final = k_heads;
             v_final = v_heads;
         } else {
             // KV-shared: k and v come from the target layer's cache.
             // We still need dummy values for RoPE (q only matters).
-            k_final = k_raw.clone();
-            v_final = v_raw.clone();
+            k_final = k_raw;
+            v_final = v_raw;
         }
 
         // 4. RoPE


### PR DESCRIPTION
## What

Both the GPU decode hot path (`forward_layer_gpu_matmuls` in
`src/lib.rs`) and the pure-CPU fallback path (`Gemma4Model::forward_layer`
in `src/model.rs`, used when no Vulkan device is available) normalise
Q/K/V per attention head with the same pattern:

```rust
let s = &mut q[hi * head_dim..(hi + 1) * head_dim];
let n = cpu_rms_norm(s, &q_norm_w, eps);  // allocates a Vec<f32>
s.copy_from_slice(&n);                     // ...then copies it back
```

`cpu_rms_norm` always allocated a fresh output `Vec<f32>`, even though
every one of these call sites immediately copied the result back over
the exact slice it read from. Adds `cpu_rms_norm_inplace` /
`cpu_rms_norm_no_weight_inplace`, which do the same math directly over
`&mut [f32]` with no allocation, and reimplements the original allocating
`cpu_rms_norm` / `cpu_rms_norm_no_weight` on top of them (`x.to_vec()` +
in-place call) so there's one source of truth for the math. Updated all
6 call sites with this pattern (3 in the GPU hot path, 3 in the CPU
fallback) to use the in-place versions directly.

Also removes three now-pointless `.clone()` calls in
`Gemma4Model::forward_layer`: `q_heads = q.clone()` /
`k_heads = k_raw.clone()` / `v_heads = v_raw.clone()` cloned the whole
projection output only to normalise the clone in place and immediately
reassign it back over the original (`q = q_heads`) or discard the
original entirely (`k_raw`/`v_raw` were never read again after the
clone) — a full extra `Vec<f32>` allocation + copy on top of the
per-head norm cost, for no behavioural difference.

Gemma4-E2B calls the per-head norm loop up to 10 times per decoder layer
(8 query heads + up to 1 key head + 1 value head), 35 layers per decode
step, so this is squarely on the per-token hot path in both code paths.

## Verification

- `cargo build --release` — clean, same 28 warnings as `main` (diffed
  the full warning list, byte-for-byte identical).
- `cargo clippy --release --all-targets` — clean, same 47 warnings as
  `main`.
- New standalone microbenchmark, `examples/bench_rms_norm_inplace.rs`
  (CPU-only, no GPU/model checkpoint needed, same methodology as the
  write/read microbenchmarks from #24/#25): asserts the old and new
  implementations agree to 1e-6, then times both at the two head widths
  Gemma4-E2B actually uses:

  ```
  sliding-window layer (head_dim=256): 360-375ns -> 285ns  (~1.3x)
  full-attention layer (head_dim=512): ~635ns    -> 564ns  (~1.13x)
  ```

  Run it yourself with `cargo run --release --example bench_rms_norm_inplace`.

As with #24/#25, no full end-to-end tok/s benchmark against a real
checkpoint — this sandbox has no cached HF model and limited disk.
