### PR TITLE
fix: stop defeating the GPU weight cache with a premature .float() call

### DIFF
--- a/tests/python/test_vulkan_ops.py
+++ b/tests/python/test_vulkan_ops.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for vllm_vulkan.vulkan_ops's persistent GPU weight cache.
+
+_WeightCache (vulkan_ops.py) keys cached GPU weight uploads on
+`id(weight.untyped_storage())`, on the assumption that the same nn.Module's
+`.weight` Parameter object (same storage) is passed in on every forward
+call, so the (potentially large) weight matrix only needs to be uploaded to
+the GPU once, not on every single token.
+
+That assumption is silently broken if a caller converts the weight tensor
+(e.g. via `.float()`) *before* passing it into vulkan_ops — `Tensor.float()`
+allocates a brand-new tensor with brand-new storage whenever the source
+isn't already float32 (true for any bf16/fp16-loaded model, the common
+case), so the cache key is different on every call and every call re-does
+the full host->device upload. See model_runner.py's `_wrap_linear` (fixed
+alongside these tests) for the real-world case this reproduces.
+
+These tests count actual uploads via `_WeightCache.put` rather than
+inspecting `len(_weight_cache)` at the end: the cache is weak-ref keyed on
+`id(storage)`, and CPython can reuse a freed tensor's memory address for a
+later allocation, so a *fresh* upload every call can still coincidentally
+leave the dict at a stable size — a real (if rare) source of test flakiness
+that counting actual `put()` calls avoids entirely.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+_rs = pytest.importorskip("vllm_vulkan._rs", exc_type=ImportError)
+
+from vllm_vulkan import vulkan_ops  # noqa: E402
+
+
+def _require_vulkan_context():
+    if not _rs.is_available():
+        pytest.skip("no Vulkan device available")
+    try:
+        ctx = _rs.VulkanContext(0)
+    except RuntimeError as exc:
+        pytest.skip(f"VulkanContext unavailable: {exc}")
+    if "mul_mat_vec_f32_f32_f32_subgroup" not in ctx.available_shaders():
+        pytest.skip("mul_mat_vec_f32_f32_f32_subgroup shader unavailable")
+    return ctx
+
+
+@pytest.fixture
+def vulkan_ctx():
+    ctx = _require_vulkan_context()
+    prev_ctx = vulkan_ops._ctx
+    vulkan_ops.set_context(ctx)
+    if vulkan_ops._ctx is None:
+        pytest.skip("Vulkan device is a software renderer; GPU dispatch disabled")
+    prev_cache = vulkan_ops._weight_cache
+    vulkan_ops._weight_cache = vulkan_ops._WeightCache()
+    try:
+        yield ctx
+    finally:
+        vulkan_ops._ctx = prev_ctx
+        vulkan_ops._weight_cache = prev_cache
+
+
+@pytest.fixture
+def upload_counter(monkeypatch):
+    """Count real GPU uploads (_WeightCache.put calls) deterministically,
+    independent of the weak-ref cache's final size (see module docstring
+    for why the latter can be misleading)."""
+    counts = {"n": 0}
+    orig_put = vulkan_ops._WeightCache.put
+
+    def counting_put(self, w, gpu):
+        counts["n"] += 1
+        return orig_put(self, w, gpu)
+
+    monkeypatch.setattr(vulkan_ops._WeightCache, "put", counting_put)
+    return counts
+
+
+def test_get_or_upload_weight_hits_cache_for_same_tensor_object(
+    vulkan_ctx, upload_counter
+):
+    """Baseline sanity check: calling _get_or_upload_weight twice with the
+    exact same tensor object must only upload once."""
+    weight = torch.randn(8, 4, dtype=torch.float32)
+
+    gpu1 = vulkan_ops._get_or_upload_weight(vulkan_ctx, weight)
+    assert gpu1 is not None
+    assert upload_counter["n"] == 1
+
+    gpu2 = vulkan_ops._get_or_upload_weight(vulkan_ctx, weight)
+    assert gpu2 is gpu1, "second call with the same tensor object should hit the cache"
+    assert upload_counter["n"] == 1, "cache hit must not trigger another upload"
+
+
+def test_linear_reuses_weight_cache_across_calls_with_bf16_weight(
+    vulkan_ctx, upload_counter
+):
+    """The actual bug: a bf16 weight (the common case for LLM inference)
+    passed into vulkan_ops.linear() repeatedly - as model_runner.py's
+    persistent nn.Module.weight Parameter would be, across every decode
+    step - must hit the GPU weight cache on every call after the first,
+    rather than re-uploading the whole matrix every time.
+
+    This only passes if vulkan_ops.linear()/_vulkan_matvec() never
+    convert `weight` to float32 before it reaches _get_or_upload_weight
+    (the conversion must happen lazily, only on a cache miss).
+    """
+    out_features, in_features = 16, 8
+    weight = torch.randn(out_features, in_features, dtype=torch.bfloat16)
+    x = torch.randn(1, in_features, dtype=torch.float32)  # T=1 < _MATVEC_THRESHOLD
+
+    vulkan_ops.linear(x, weight, None)
+    assert upload_counter["n"] == 1, "first call should upload once"
+
+    for _ in range(5):
+        vulkan_ops.linear(x, weight, None)
+    assert upload_counter["n"] == 1, (
+        "repeated calls with the same weight object must hit the cache, "
+        "not re-upload the weight matrix on every call"
+    )
+
+
+def test_wrap_linear_reuses_weight_cache_across_repeated_forward_calls(
+    vulkan_ctx, upload_counter
+):
+    """End-to-end regression test for the model_runner.py bug: a wrapped
+    Linear module's forward(), called repeatedly (as it would be once per
+    decode step), must not defeat the weight cache by pre-converting
+    `weight` with `.float()` before calling vulkan_ops.linear() - that
+    would give every call a fresh tensor identity and always miss.
+    """
+    from vllm_vulkan.model_runner import _wrap_linear  # noqa: PLC0415
+
+    # requires_grad=False matches real inference weights (vLLM always runs
+    # inference-only, never training) - without it, weight.float() produces
+    # a tensor that still requires grad, and the later .numpy() call inside
+    # _to_bytes fails, an unrelated test-construction pitfall rather than
+    # anything about the cache behaviour actually under test here.
+    module = torch.nn.Linear(8, 16, bias=True)
+    module.weight = torch.nn.Parameter(
+        module.weight.detach().to(torch.bfloat16), requires_grad=False
+    )
+    module.bias = torch.nn.Parameter(
+        module.bias.detach().to(torch.bfloat16), requires_grad=False
+    )
+
+    _wrap_linear(module)
+
+    x = torch.randn(1, 8, dtype=torch.float32)  # T=1: decode-shaped input
+    module.forward(x)
+    assert upload_counter["n"] == 1, "first forward() should upload once"
+
+    for _ in range(5):
+        module.forward(x)
+    assert upload_counter["n"] == 1, (
+        "repeated forward() calls (as happen once per decode step in real "
+        "usage) must hit the weight cache, not re-upload the weight matrix "
+        "on every single call"
+    )

