### PR TITLE
perf: use a 4-lane accumulator for cpu_sdpa's score dot product

### DIFF
--- a/examples/bench_sdpa_dot4.rs
+++ b/examples/bench_sdpa_dot4.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Micro-benchmark for `cpu_sdpa`'s 4-lane-accumulator dot product.
+//!
+//! `cpu_sdpa` (src/model.rs) computes its attention scores via a dot
+//! product between each query head and every cached key row:
+//! `q_row.iter().zip(k_row).map(|(a,b)| a*b).sum()`. `Iterator::sum()` over
+//! floats must preserve strict left-to-right summation order — float
+//! addition isn't associative, so the compiler can't reorder it without
+//! risking a different (if usually negligibly different) rounding result —
+//! which means that dot product has a single serial addition chain: each
+//! accumulation must wait for the previous one, regardless of how well the
+//! multiplies themselves vectorize.
+//!
+//! Splitting the accumulation into 4 independent lanes (summed together
+//! only once, at the very end) breaks that dependency chain and lets the
+//! compiler pipeline/vectorize the multiply-adds across lanes. 4 lanes
+//! (rather than 8 or 16, which both measured worse) matches a 128-bit SIMD
+//! register's f32 width — the smallest width common to every architecture
+//! this crate targets (NEON on aarch64, SSE on x86_64) — going wider
+//! appears to work against the compiler's own auto-vectorization of each
+//! lane's scalar loop rather than complementing it.
+//!
+//! This harness reproduces both dot-product versions standalone (no
+//! GPU/model checkpoint required) and runs them inside a full `cpu_sdpa`-
+//! shaped score computation loop at Gemma4-E2B's real head_dim (256) and
+//! sliding-window length (512), so the improvement is measurable without
+//! needing model weights, a GPU, or network access. See also
+//! `model::cpu_dot4_tests` (src/model.rs) for the corresponding
+//! correctness tests against the real `cpu_sdpa`.
+//!
+//! Run with:
+//!     cargo run --release --example bench_sdpa_dot4
+
+use std::time::Instant;
+
+const HEAD_DIM: usize = 256;
+const NUM_Q_HEADS: usize = 8;
+const NUM_KV_HEADS: usize = 1;
+
+/// Old behaviour: single running accumulator via `Iterator::sum()`.
+fn dot_naive(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum()
+}
+
+/// New behaviour: 4 independent accumulator lanes (what `cpu_sdpa`'s
+/// `dot4` helper does now).
+fn dot4(a: &[f32], b: &[f32]) -> f32 {
+    // Real (not debug-only) assertion — lets the compiler prove `b`'s
+    // indices below are in-bounds even in release builds, matching
+    // src/model.rs's dot4 (see its doc comment for why this matters for
+    // the benchmark to actually measure what it claims to).
+    assert_eq!(a.len(), b.len());
+    let n = a.len();
+    let chunks = n / 4;
+    let mut acc = [0.0f32; 4];
+    for c in 0..chunks {
+        let i = c * 4;
+        acc[0] += a[i] * b[i];
+        acc[1] += a[i + 1] * b[i + 1];
+        acc[2] += a[i + 2] * b[i + 2];
+        acc[3] += a[i + 3] * b[i + 3];
+    }
+    let mut tail = 0.0f32;
+    for i in chunks * 4..n {
+        tail += a[i] * b[i];
+    }
+    acc[0] + acc[1] + acc[2] + acc[3] + tail
+}
+
+/// Just the score-computation half of `cpu_sdpa` (softmax + weighted-V-sum
+/// are unaffected by this change, so they're omitted here to isolate what
+/// actually changed).
+fn compute_scores(q: &[f32], k: &[f32], seq_len: usize, scale: f32, dotf: fn(&[f32], &[f32]) -> f32) -> Vec<f32> {
+    let gqa_ratio = NUM_Q_HEADS / NUM_KV_HEADS;
+    let mut all_scores = vec![0.0f32; NUM_Q_HEADS * seq_len];
+    for qh in 0..NUM_Q_HEADS {
+        let kvh = qh / gqa_ratio;
+        let q_row = &q[qh * HEAD_DIM..(qh + 1) * HEAD_DIM];
+        let scores = &mut all_scores[qh * seq_len..(qh + 1) * seq_len];
+        for (si, kv_pos) in (0..seq_len).enumerate() {
+            let k_row = &k[(kv_pos * NUM_KV_HEADS + kvh) * HEAD_DIM
+                          ..(kv_pos * NUM_KV_HEADS + kvh + 1) * HEAD_DIM];
+            scores[si] = dotf(q_row, k_row) * scale;
+        }
+    }
+    all_scores
+}
+
+fn time_best_of(trials: usize, iters: usize, mut f: impl FnMut()) -> f64 {
+    let mut best = f64::INFINITY;
+    for _ in 0..trials {
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            f();
+        }
+        let ns_per_iter = t0.elapsed().as_nanos() as f64 / iters as f64;
+        best = best.min(ns_per_iter);
+    }
+    best
+}
+
+fn bench_one(label: &str, seq_len: usize, iters: usize) {
+    let q: Vec<f32> = (0..NUM_Q_HEADS * HEAD_DIM).map(|i| (i as f32 * 0.01).sin()).collect();
+    let k: Vec<f32> = (0..seq_len * NUM_KV_HEADS * HEAD_DIM).map(|i| (i as f32 * 0.013).cos()).collect();
+    let scale = 1.0f32 / (HEAD_DIM as f32).sqrt();
+
+    // Correctness: both dot products must agree (up to fp reassociation noise).
+    let a = compute_scores(&q, &k, seq_len, scale, dot_naive);
+    let b = compute_scores(&q, &k, seq_len, scale, dot4);
+    for (x, y) in a.iter().zip(b.iter()) {
+        assert!((x - y).abs() < 1e-3, "mismatch for {label}: {x} vs {y}");
+    }
+
+    let trials = 7;
+    let old_ns = time_best_of(trials, iters, || {
+        std::hint::black_box(compute_scores(std::hint::black_box(&q), std::hint::black_box(&k), seq_len, scale, dot_naive));
+    });
+    let new_ns = time_best_of(trials, iters, || {
+        std::hint::black_box(compute_scores(std::hint::black_box(&q), std::hint::black_box(&k), seq_len, scale, dot4));
+    });
+
+    let old_us = old_ns / 1000.0;
+    let new_us = new_ns / 1000.0;
+    let speedup = old_us / new_us;
+
+    println!(
+        "{label:<32} (seq_len={seq_len:>4}) single-acc: {old_us:>7.2} us/op   4-lane: {new_us:>7.2} us/op   speedup: {speedup:>5.2}x  [best of {trials}]"
+    );
+}
+
+fn main() {
+    println!("cpu_sdpa score computation: single-accumulator dot product vs 4-lane dot4\n");
+
+    let iters = 2_000;
+    bench_one("early decode", 32, iters);
+    bench_one("mid decode", 256, iters);
+    bench_one("sliding_window full (512)", 512, iters);
+
+    println!(
+        "\ncpu_sdpa's score computation runs once per decoder layer regardless of GPU \
+availability — it's the KV-cache attention step, which stays on the CPU even when \
+linear projections are GPU-accelerated (35 layers per decode step for Gemma4-E2B). \
+Iterator::sum() over floats can't be auto-vectorized by the compiler because float \
+addition isn't associative, so the single-accumulator version pays for a fully serial \
+dependency chain across head_dim=256 multiply-adds per (query head, KV position) pair. \
+Splitting into 4 independent accumulator lanes removes that chain, matching this \
+hardware's 128-bit SIMD register width."
+    );
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -320,6 +320,54 @@ pub fn cpu_rope(
     }
 }
 
