### PR TITLE
perf: tune tanh.comp's local_size_x from 512 to 128

### DIFF
--- a/shaders/tanh.comp
+++ b/shaders/tanh.comp
@@ -5,13 +5,29 @@
 
 #extension GL_EXT_control_flow_attributes : enable
 
-layout(local_size_x = 512, local_size_y = 1, local_size_z = 1) in;
+// local_size_x=128 (not the more common 512): measured on this hardware
+// (marginal per-dispatch cost within a batched submit, averaged over
+// hundreds of iterations, at vocab=262144 — the only shape tanh_f32 is
+// actually dispatched at, for the LM head's logit softcap), 128 is a
+// clear, reproducible ~1.2-1.35x win over 512, monotonically improving
+// as local_size_x decreases from 1024 down to 128 (consistent across 4
+// repeated runs). Same tuning finding as gelu.comp's local_size_x=128
+// (see gelu_tests::gpu_gelu_matches_cpu_reference), though here it holds
+// even at a much larger element count.
+layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
 
 layout (binding = 0) readonly buffer X {A_TYPE data_a[];};
 layout (binding = 1) writeonly buffer D {D_TYPE data_d[];};
 
 void main() {
-    const uint i = gl_GlobalInvocationID.z * 262144 + gl_GlobalInvocationID.y * 512 + gl_GlobalInvocationID.x;
+    // Strides here must track local_size_x (128): every production call
+    // site currently dispatches with (wgX, 1, 1) only, so
+    // GlobalInvocationID.y/z are always 0 and these strides are inert
+    // today — but keeping them mismatched with local_size_x would be a
+    // silent correctness trap for any future multi-dimensional dispatch
+    // of this shader (128*512 = 65536, matching the same "512 groups
+    // before rolling over" convention as the original 512*512 = 262144).
+    const uint i = gl_GlobalInvocationID.z * 65536 + gl_GlobalInvocationID.y * 128 + gl_GlobalInvocationID.x;
 
     if (i >= p.KX) {
         return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1273,7 +1273,7 @@ impl VulkanModel {
                 eng.record_barrier_to(cb);
                 eng.record_to(cb, "mul_f32_f32_f32", &[&*logit_raw_p, &*inv_cap_p, &*scaled_p], bytemuck::cast_slice(&binary_broadcast_pc(vocab)), (wg256(vocab), 1, 1)).unwrap();
                 eng.record_barrier_to(cb);
-                eng.record_to(cb, "tanh_f32", &[&*scaled_p, &*tanh_p], bytemuck::cast_slice(&unary_head_pc(vocab)), (wg512(vocab), 1, 1)).unwrap();
+                eng.record_to(cb, "tanh_f32", &[&*scaled_p, &*tanh_p], bytemuck::cast_slice(&unary_head_pc(vocab)), (wg128(vocab), 1, 1)).unwrap();
                 eng.record_barrier_to(cb);
                 eng.record_to(cb, "mul_f32_f32_f32", &[&*tanh_p, &*cap_p, &*final_p], bytemuck::cast_slice(&binary_broadcast_pc(vocab)), (wg256(vocab), 1, 1)).unwrap();
             }
@@ -2152,17 +2152,11 @@ fn wg256(n: usize) -> u32 {
     n.div_ceil(256) as u32
 }
 
-/// Workgroup count for `tanh_f32` (512 threads/workgroup, 1 element/thread
-/// — see `tanh.comp`). NOT used for `gelu_f32` (see `wg128` below): the two
-/// shaders have independently-tuned `local_size_x` values, so they need
-/// separate workgroup-count helpers even though both are 1-element/thread
-/// unary shaders.
-fn wg512(n: usize) -> u32 {
-    n.div_ceil(512) as u32
-}
-
-/// Workgroup count for `gelu_f32` (128 threads/workgroup, 1 element/thread
-/// — see `gelu.comp`, tuned to 128 rather than the more common 512).
+/// Workgroup count for `gelu_f32` and `tanh_f32` (both 128 threads/workgroup,
+/// 1 element/thread — see `gelu.comp` / `tanh.comp`; both independently
+/// measured to be faster at `local_size_x=128` than the more common 512
+/// at their respective real dispatch sizes: `ple_dim`/`ffn_inter` for
+/// gelu, `vocab` for tanh).
 fn wg128(n: usize) -> u32 {
     n.div_ceil(128) as u32
 }
@@ -3026,7 +3020,7 @@ mod softcap_tests {
             let cb = eng.begin_batch().unwrap();
             eng.record_to(cb, "mul_f32_f32_f32", &[&logits_buf, &inv_cap_buf, &scaled_buf], bytemuck::cast_slice(&binary_broadcast_pc(vocab)), (wg256(vocab), 1, 1)).unwrap();
             eng.record_barrier_to(cb);
-            eng.record_to(cb, "tanh_f32", &[&scaled_buf, &tanh_buf], bytemuck::cast_slice(&unary_head_pc(vocab)), (wg512(vocab), 1, 1)).unwrap();
+            eng.record_to(cb, "tanh_f32", &[&scaled_buf, &tanh_buf], bytemuck::cast_slice(&unary_head_pc(vocab)), (wg128(vocab), 1, 1)).unwrap();
             eng.record_barrier_to(cb);
             eng.record_to(cb, "mul_f32_f32_f32", &[&tanh_buf, &cap_buf, &final_buf], bytemuck::cast_slice(&binary_broadcast_pc(vocab)), (wg256(vocab), 1, 1)).unwrap();
             eng.submit_batch(cb).unwrap();
@@ -3287,7 +3281,7 @@ mod final_norm_lm_head_tests {
         engine.record_barrier_to(cb);
         engine.record_to(cb, "mul_f32_f32_f32", &[&raw_logit_buf, &inv_cap_buf, &scaled_buf], bytemuck::cast_slice(&binary_broadcast_pc(vocab)), (wg256(vocab), 1, 1)).unwrap();
         engine.record_barrier_to(cb);
-        engine.record_to(cb, "tanh_f32", &[&scaled_buf, &tanh_buf], bytemuck::cast_slice(&unary_head_pc(vocab)), (wg512(vocab), 1, 1)).unwrap();
+        engine.record_to(cb, "tanh_f32", &[&scaled_buf, &tanh_buf], bytemuck::cast_slice(&unary_head_pc(vocab)), (wg128(vocab), 1, 1)).unwrap();
         engine.record_barrier_to(cb);
         engine.record_to(cb, "mul_f32_f32_f32", &[&tanh_buf, &cap_buf, &final_buf], bytemuck::cast_slice(&binary_broadcast_pc(vocab)), (wg256(vocab), 1, 1)).unwrap();
         engine.submit_batch(cb).unwrap();


### PR DESCRIPTION
## Summary
Same tuning methodology as #49 (gelu.comp): measured the marginal per-dispatch cost (within a batched submit, the realistic scenario since `tanh_f32` is always fused into the LM head's `scale->tanh->scale` logit-softcap submit, never dispatched standalone) across `local_size_x` in {128, 256, 512, 1024} at `vocab=262144` — the only shape `tanh_f32` is actually dispatched at.

## Measurement
Unlike `gelu.comp` (where the win was specific to the small `ple_dim=256` shape and a tie at larger sizes), `tanh.comp`'s win holds even at this much larger element count: `local_size_x=128` gives a clear, reproducible **~1.2-1.35x speedup** over 512, monotonically improving as `local_size_x` decreases from 1024 down to 128 — consistent across 4 repeated runs:

```
local_size_x=  128  marginal=42-46us/dispatch
local_size_x=  256  marginal=50-56us/dispatch
local_size_x=  512  marginal=55-59us/dispatch
local_size_x= 1024  marginal=55-59us/dispatch
```

## Changes
- `shaders/tanh.comp`: `local_size_x` 512 → 128, documented with measurement rationale. Also updates the global-index stride constants (previously hardcoded to match 512) to track the new value — inert today since every call site dispatches with `(wgX, 1, 1)` only, but avoids a dormant correctness trap (same class of issue a reviewer caught in #49).
- `src/lib.rs`: since `gelu_f32` and `tanh_f32` now share `local_size_x=128`, this collapses the previous `wg512()`/`wg128()` pair into a single shared `wg128()`, used at all 3 `tanh_f32` call sites (1 production, 2 test).

## Verification
- `cargo build --release` (with shader recompile): clean.
- `cargo test --release`: 22/22 passing — `softcap_tests::gpu_softcap_vs_cpu_softcap` already exercises this exact dispatch (tanh_f32 over the full vocab) against a CPU reference and continues to pass, confirming correctness.
- `cargo clippy --release --all-targets`: 49 warnings (matches established baseline exactly).
- `pytest tests/python/`: 46 passed, 2 skipped (matches baseline).