--- a/vllm_vulkan/model_runner.py
+++ b/vllm_vulkan/model_runner.py
@@ -264,7 +264,18 @@ def _wrap_linear(module: nn.Module) -> None:
         row_reduce = getattr(module, "reduce_results", False) and tp_size > 1
         matmul_bias = None if (row_reduce or skip_bias) else bias
         try:
-            result = vulkan_ops.linear(x.float(), weight.float(), matmul_bias)
+            # weight is passed through as-is (NOT weight.float()) so its
+            # tensor identity - and hence vulkan_ops's persistent GPU
+            # weight cache, keyed on id(weight.untyped_storage()) - stays
+            # stable across every call. weight.float() would allocate a
+            # brand-new tensor (and storage) whenever weight isn't already
+            # float32 (true for any bf16/fp16-loaded model, the common
+            # case), silently defeating the cache and forcing a full
+            # weight-matrix re-upload to the GPU on every single forward
+            # call instead of once. vulkan_ops.linear()/_vulkan_matvec()
+            # do their own float32 conversion internally, lazily, only on
+            # a cache miss (see _get_or_upload_weight).
+            result = vulkan_ops.linear(x.float(), weight, matmul_bias)
             result = result.to(x.dtype)
         except Exception as exc:
             logger.debug("Vulkan linear failed (%s)", exc)

--- a/vllm_vulkan/vulkan_ops.py
+++ b/vllm_vulkan/vulkan_ops.py
@@ -259,17 +259,21 @@ def _vulkan_matvec(
     weight: torch.Tensor,  # [N, K] any dtype
 ) -> torch.Tensor:
     """Dispatch mul_mat_vec_f32_f32_f32_subgroup for decode (T<4)."""