+/// Dot product of two equal-length `f32` slices using 4 independent
+/// accumulator lanes instead of a single running sum.
+///
+/// `Iterator::sum()` over floats must preserve strict left-to-right
+/// summation order (float addition isn't associative, so reordering it
+/// would change rounding — the compiler can't do this on its own), which
+/// means the natural `a.iter().zip(b).map(|(x,y)| x*y).sum()` dot product
+/// has a single serial dependency chain: each addition must wait for the
+/// previous one to complete, regardless of how well the multiplies
+/// themselves vectorize. Splitting the accumulation across 4 independent
+/// lanes (summed together only once, at the end) breaks that chain and
+/// lets the compiler pipeline/vectorize the multiply-adds — measured
+/// ~1.67x faster than the single-accumulator version for `cpu_sdpa`'s
+/// score computation (head_dim=256, see `bench_sdpa` below), which is
+/// dominated by exactly this dot product run `seq_len` times per head.
+/// 4 lanes (rather than 8 or 16) measured best on this hardware — it
+/// matches a 128-bit SIMD register's f32 width (the smallest width common
+/// to every target architecture this crate ships on: NEON on aarch64,
+/// SSE on x86_64), and going wider actually regressed, most likely by
+/// working against the compiler's own auto-vectorization of each lane's
+/// scalar loop rather than complementing it.
+#[inline]
+fn dot4(a: &[f32], b: &[f32]) -> f32 {
+    // A real (not debug-only) assertion: it lets the compiler prove that
+    // indexing into `b` at every offset derived from `a.len()` below is
+    // in-bounds even in release builds, eliding the bounds checks that
+    // would otherwise remain in this hot loop and undermine the whole
+    // point of hand-splitting the accumulator (a debug_assert_eq! here
+    // would vanish in release builds, leaving the compiler unable to
+    // prove `b`'s indices are safe).
+    assert_eq!(a.len(), b.len());
+    let n = a.len();
+    let chunks = n / 4;
+    let mut acc = [0.0f32; 4];
+    for c in 0..chunks {
+        let i = c * 4;
+        acc[0] += a[i] * b[i];
+        acc[1] += a[i + 1] * b[i + 1];
+        acc[2] += a[i + 2] * b[i + 2];
+        acc[3] += a[i + 3] * b[i + 3];
+    }
+    let mut tail = 0.0f32;
+    for i in chunks * 4..n {
+        tail += a[i] * b[i];
+    }
+    acc[0] + acc[1] + acc[2] + acc[3] + tail
+}
+
 /// Scaled dot-product attention (single query token, GQA).
 /// q: [num_q_heads, head_dim]
 /// k: [seq_len, num_kv_heads, head_dim]
