### PR TITLE
perf: remove two redundant residual-stream clones in the decode hot path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1365,7 +1365,13 @@ impl VulkanModel {
         let layer_scalar = w!("layer_scalar")[0];
 
         // ── ATTENTION ──────────────────────────────────────────────────────
-        let residual = hidden.to_vec();
+        // `hidden` is an immutable `&[f32]` for this whole call (the caller
+        // only reassigns its own `hidden` binding *after* this function
+        // returns — see forward_gpu's layer loop) and `residual` below is
+        // only ever read (never mutated), so it can simply alias `hidden`
+        // instead of heap-allocating a full copy of it (1536 floats / 6KB)
+        // on every one of the 35 layers, every decode step.
+        let residual = hidden;
         let _t_layer = std::time::Instant::now();
 
         let shader = "mul_mat_vec_f16_f32_f32_r4";
@@ -1548,7 +1554,7 @@ impl VulkanModel {
 
         if use_fused_post_attn {
             return self.fused_post_attention(
-                layer_idx, shader, &attn_out, &residual, layer_ple,
+                layer_idx, shader, &attn_out, residual, layer_ple,
                 h, q_dim, ffn_inter, ple_dim, eps, t, &_t_layer,
             );
         }
@@ -1577,7 +1583,11 @@ impl VulkanModel {
         let pa_normed = model::cpu_rms_norm(&o_proj, &pa_w, eps);
         let hidden2: Vec<f32> = residual.iter().zip(pa_normed.iter())
             .map(|(&r, &a)| r + a).collect();
-        let residual2 = hidden2.clone();
+        // hidden2 is only read from here on (never mutated), so residual2
+        // can borrow it instead of cloning — this whole branch is the
+        // older 3-submit CPU-fallback path (use_fused_post_attn == false),
+        // kept for the CPU-only build/test configuration.
+        let residual2 = &hidden2;
 
         // CPU: pre_ffn_norm
         let ff_in = model::cpu_rms_norm(&hidden2, &pf_w, eps);


### PR DESCRIPTION
## What
`forward_layer_gpu_matmuls`'s `let residual = hidden.to_vec();` heap-allocated and copied a full 1536-float (6KB) buffer on every one of the 35 decoder layers, every decode step — even though `hidden` is an immutable `&[f32]` for the entire call (the caller only reassigns its own `hidden` binding *after* this function returns, in `forward_gpu`'s layer loop) and `residual` is only ever read afterward (passed as `&residual` into `fused_post_attention`, or zipped read-only in the older CPU-fallback branch).

The same pattern existed one level down, in that CPU-fallback branch specifically: `let residual2 = hidden2.clone();`, where `hidden2` is likewise only read after that point.

## Fix
Both are now plain borrows (`let residual = hidden;` / `let residual2 = &hidden2;`) instead of allocating owned copies — removing one guaranteed-redundant allocation+copy per layer (the first one; the second is CPU-fallback-only, so only hit without a GPU).

## Measured impact
A standalone `Vec<f32>::to_vec()` clone of 1536 f32 elements costs ~168ns/call on this hardware. Modest on its own (~5.9us/decode-step across 35 layers for the always-executed first clone), but a genuinely redundant cost with zero downside to removing it — this is a pure allocation-removal cleanup, not a GPU dispatch change, so unlike several other candidate optimizations investigated this session it carries none of the "extra vkQueueSubmit might not pay for its own ~150us fence-wait at short sequence lengths" risk that applies to GPU-side changes.

## Testing
All 19 lib tests pass unchanged, including `matvec_fusion_tests::fused_post_attention_matches_three_submit_path` (which cross-validates the fused GPU path against the older 3-submit CPU-fallback path via L2-relative-error — exercising both edited call sites) and `fused_post_attention_is_faster_than_three_submit_path`. Zero new clippy warnings (48 lib / 49 lib+all-targets, unchanged from `main`). No Python changes in this commit.