-    # Cache key on original weight (before .float())
+    # Cache key on original weight (before .float()) - and the .float()
+    # conversion itself only happens lazily, in the `w_gpu is None`
+    # fallback branch below, since on the (overwhelmingly common) cache-hit
+    # path the GPU-resident buffer already holds the converted weight and
+    # recomputing weight.float() here would just be a wasted full
+    # weight-matrix copy, every single call, for a value nothing else uses.
     w_gpu = _get_or_upload_weight(ctx, weight)
-    weight_f32 = weight.float()
 
     T, K = x.shape  # noqa: N806
-    N = weight_f32.shape[0]  # noqa: N806
+    N = weight.shape[0]  # noqa: N806
     pc = _matvec_pc(T, K, N)
     x_bytes = _to_bytes(x)
     out_size = T * N * 4
 
-    w_binding = w_gpu if w_gpu is not None else _to_bytes(weight_f32)
+    w_binding = w_gpu if w_gpu is not None else _to_bytes(weight.float())
 
     results = ctx.execute_batch(
         [


### PR DESCRIPTION
## What
`vulkan_ops._WeightCache` (`vulkan_ops.py`) keys cached GPU weight uploads on `id(weight.untyped_storage())`, on the assumption that the same `nn.Module`'s persistent `.weight` Parameter object is passed in on every forward call, so a (potentially large) weight matrix only needs to be uploaded to the GPU once, not on every single token.

`model_runner.py`'s `_wrap_linear` (the vLLM Linear-module dispatch hook — the actual "`vllm serve`"-integrated path this plugin documents as its primary usage, distinct from the standalone `VulkanModel` server) called `vulkan_ops.linear(x.float(), weight.float(), matmul_bias)` — converting `weight` with `.float()` **before** passing it in. `Tensor.float()` allocates a brand-new tensor with brand-new storage whenever the source isn't already float32 (true for any bf16/fp16-loaded model, the common case), so the cache key was different on every single call, and every call re-did the full host→device weight upload instead of reusing the cached one — for every wrapped Linear module (q/k/v/o_proj, gate/up/down_proj, ...) in every decoder layer, **on every single token**.

`vulkan_ops.py`'s own `_vulkan_matvec` compounded this: even on a cache hit, it unconditionally recomputed `weight.float()` right after `_get_or_upload_weight` — a second full weight-matrix copy used only for `.shape[0]` (dtype-independent, didn't need the conversion at all) and a fallback byte-encoding path only reachable when the GPU upload itself failed.

## Measured impact
For a single Linear call at a realistic Gemma4-E2B FFN shape (k=1536, n=6144, bf16 weight) on this hardware:
- Cache defeated (before): **~13.1ms/call**
- Cache working (after): **~0.94ms/call**
- **~13.9x speedup** — compounding across every Linear module (~7 per layer) in every decoder layer (26-34 for typical models), on every token.

## Fix
- `model_runner.py`: `_wrap_linear` now passes the original weight object through unconverted, preserving its identity for the cache.
- `vulkan_ops.py`: `_vulkan_matvec`'s `weight.float()` is now lazy (only computed in the `w_gpu is None` fallback branch), and `N` is read from `weight.shape[0]` directly (shape doesn't depend on dtype).

## Testing
Added `tests/python/test_vulkan_ops.py` (3 new tests, using a real Vulkan device, skips cleanly without one):
- Baseline cache-hit sanity check (`_get_or_upload_weight`)
- A `vulkan_ops.linear()`-level regression test
- An end-to-end `_wrap_linear` regression test — the one that actually reproduces the bug (the other two don't go through the buggy call site and pass either way)

All three count real uploads via a `_WeightCache.put` wrapper rather than inspecting final cache size, since the weak-ref keyed cache's dict size can — misleadingly — stay stable even when every call is a fresh miss, if CPython happens to reuse a freed tensor's memory address for the next allocation (verified this empirically while writing the test). Verified the regression test fails (6 uploads for 6 calls) on the pre-fix code and passes (1 upload) after. Verified output correctness is unaffected (l2 rel err 0.0 vs a `torch.nn.functional.linear` reference).

`ruff`/`mypy` clean; all 32 Python tests pass (2 skipped, no vllm installed in this environment); no Rust changes, so all 19 lib tests continue to pass unaffected.