### PR TITLE
perf: stop compiling the dead _r2 matvec pipeline variant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2823,6 +2823,82 @@ mod binary_elementwise_tests {
 }
 
 #[cfg(test)]
+mod pipeline_cache_startup_tests {
+    //! `compile_matvec` used to also compile a NUM_ROWS=2 (`_r2`) variant
+    //! for all 17 MATVEC_SHADERS entries, never actually dispatched
+    //! anywhere in this codebase (confirmed via `grep -rn '_r2' src/
+    //! vllm_vulkan/ tests/` finding zero dispatch call sites — every
+    //! real matvec dispatch uses either the unsuffixed base variant, the
+    //! `_subgroup` unsuffixed variant, or `_r4`). Measured directly
+    //! (`PipelineCache::new()`, i.e. model-load, timed before/after
+    //! removing it): ~1865-1885ms with `_r2` vs ~1461-1467ms without,
+    //! consistently reproducible across repeated runs — a ~400ms
+    //! (~22%) model-load startup-time win from removing this dead
+    //! pipeline. This test is a deterministic (non-flaky) structural
+    //! regression guard confirming `_r2` variants are no longer compiled
+    //! at all, rather than a wall-clock assertion (which would be
+    //! sensitive to the specific CI runner's absolute performance).
+    use super::*;
+
+    fn make_engine() -> Option<compute::ComputeEngine> {
+        let dev = match device::ComputeDevice::create(0) {
+            Ok(d) => d,
+            Err(e) => { eprintln!("skip: no Vulkan device available ({e})"); return None; }
+        };
+        let shader_spvs = include_all_shaders();
+        let refs: std::collections::HashMap<&str, &[u8]> = shader_spvs.iter()
+            .map(|(k, v)| (k.as_str(), v.as_slice())).collect();
+        Some(compute::ComputeEngine::new(
+            dev.instance.clone(), dev.physical_device, dev.device.clone(),
+            dev.compute_queue, dev.compute_queue_family, &refs,
+        ).expect("create ComputeEngine"))
+    }
+
+    #[test]
+    fn r2_matvec_variant_is_no_longer_compiled() {
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        // Trivial zero-filled data: this test only checks whether
+        // `record_to` finds a compiled pipeline for each shader name
+        // (Ok) or not (Err "not found") — the actual numerical result is
+        // irrelevant here, unlike the correctness tests elsewhere.
+        let k = 64usize;
+        let n = 4usize;
+        let weight_f16 = f32_to_f16_bytes(&vec![0.0f32; n * k]);
+        let x = vec![0.0f32; k];
+        let wbuf = engine.alloc_host_coherent_storage(weight_f16.len() as u64).unwrap();
+        wbuf.write(&weight_f16).unwrap();
+        let xbuf = engine.alloc_host_coherent_storage((k * 4) as u64).unwrap();
+        xbuf.write(bytemuck::cast_slice(&x)).unwrap();
+        let out = engine.alloc_host_coherent_storage((n * 4) as u64).unwrap();
+        let pc = mv_pc(k, n, 1);
+
+        // The base and _r4 variants must still be present and dispatchable...
+        let cb = engine.begin_batch().unwrap();
+        let res_base = engine.record_to(
+            cb, "mul_mat_vec_f16_f32_f32", &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, 1, 1),
+        );
+        assert!(res_base.is_ok(), "base matvec variant should still be compiled: {res_base:?}");
+
+        let res_r4 = engine.record_to(
+            cb, "mul_mat_vec_f16_f32_f32_r4", &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), (wg_r4(n), 1, 1),
+        );
+        assert!(res_r4.is_ok(), "_r4 matvec variant should still be compiled: {res_r4:?}");
+
+        // ...but the dead _r2 variant must be gone.
+        let res_r2 = engine.record_to(
+            cb, "mul_mat_vec_f16_f32_f32_r2", &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), (n.div_ceil(2) as u32, 1, 1),
+        );
+        assert!(
+            res_r2.is_err(),
+            "expected '_r2' matvec variant to no longer be compiled (dead code, never \
+             dispatched anywhere), but record_to succeeded: {res_r2:?}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod record_to_tests {
     //! Validates `ComputeEngine::record_to`'s stack-allocated descriptor-
     //! write buffers (see its doc comment) — specifically the

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -220,16 +220,27 @@ impl PipelineCache {
 
     /// Compile a shader with the standard matvec specialization constants:
     /// BLOCK_SIZE=512, NUM_ROWS=1, NUM_COLS=1.
-    /// Also compiles NUM_ROWS=2 and NUM_ROWS=4 variants for larger matrices.
+    /// Also compiles a NUM_ROWS=4 variant for larger matrices.
+    ///
+    /// A NUM_ROWS=2 (`_r2`) variant used to be compiled here as well, but
+    /// was never actually dispatched anywhere in this codebase (Rust or
+    /// Python — every real matvec dispatch uses either this unsuffixed
+    /// base variant, the `_subgroup` unsuffixed variant, or `_r4`; `grep
+    /// -rn '_r2' src/ vllm_vulkan/ tests/` finds zero dispatch call
+    /// sites, only its own compilation). Compiling it cost ~400ms
+    /// (~22%) of `PipelineCache::new()`'s (i.e. model-load) wall time,
+    /// measured directly (~1865-1885ms with it vs ~1461-1467ms without,
+    /// consistently reproducible) before removing it — for a pipeline
+    /// that was pure dead weight, so it's removed rather than kept "just
+    /// in case". See `pipeline_cache_startup_tests::
+    /// r2_matvec_variant_is_no_longer_compiled` for a (non-timing-based,
+    /// CI-safe) regression guard confirming the removal.
     pub fn compile_matvec(&mut self, name: &str, spv: &[u8]) -> Result<(), String> {
         self.compile_one_with_spec(name, spv, &[
             (0, 512), // BLOCK_SIZE = 512
             (1, 1),   // NUM_ROWS = 1
             (2, 1),   // NUM_COLS = 1
         ])?;
-        // NUM_ROWS=2 variant for wider matrices
-        let r2 = format!("{name}_r2");
-        let _ = self.compile_one_with_spec(&r2, spv, &[(0, 512), (1, 2), (2, 1)]);
         // NUM_ROWS=4 variant, BLOCK_SIZE=32 (not 512): BLOCK_SIZE is tied
         // directly to the shader's local_size_x (`layout(local_size_x_id =
         // 0, ...)`), so this is a genuinely independent tuning axis from


### PR DESCRIPTION
## Summary
`compile_matvec` compiled three specialization-constant variants per `MATVEC_SHADERS` entry: the unsuffixed base (NUM_ROWS=1), `_r2` (NUM_ROWS=2), and `_r4` (NUM_ROWS=4, BLOCK_SIZE=32). `_r2` was never actually dispatched anywhere in this codebase — `grep -rn '_r2' src/ vllm_vulkan/ tests/` finds zero dispatch call sites (Rust or Python); every real matvec dispatch uses either the base variant, the `_subgroup` unsuffixed variant, or `_r4`.

## Measurement
Measured `PipelineCache::new()`'s (i.e. model-load) wall time directly before/after removing it:

- **With `_r2`**: ~1865-1885ms
- **Without `_r2`**: ~1461-1467ms

Consistently reproducible across repeated runs — a **~400ms (~22%) model-load startup-time reduction** from removing a pipeline that did nothing (compiled for all 17 `MATVEC_SHADERS` entries).

## Changes
- `src/pipeline.rs`: removes the `_r2` compilation from `compile_matvec`.
- New test `pipeline_cache_startup_tests::r2_matvec_variant_is_no_longer_compiled`: a deterministic (non-timing-based) regression guard confirming the base and `_r4` variants are still compiled/dispatchable, while `_r2` now correctly fails with "not found". A wall-clock assertion was deliberately avoided for the committed test since absolute pipeline compilation time varies too much across different CI runners to make a hard timing threshold reliable; the measurement above was done locally and is reported for context only.

## Verification
- `cargo build --release`: clean.
- `cargo test --release`: 25/25 passing (24 baseline + 1 new).
- `cargo clippy --release --all-targets`: 49 warnings (matches established baseline exactly).
- `pytest tests/python/`: 46 passed, 2 skipped (matches baseline) — and noticeably faster (23.85s vs ~29.5s), consistent with the model-load speedup.