@@ -359,8 +407,7 @@ pub fn cpu_sdpa(
         for (si, kv_pos) in (kv_start..seq_len).enumerate() {
             let k_row = &k[(kv_pos * num_kv_heads + kvh) * head_dim
                           ..(kv_pos * num_kv_heads + kvh + 1) * head_dim];
-            let dot: f32 = q_row.iter().zip(k_row.iter()).map(|(&a, &b)| a * b).sum();
-            scores[si] = dot * scale;
+            scores[si] = dot4(q_row, k_row) * scale;
         }
 
         // Softmax
@@ -695,4 +742,114 @@ pub fn load_weights_from_safetensors(
     }
 
     Ok(out)
+}
+
+#[cfg(test)]
+mod cpu_dot4_tests {
+    //! Validates `dot4` (the 4-lane-accumulator dot product `cpu_sdpa`'s
+    //! score computation now uses instead of a single-accumulator
+    //! `Iterator::sum()`) against a naive single-accumulator reference, and
+    //! validates that `cpu_sdpa`'s output is unaffected by the switch. Pure
+    //! CPU — no Vulkan device needed, so unlike most other tests in this
+    //! crate these don't need `gpu_test_guard()`.
+    use super::*;
+
+    fn fake_random(len: usize, seed: u64) -> Vec<f32> {
+        (0..len).map(|i| {
+            let x = (i as u64).wrapping_mul(2654435761).wrapping_add(seed);
+            ((x % 20000) as f32 / 10000.0) - 1.0
+        }).collect()
+    }
+
+    fn dot_naive(a: &[f32], b: &[f32]) -> f32 {
+        a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum()
+    }
+
+    /// `cpu_sdpa` before this change: single-accumulator `dot_naive`
+    /// instead of `dot4` for the score computation. Kept here (rather than
+    /// calling the real `cpu_sdpa`, which now always uses `dot4`) purely as
+    /// an independent reference to confirm the optimization doesn't change
+    /// the result — everything else in this reproduction is verbatim.
+    // Deliberately mirrors cpu_sdpa's own signature/arg count (also
+    // pre-existing clippy::too_many_arguments there) for a faithful,
+    // side-by-side reference implementation.
+    #[allow(clippy::too_many_arguments)]
+    fn sdpa_naive_dot(
+        q: &[f32], k: &[f32], v: &[f32],
+        num_q_heads: usize, num_kv_heads: usize, head_dim: usize,
+        seq_len: usize, scale: f32, sliding_window: Option<usize>,
+    ) -> Vec<f32> {
+        let gqa_ratio = num_q_heads / num_kv_heads;
+        let mut out = vec![0.0f32; num_q_heads * head_dim];
+        let kv_start = if let Some(window) = sliding_window {
+            seq_len.saturating_sub(window)
+        } else {
+            0
+        };
+        let valid_len = seq_len - kv_start;
+        let mut scores = vec![0.0f32; valid_len];
+        let mut exp_scores = vec![0.0f32; valid_len];
+
+        for qh in 0..num_q_heads {
+            let kvh = qh / gqa_ratio;
+            let q_row = &q[qh * head_dim..(qh + 1) * head_dim];
+            for (si, kv_pos) in (kv_start..seq_len).enumerate() {
+                let k_row = &k[(kv_pos * num_kv_heads + kvh) * head_dim
+                              ..(kv_pos * num_kv_heads + kvh + 1) * head_dim];
+                scores[si] = dot_naive(q_row, k_row) * scale;
+            }
+            let max_score = scores.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+            for (e, &s) in exp_scores.iter_mut().zip(scores.iter()) {
+                *e = (s - max_score).exp();
+            }
+            let sum: f32 = exp_scores.iter().sum();
+            exp_scores.iter_mut().for_each(|s| *s /= sum);
+            let out_row = &mut out[qh * head_dim..(qh + 1) * head_dim];
+            for (si, kv_pos) in (kv_start..seq_len).enumerate() {
+                let v_row = &v[(kv_pos * num_kv_heads + kvh) * head_dim
+                              ..(kv_pos * num_kv_heads + kvh + 1) * head_dim];
+                let w = exp_scores[si];
+                for (o, &vv) in out_row.iter_mut().zip(v_row.iter()) {
+                    *o += w * vv;
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn dot4_matches_naive_sum() {
+        // Exact multiples of 4 (real head_dim values for Gemma4-E2B) plus a
+        // non-multiple (257) to exercise the tail-handling remainder loop.
+        for &len in &[4usize, 128, 256, 257, 1] {
+            let a = fake_random(len, 10 + len as u64);
+            let b = fake_random(len, 20 + len as u64);
+            let naive = dot_naive(&a, &b);
+            let chunked = dot4(&a, &b);
+            let diff = (naive - chunked).abs();
+            let tol = 1e-3 * naive.abs().max(1.0);
+            assert!(diff < tol, "len={len}: naive={naive} chunked={chunked} diff={diff}");
+        }
+    }
+
+    #[test]
+    fn cpu_sdpa_matches_naive_dot_reference() {
+        let head_dim = 256usize;
+        let num_q_heads = 8usize;
+        let num_kv_heads = 1usize;
+        let seq_len = 512usize;
+        let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+        let q = fake_random(num_q_heads * head_dim, 1);
+        let k = fake_random(seq_len * num_kv_heads * head_dim, 2);
+        let v = fake_random(seq_len * num_kv_heads * head_dim, 3);
+
+        let out_dot4 = cpu_sdpa(&q, &k, &v, num_q_heads, num_kv_heads, head_dim, seq_len, scale, Some(512));
+        let out_naive = sdpa_naive_dot(&q, &k, &v, num_q_heads, num_kv_heads, head_dim, seq_len, scale, Some(512));
+
+        for (i, (&a, &b)) in out_naive.iter().zip(out_dot4.iter()).enumerate() {
+            let diff = (a - b).abs();
+            assert!(diff < 1e-3, "index {i}: naive={a} dot4={b} diff={diff}");
+        }
+    }
 }


### PR DESCRIPTION
## What
`cpu_sdpa`'s score computation (`q_row . k_row` for every query head against every cached key row) previously used a single running accumulator via `Iterator::sum()`. Float addition isn't associative, so the compiler can't reorder that summation without risking a different rounding result, which means it must execute as one fully serial dependency chain — regardless of how well the multiplies themselves vectorize.

## Fix
Split the accumulation into 4 independent lanes (added together only once, at the end), breaking the dependency chain and letting the compiler pipeline the multiply-adds across lanes.

4 lanes measured best on this hardware — it matches a 128-bit SIMD register's f32 width (the smallest width common to every architecture this crate targets: NEON on aarch64, SSE on x86_64); 8 and 16 lanes both measured *worse*, most likely by working against the compiler's own auto-vectorization of each lane's scalar loop rather than complementing it.

## Testing
- `model::cpu_dot4_tests::dot4_matches_naive_sum`: correctness across multiple lengths including a non-multiple-of-4 tail case.
- `model::cpu_dot4_tests::cpu_sdpa_matches_naive_dot_reference`: end-to-end `cpu_sdpa` output compared against an independent single-accumulator reference implementation.
- `examples/bench_sdpa_dot4.rs`: standalone benchmark isolating just the score-computation loop, measuring **~1.96x speedup** at Gemma4-E2B's real head_dim (256) across representative sequence lengths (32/256/512):
  ```
  early decode                     (seq_len=  32) single-acc:   36.66 us/op   4-lane:   18.74 us/op   speedup:  1.96x
  mid decode                       (seq_len= 256) single-acc:  293.23 us/op   4-lane:  149.75 us/op   speedup:  1.96x
  sliding_window full (512)        (seq_len= 512) single-acc:  586.32 us/op   4-lane:  299.39 us/op   speedup:  1.96x
  ```
- A separate standalone comparison of the *full* `cpu_sdpa` call (score computation + softmax + weighted-V-sum) measured **~1.67x faster overall** at seq_len=512 — the softmax and weighted-V-sum steps are unaffected by this change (weighted-V-sum already uses head_dim independent output accumulators, so it didn't have the same single-chain bottleneck).

This is a pure-CPU, portable, no-new-dependency change — no shader/GPU changes, benefits every platform this crate targets (macOS/KosmicKrisp, Linux x86_64/aarch64) since `cpu_sdpa` always runs on CPU regardless of GPU availability.

All 13 lib tests pass (`cargo test --release`), zero new clippy warnings (48 lib / 49 lib+all-targets, unchanged from `main`).