### PR TITLE
perf: precompute cpu_rope's per-index sin/cos table once per call

### DIFF
--- a/examples/bench_rope.rs
+++ b/examples/bench_rope.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Micro-benchmark for hoisting the per-index `(sin, cos)` table out of
+//! `cpu_rope`'s per-head loop.
+//!
+//! `cpu_rope` (src/model.rs) applies rotary positional embedding to every
+//! query head (8 for Gemma4-E2B) and key head (1, since Gemma4-E2B uses
+//! multi-query attention) in the current decoder layer. Its rotation angle
+//! for index `i` depends only on `pos`, `i`, `rotary_dim`, and `theta` —
+//! the same four inputs for every head in a given call (Q and K alike,
+//! since `forward_layer_gpu_matmuls`/`Gemma4Model::forward_layer` both call
+//! `cpu_rope` with one shared `rotary_dim`/`theta` for the whole call). The
+//! previous implementation recomputed `theta.powf(..)` and
+//! `angle.sin_cos()` — both genuinely expensive transcendental functions,
+//! unlike a plain multiply/add — inside the per-head loop, so a single
+//! decode step paid for `rotary_dim/2` of each per *head* instead of once
+//! per call. Precomputing the `(sin, cos)` table once and reusing it
+//! across every head removes that redundant transcendental work entirely,
+//! with no change in the result (every head applies the exact same
+//! rotation it would otherwise have recomputed itself).
+//!
+//! This harness reproduces both versions standalone (no GPU/model
+//! checkpoint required) and times them at both RoPE configurations
+//! Gemma4-E2B actually uses (sliding-window layers: rotary_dim=head_dim=256,
+//! theta=10000; full-attention layers: rotary_dim=head_dim/4=128,
+//! theta=1000000), with num_q_heads=8, num_kv_heads=1 (the real GQA ratio
+//! for this model), so the improvement is measurable without needing model
+//! weights, a GPU, or network access.
+//!
+//! Run with:
+//!     cargo run --release --example bench_rope
+
+use std::time::Instant;
+
+const NUM_Q_HEADS: usize = 8;
+const NUM_KV_HEADS: usize = 1;
+
+/// Old behaviour: recompute `freq`/`angle`/`sin_cos` inside the per-head
+/// loop (verbatim copy of `cpu_rope` before this change).
+fn rope_recompute_per_head(
+    q: &mut [f32], k: &mut [f32], pos: usize, head_dim: usize, rotary_dim: usize, theta: f32,
+) {
+    let rotate_head = |x: &mut [f32], pos: usize, rotary_dim: usize, theta: f32| {
+        let half = rotary_dim / 2;
+        for i in 0..half {
+            let freq = 1.0 / theta.powf(i as f32 * 2.0 / rotary_dim as f32);
+            let angle = pos as f32 * freq;
+            let (s, c) = angle.sin_cos();
+            let x0 = x[i];
+            let x1 = x[i + half];
+            x[i]        = x0 * c - x1 * s;
+            x[i + half] = x0 * s + x1 * c;
+        }
+    };
+
+    for h in 0..NUM_Q_HEADS {
+        let slice = &mut q[h * head_dim..(h + 1) * head_dim];
+        rotate_head(slice, pos, rotary_dim, theta);
+    }
+    for h in 0..NUM_KV_HEADS {
+        let slice = &mut k[h * head_dim..(h + 1) * head_dim];
+        rotate_head(slice, pos, rotary_dim, theta);
+    }
+}
+
+/// New behaviour: precompute the `(sin, cos)` table once per call, reuse
+/// it across every head (what `cpu_rope` does now).
+fn rope_precomputed_table(
+    q: &mut [f32], k: &mut [f32], pos: usize, head_dim: usize, rotary_dim: usize, theta: f32,
+) {
+    let half = rotary_dim / 2;
+    let mut sin_cos: Vec<(f32, f32)> = Vec::with_capacity(half);
+    for i in 0..half {
+        let freq = 1.0 / theta.powf(i as f32 * 2.0 / rotary_dim as f32);
+        let angle = pos as f32 * freq;
+        sin_cos.push(angle.sin_cos());
+    }
+
+    let rotate_head = |x: &mut [f32], sin_cos: &[(f32, f32)]| {
+        for (i, &(s, c)) in sin_cos.iter().enumerate() {
+            let x0 = x[i];
+            let x1 = x[i + half];
+            x[i]        = x0 * c - x1 * s;
+            x[i + half] = x0 * s + x1 * c;
+        }
+    };
+
+    for h in 0..NUM_Q_HEADS {
+        let slice = &mut q[h * head_dim..(h + 1) * head_dim];
+        rotate_head(slice, &sin_cos);
+    }
+    for h in 0..NUM_KV_HEADS {
+        let slice = &mut k[h * head_dim..(h + 1) * head_dim];
+        rotate_head(slice, &sin_cos);
+    }
+}
+
+/// Time `f` over `iters` calls, repeated `trials` times, returning the best
+/// (minimum) per-call time in nanoseconds — see bench_sdpa.rs's doc comment
+/// for why "best of N reps" is used here.
+fn time_best_of(trials: usize, iters: usize, mut f: impl FnMut()) -> f64 {
+    let mut best = f64::INFINITY;
+    for _ in 0..trials {
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            f();
+        }
+        let ns_per_iter = t0.elapsed().as_nanos() as f64 / iters as f64;
+        best = best.min(ns_per_iter);
+    }
+    best
+}
+
+fn bench_one(label: &str, head_dim: usize, rotary_dim: usize, theta: f32, pos: usize, iters: usize) {
+    let q_init: Vec<f32> = (0..NUM_Q_HEADS * head_dim).map(|i| (i as f32 * 0.01).sin()).collect();
+    let k_init: Vec<f32> = (0..NUM_KV_HEADS * head_dim).map(|i| (i as f32 * 0.013).cos()).collect();
+
+    // Correctness check: both paths must agree.
+    let mut q_a = q_init.clone();
+    let mut k_a = k_init.clone();
+    rope_recompute_per_head(&mut q_a, &mut k_a, pos, head_dim, rotary_dim, theta);
+    let mut q_b = q_init.clone();
+    let mut k_b = k_init.clone();
+    rope_precomputed_table(&mut q_b, &mut k_b, pos, head_dim, rotary_dim, theta);
+    for (x, y) in q_a.iter().zip(q_b.iter()) {
+        assert!((x - y).abs() < 1e-6, "Q mismatch for {label}: {x} vs {y}");
+    }
+    for (x, y) in k_a.iter().zip(k_b.iter()) {
+        assert!((x - y).abs() < 1e-6, "K mismatch for {label}: {x} vs {y}");
+    }
+
+    let trials = 7;
+    let old_ns = time_best_of(trials, iters, || {
+        let mut q = q_init.clone();
+        let mut k = k_init.clone();
+        rope_recompute_per_head(
+            std::hint::black_box(&mut q), std::hint::black_box(&mut k),
+            pos, head_dim, rotary_dim, theta,
+        );
+    });
+    let new_ns = time_best_of(trials, iters, || {
+        let mut q = q_init.clone();
+        let mut k = k_init.clone();
+        rope_precomputed_table(
+            std::hint::black_box(&mut q), std::hint::black_box(&mut k),
+            pos, head_dim, rotary_dim, theta,
+        );
+    });
+
+    let old_us = old_ns / 1000.0;
+    let new_us = new_ns / 1000.0;
+    let speedup = old_us / new_us;
+
+    println!(
+        "{label:<28} (rotary_dim={rotary_dim:>3}) old: {old_us:>7.3} us/op   new: {new_us:>7.3} us/op   speedup: {speedup:>5.2}x  [best of {trials}]"
+    );
+}
+
+fn main() {
+    println!("cpu_rope: old (sin/cos/powf recomputed per head) vs new (precomputed once per call)\n");
+
+    let iters = 20_000;
+    // Sliding-window layers: rotary_dim == head_dim (full rotation).
+    bench_one("sliding-window layer", 256, 256, 10_000.0, 128, iters);
+    // Full-attention layers: rotary_dim == head_dim/4 (partial_rotary_factor=0.25).
+    bench_one("full-attention layer", 512, 128, 1_000_000.0, 128, iters);
+
+    println!(
+        "\ncpu_rope runs once per decoder layer regardless of GPU availability — RoPE stays \
+on the CPU even when linear projections are GPU-accelerated. Each call previously \
+recomputed rotary_dim/2 sin_cos+powf pairs once per head (8 query heads + 1 key head \
+for Gemma4-E2B) even though they don't depend on which head is being rotated; \
+precomputing them once per call removes 8x (sliding-window) redundant transcendental \
+function calls, 35 layers per decode step."
+    );
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -270,6 +270,19 @@ pub fn cpu_gelu(x: &[f32]) -> Vec<f32> {
 
 /// RoPE: apply rotary positional embedding to q and k.
 /// pos: token position, x: [num_heads, head_dim], rotary_dim = dims to rotate
+///
+/// The per-index rotation angle (and hence its `sin`/`cos`) depends only on
+/// `pos`, `i`, `rotary_dim`, and `theta` — the same values for every head,
+/// and the same for Q and K (both are called with the same `rotary_dim`/
+/// `theta` here). The previous implementation recomputed `theta.powf(..)`
+/// and `angle.sin_cos()` (both transcendental, i.e. genuinely expensive —
+/// unlike a plain multiply/add) inside the per-head loop, so a single
+/// decode step paid for `rotary_dim/2` of each per *head* (8 query heads +
+/// up to 1 key head for Gemma4-E2B) instead of just once. Precomputing the
+/// `(sin, cos)` table once and reusing it across every head removes that
+/// redundant work entirely — same math, computed once instead of up to 9
+/// times, with no change in the result (every head applies the exact same
+/// precomputed rotation it would otherwise have recomputed itself).
 pub fn cpu_rope(
     q: &mut [f32], k: &mut [f32],
     pos: usize,
@@ -279,12 +292,16 @@ pub fn cpu_rope(
     rotary_dim: usize,
     theta: f32,
 ) {
-    let rotate_head = |x: &mut [f32], pos: usize, head_dim: usize, rotary_dim: usize, theta: f32| {
-        let half = rotary_dim / 2;
-        for i in 0..half {
-            let freq = 1.0 / theta.powf(i as f32 * 2.0 / rotary_dim as f32);
-            let angle = pos as f32 * freq;
-            let (s, c) = angle.sin_cos();
+    let half = rotary_dim / 2;
+    let mut sin_cos: Vec<(f32, f32)> = Vec::with_capacity(half);
+    for i in 0..half {
+        let freq = 1.0 / theta.powf(i as f32 * 2.0 / rotary_dim as f32);
+        let angle = pos as f32 * freq;
+        sin_cos.push(angle.sin_cos());
+    }
+
+    let rotate_head = |x: &mut [f32], sin_cos: &[(f32, f32)]| {
+        for (i, &(s, c)) in sin_cos.iter().enumerate() {
             let x0 = x[i];
             let x1 = x[i + half];
             x[i]        = x0 * c - x1 * s;
@@ -295,11 +312,11 @@ pub fn cpu_rope(
 
     for h in 0..num_q_heads {
         let slice = &mut q[h * head_dim..(h + 1) * head_dim];
-        rotate_head(slice, pos, head_dim, rotary_dim, theta);
+        rotate_head(slice, &sin_cos);
     }
     for h in 0..num_kv_heads {
         let slice = &mut k[h * head_dim..(h + 1) * head_dim];
-        rotate_head(slice, pos, head_dim, rotary_dim, theta);
+        rotate_head(slice, &sin_cos);
     }
 }
 


### PR DESCRIPTION
## What

`cpu_rope` applies rotary positional embedding to every query head (8 for Gemma4-E2B) and key head (1, multi-query attention) in the current decoder layer. Its per-index rotation angle depends only on `pos`, `i`, `rotary_dim`, and `theta` — the same four inputs for every head in a given call. The previous implementation recomputed `theta.powf(..)` and `angle.sin_cos()` (genuinely expensive transcendental functions) **inside the per-head loop**, so a single call paid for `rotary_dim/2` of each per *head* (up to 9 times) instead of once.

This hoists the `(sin, cos)` table computation out of the per-head loop into one pass, then has every head's rotation read from that shared table. Same math, computed once instead of up to 9 times — a pure redundant-work removal, not a behavioural change, so both the GPU-accelerated decode path and the pure-CPU reference path (both call this same function) benefit identically.

## Verification

New standalone microbenchmark `examples/bench_rope.rs` (CPU-only, no GPU/checkpoint needed, same methodology as `bench_sdpa.rs`): asserts old and new implementations agree to 1e-6, then times both at the two RoPE configurations Gemma4-E2B actually uses:

```
sliding-window layer (rotary_dim=256): 15.87us -> 1.76us   (9.01x)
full-attention layer (rotary_dim=128): 7.60us  -> 1.15us   (6.61x)
```

Consistent across repeated runs (9.01-9.02x and 6.60-6.62x). Unlike this series' other recent findings (mostly 1.1-1.5x wins specific to this GPU/driver's dispatch-overhead profile), this is a pure CPU algorithmic fix with **no GPU/driver dependency at all** — RoPE runs on the CPU regardless of which backend handles the linear projections, so this benefits every platform this plugin targets, including bare-metal CUDA/ROCm/Metal-equivalent setups where GPU-submit overhead is much lower and this CPU cost is proportionally a larger share of total decode time.

Also fixes a pre-existing clippy warning as a side effect (`unused variable: head_dim` on the old closure) — confirmed by diffing the full warning list: one *fewer* warning than `main`, no new ones.

`cargo build --release`, `cargo test --release` (all 7 existing GPU tests still pass, including `gpu_input_layernorm_matches_cpu_reference` which exercises this exact function on both paths), and `cargo clippy --release --all-targets` are all clean.
