### PR TITLE
perf: use BLOCK_SIZE=32 instead of 512 for the _r4 matvec variant

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -230,9 +230,26 @@ impl PipelineCache {
         // NUM_ROWS=2 variant for wider matrices
         let r2 = format!("{name}_r2");
         let _ = self.compile_one_with_spec(&r2, spv, &[(0, 512), (1, 2), (2, 1)]);
-        // NUM_ROWS=4 variant
+        // NUM_ROWS=4 variant, BLOCK_SIZE=32 (not 512): BLOCK_SIZE is tied
+        // directly to the shader's local_size_x (`layout(local_size_x_id =
+        // 0, ...)`), so this is a genuinely independent tuning axis from
+        // NUM_ROWS — measured across all 5 real Gemma4-E2B matvec shapes,
+        // BLOCK_SIZE=32 is 1.05x-1.91x faster than the previous 512, and
+        // consistently the best of {16, 32, 64, 128, 256, 512, 1024}
+        // tried (16 regressed relative to 32 at every shape, consistent
+        // with 32 being this hardware's native SIMD/subgroup width — see
+        // matvec_r4_tests::r4_matches_base_at_gemma4_e2b_shapes /
+        // r4_is_faster_than_base_at_gemma4_e2b_shapes, which validate
+        // this exact configuration).
+        // Unlike _r2 (compiled leniently above since nothing in production
+        // actually dispatches it), _r4 is used for every single matvec
+        // dispatch in the whole model — silently swallowing its
+        // compilation failure here would defer the actual problem to a
+        // much more confusing "shader not found" error the first time
+        // something tries to dispatch it at runtime, instead of failing
+        // fast and clearly at model-load time.
         let r4 = format!("{name}_r4");
-        let _ = self.compile_one_with_spec(&r4, spv, &[(0, 512), (1, 4), (2, 1)]);
+        self.compile_one_with_spec(&r4, spv, &[(0, 32), (1, 4), (2, 1)])?;
         Ok(())
     }
 


### PR DESCRIPTION
## What
Every matvec dispatch in `forward_layer_gpu_matmuls`/`fused_post_attention` uses the `_r4` (NUM_ROWS=4) shader variant, but its `BLOCK_SIZE` specialization constant — which is tied directly to the shader's `local_size_x` via `layout(local_size_x_id = 0, ...)` in `mul_mat_vec.comp`, not just an internal loop parameter — had never been tuned independently of `NUM_ROWS`. `_r8` (doubling `NUM_ROWS` again) was already tried and measured ~1.32x *slower* than `_r4`, likely due to register pressure; this is a genuinely separate axis.

## Measured impact
Swept `BLOCK_SIZE` in `{16, 32, 64, 128, 256, 512(previous), 1024}` across all 5 real Gemma4-E2B matvec shapes (q_proj sliding/full-attn, o_proj, gate/up_proj, down_proj): **BLOCK_SIZE=32 was consistently the fastest of every value tried, by 1.05x-1.91x over the previous 512**. 16 regressed relative to 32 at every shape, consistent with 32 being this hardware's native SIMD/subgroup width (Apple M1 via Mesa Honeykrisp) — values on either side of it are worse.

Since the `_r4` variant is used for **every single matvec dispatch in the whole model** (QKV, o_proj, FFN gate/up/down, PLE gate/proj, and the LM head), this change compounds across the entire decode step rather than affecting one isolated op.

## Testing
The existing `matvec_r4_tests::r4_matches_base_at_gemma4_e2b_shapes` / `r4_is_faster_than_base_at_gemma4_e2b_shapes` already validate the `_r4` variant's correctness and speedup against the base (`NUM_ROWS=1`, `BLOCK_SIZE=512`, unchanged) variant at all 5 shapes, so they automatically re-validate this new configuration with **no test changes needed** — and every downstream test that exercises `_r4` transitively shows a consistent improvement:
- `ple_proj`'s GPU-vs-CPU speedup rose from ~6.1-6.6x to **~9.4x**
- fused-QKV's speedup from ~1.10-1.12x to **~1.32x**
- fused-post-attention's 3-submit-vs-fused speedup improved with both sides substantially faster in absolute terms

All 21 lib tests pass; zero new clippy warnings (48 lib / 49 lib+all-targets, unchanged from `main`). No Python changes in this commit.
