### PR TITLE
perf: vectorize the pure-Python compute_slot_mapping fallback

### DIFF
--- a/tests/python/test_patches.py
+++ b/tests/python/test_patches.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for vllm_vulkan.patches's pure-Python compute_slot_mapping fallback.
+
+_pure_python_compute_slot_mapping (patches.py) is only installed when
+vllm._C (the compiled C++ extension) isn't available - a fallback for
+running vLLM from its Python source tree without building the C++
+extensions. It used to loop over range(num_reqs) in Python, calling
+.item() twice per request (forcing a CPU/tensor sync each time) purely to
+slice positions/slot_mapping and index one block_table row at a time - work
+now done in one vectorized pass instead.
+
+These tests compare the vectorized implementation against a verbatim copy
+of the original per-request-loop version (kept here as an independent
+reference, not a copy of the new implementation), across several batch
+shapes including empty requests, and measure the speedup at a more
+realistic concurrent-batch size. No Vulkan device or vllm install needed -
+this is pure PyTorch/Python logic.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from vllm_vulkan.patches import _pure_python_compute_slot_mapping  # noqa: E402
+
+
+def _reference_compute_slot_mapping_loop(
+    num_tokens: int,
+    max_num_tokens: int,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+    block_table: torch.Tensor,
+    block_table_stride: int,
+    block_size: int,
+    slot_mapping: torch.Tensor,
+) -> None:
+    """Verbatim copy of _pure_python_compute_slot_mapping's original
+    per-request Python loop, kept as an independent reference (not derived
+    from the vectorized implementation under test)."""
+    num_reqs = query_start_loc.shape[0] - 1
+
+    for req_idx in range(num_reqs):
+        start = int(query_start_loc[req_idx].item())
+        end = int(query_start_loc[req_idx + 1].item())
+        if start >= end:
+            continue
+
+        pos_slice = positions[start:end]
+        block_indices = (pos_slice // block_size).long()
+        row = block_table[req_idx]
+        block_ids = row[block_indices].long()
+        offsets = (pos_slice % block_size).long()
+        slots = block_ids * block_size + offsets
+        slot_mapping[start:end] = slots
+
+
+def _make_batch(
+    seed: int, req_lens: list[int], block_size: int, max_blocks_per_req: int
+):
+    torch.manual_seed(seed)
+    num_tokens = sum(req_lens)
+    num_reqs = len(req_lens)
+
+    query_start_loc = torch.zeros(num_reqs + 1, dtype=torch.int32)
+    query_start_loc[1:] = torch.tensor(req_lens, dtype=torch.int32).cumsum(0)
+
+    # Random positions within a plausible sequence length range, per request.
+    positions = torch.cat(
+        [torch.randperm(max(1, ln * 3))[:ln].sort().values.long() for ln in req_lens]
+        if num_tokens > 0
+        else [torch.zeros(0, dtype=torch.int64)]
+    )
+    assert positions.shape[0] == num_tokens
+
+    block_table = torch.randint(
+        0, 1000, (num_reqs, max_blocks_per_req), dtype=torch.int32
+    )
+    return num_tokens, query_start_loc, positions, block_table
+
+
+@pytest.mark.parametrize(
+    ("req_lens", "block_size", "max_blocks_per_req"),
+    [
+        ([5], 4, 8),
+        ([3, 4, 2], 4, 8),
+        ([0, 5, 0, 3], 4, 8),  # some requests have zero tokens this step
+        ([1, 1, 1, 1, 1], 2, 4),
+        ([17, 0, 9, 0, 0, 23], 16, 16),
+        ([], 4, 8),  # no requests at all
+    ],
+)
+def test_vectorized_matches_reference_loop(
+    req_lens: list[int], block_size: int, max_blocks_per_req: int
+):
+    num_tokens, query_start_loc, positions, block_table = _make_batch(
+        0, req_lens, block_size, max_blocks_per_req
+    )
+    max_num_tokens = max(num_tokens, 1) * 2
+
+    slot_mapping_ref = torch.full((max_num_tokens,), -1, dtype=torch.int64)
+    slot_mapping_new = torch.full((max_num_tokens,), -1, dtype=torch.int64)
+
+    _reference_compute_slot_mapping_loop(
+        num_tokens,
+        max_num_tokens,
+        query_start_loc,
+        positions,
+        block_table,
+        block_table.shape[1],
+        block_size,
+        slot_mapping_ref,
+    )
+    _pure_python_compute_slot_mapping(
+        num_tokens,
+        max_num_tokens,
+        query_start_loc,
+        positions,
+        block_table,
+        block_table.shape[1],
+        block_size,
+        slot_mapping_new,
+    )
+
+    torch.testing.assert_close(slot_mapping_new, slot_mapping_ref)
+
+
+def test_vectorized_is_faster_at_a_realistic_batch_size():
+    # A moderately large concurrent-decode-style batch: many requests, one
+    # token each (the shape this fallback would see once per decode step).
+    req_lens = [1] * 128
+    num_tokens, query_start_loc, positions, block_table = _make_batch(
+        1, req_lens, block_size=16, max_blocks_per_req=64
+    )
+    max_num_tokens = num_tokens
+
+    def time_best_of(trials: int, iters: int, fn) -> float:
+        best = float("inf")
+        for _ in range(trials):
+            t0 = time.perf_counter()
+            for _ in range(iters):
+                fn()
+            dt = (time.perf_counter() - t0) / iters
+            best = min(best, dt)
+        return best
+
+    slot_mapping = torch.zeros(max_num_tokens, dtype=torch.int64)
+
+    old_s = time_best_of(
+        5,
+        50,
+        lambda: _reference_compute_slot_mapping_loop(
+            num_tokens,
+            max_num_tokens,
+            query_start_loc,
+            positions,
+            block_table,
+            block_table.shape[1],
+            16,
+            slot_mapping,
+        ),
+    )
+    new_s = time_best_of(
+        5,
+        50,
+        lambda: _pure_python_compute_slot_mapping(
+            num_tokens,
+            max_num_tokens,
+            query_start_loc,
+            positions,
+            block_table,
+            block_table.shape[1],
+            16,
+            slot_mapping,
+        ),
+    )
+
+    print(
+        f"\ncompute_slot_mapping ({len(req_lens)} reqs, 1 token each): "
+        f"loop {old_s * 1e6:.1f} us/call   vectorized {new_s * 1e6:.1f} us/call   "
+        f"speedup {old_s / new_s:.2f}x"
+    )
+    assert new_s < old_s, (
+        f"vectorized ({new_s * 1e6:.1f}us) was not faster than the "
+        f"per-request loop ({old_s * 1e6:.1f}us)"
+    )

--- a/vllm_vulkan/patches.py
+++ b/vllm_vulkan/patches.py
@@ -14,10 +14,8 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import torch
+import torch
 
 logger = logging.getLogger(__name__)
 
@@ -74,32 +72,53 @@ def _pure_python_compute_slot_mapping(
 
     Context Parallelism (TOTAL_CP_WORLD_SIZE > 1) is not supported on CPU,
     consistent with the original C++ implementation.
+
+    Vectorized across every request in one pass instead of a Python loop
+    over range(num_reqs): the original version called `.item()` twice per
+    request (forcing a CPU/tensor sync each time) purely to slice
+    `positions`/`slot_mapping` and index into `block_table` one request row
+    at a time - work that `torch.repeat_interleave` (to build a per-token
+    "which request do I belong to" index from `query_start_loc` without a
+    loop) plus a single fancy-indexed gather from `block_table` does in one
+    shot for the whole batch. This runs once per forward pass (prefill and
+    decode) whenever `vllm._C` isn't available, so the per-request Python/
+    tensor-sync overhead scaled with concurrent batch size on every call.
     """
     assert TOTAL_CP_WORLD_SIZE == 1, "Context Parallelism is not supported on CPU."
 
     num_reqs = query_start_loc.shape[0] - 1
+    if num_reqs <= 0 or num_tokens <= 0:
+        return
 
-    for req_idx in range(num_reqs):
-        start = int(query_start_loc[req_idx].item())
-        end = int(query_start_loc[req_idx + 1].item())
-        if start >= end:
-            continue
+    positions = positions[:num_tokens]
 
-        # positions for this request's tokens: shape [token_num]
-        pos_slice = positions[start:end]  # int64
+    # Per-token request index, built without a Python loop: repeat request
+    # index r exactly (query_start_loc[r+1] - query_start_loc[r]) times -
+    # requests with zero tokens this step (start == end) are naturally
+    # skipped, matching the original `if start >= end: continue`.
+    #
+    # query_start_loc is frequently a CPU tensor (often pinned memory) even
+    # when positions/block_table live on the active accelerator device, so
+    # req_ids_per_token (used to index block_table alongside block_indices,
+    # which is derived from positions) must be built on positions.device,
+    # not query_start_loc.device - indexing with tensors on mismatched
+    # devices raises a RuntimeError.
+    req_lens = (
+        (query_start_loc[1:] - query_start_loc[:-1])
+        .clamp(min=0)
+        .to(device=positions.device, dtype=torch.int64)
+    )
+    req_ids_per_token = torch.repeat_interleave(
+        torch.arange(num_reqs, dtype=torch.int64, device=positions.device),
+        req_lens,
+    )
 
-        # block indices within the block_table row: shape [token_num]
-        block_indices = (pos_slice // block_size).long()
+    block_indices = (positions // block_size).long()
+    block_ids = block_table[req_ids_per_token, block_indices].long()
+    offsets = (positions % block_size).long()
+    slots = block_ids * block_size + offsets
 
-        # physical block IDs from the block table: shape [token_num]
-        row = block_table[req_idx]  # shape [max_num_blocks_per_req], int32
-        block_ids = row[block_indices].long()  # int64 for arithmetic
-
-        # slot = block_id * block_size + position % block_size
-        offsets = (pos_slice % block_size).long()
-        slots = block_ids * block_size + offsets
-
-        slot_mapping[start:end] = slots
+    slot_mapping[:num_tokens] = slots
 
 
 class _FuncWrapper:


### PR DESCRIPTION
## What
`patches.py`'s `_pure_python_compute_slot_mapping` (the fallback for `vllm._C.compute_slot_mapping_kernel_impl`, installed whenever the compiled C++ extension isn't available — e.g. running vLLM from its Python source tree) looped over `range(num_reqs)` in Python, calling `.item()` twice per request purely to slice `positions`/`slot_mapping` and index one `block_table` row at a time. This runs once per forward pass (both prefill and decode), with the per-request Python/tensor-sync overhead scaling with concurrent batch size on every single call.

## Fix
Replaced the loop with a single vectorized pass over the whole batch: `torch.repeat_interleave` builds a per-token "which request do I belong to" index directly from `query_start_loc` (repeating request index `r` exactly `query_start_loc[r+1]-query_start_loc[r]` times — requests with zero tokens this step are naturally skipped, matching the original `if start >= end: continue`), then a single fancy-indexed gather from `block_table` replaces the per-request row lookup.

## Measured impact
For a batch of 128 concurrent single-token requests (the shape this fallback would see once per decode step under concurrent serving) on this hardware:
- Python loop: **~2.2ms/call**
- Vectorized: **~33us/call**
- **~66x speedup**

## Testing
Added `tests/python/test_patches.py`:
- `test_vectorized_matches_reference_loop`: 6 parametrized cases (single/multiple requests, requests with zero tokens interspersed, no requests at all) comparing the vectorized implementation against a verbatim, independently-kept copy of the original per-request-loop version.
- `test_vectorized_is_faster_at_a_realistic_batch_size`: the 66x measurement above, asserted as a real (not just claimed) speedup.

No vllm install or Vulkan device needed for these tests — pure PyTorch/Python logic. `ruff`/`mypy` clean; all 46 Python tests pass (2 skipped, no vllm installed in this environment); no Rust changes, so all 19 lib tests continue to pass unaffected.
