### PR TITLE
perf: stop compiling dead quantized-weight matvec pipelines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -740,21 +740,23 @@ fn include_all_shaders() -> std::collections::HashMap<String, Vec<u8>> {
     spv!("mul_mat_vec_f32_f32_f32_subgroup");
     spv!("mul_mat_vec_f16_f32_f32");
     spv!("mul_mat_vec_f16_f32_f32_subgroup");
-    // Quantized weight × f32 activations → f32 output
-    spv!("mul_mat_vec_q4_0_f32_f32");
-    spv!("mul_mat_vec_q4_0_f32_f32_subgroup");
-    spv!("mul_mat_vec_q4_1_f32_f32");
-    spv!("mul_mat_vec_q5_0_f32_f32");
-    spv!("mul_mat_vec_q5_1_f32_f32");
-    spv!("mul_mat_vec_q8_0_f32_f32");
-    spv!("mul_mat_vec_q8_0_f32_f32_subgroup");
-    // Quant K-type: activations f16 → f32 (new naming convention)
-    spv!("mul_mat_vec_q2_k_f16_f32");
-    spv!("mul_mat_vec_q3_k_f16_f32");
-    spv!("mul_mat_vec_q4_k_f32_f32_subgroup");
-    spv!("mul_mat_vec_q5_k_f16_f32");
-    spv!("mul_mat_vec_q6_k_f32_f32_subgroup");
-    spv!("mul_mat_vec_iq4_nl_f32_f32");
+    // Quantized-weight matvec variants (Q4_0/Q4_1/Q5_0/Q5_1/Q8_0/Q2_K/Q3_K/
+    // Q4_K/Q5_K/Q6_K/IQ4_NL) are NOT registered here: this backend only
+    // ever loads f16/f32 weights (see model_runner.py/vulkan_ops.py — no
+    // quantization scheme is referenced anywhere in the Python weight-
+    // loading path, and `VulkanPlatform.verify_quantization` is a no-op
+    // passthrough), so these were pure dead weight — compiled into 2
+    // pipelines each (base + _r4) via `compile_matvec` for zero benefit.
+    // Confirmed via `grep -rn 'q4_0\|q8_0\|...' src/ vllm_vulkan/ tests/`
+    // finding zero dispatch call sites for any of them. Measured
+    // `PipelineCache::new()`'s (i.e. model-load) wall time before/after
+    // removing them: ~1473-1474ms with vs ~733-747ms without — a
+    // further ~730ms (~50%) model-load reduction on top of the earlier
+    // `_r2` removal (#52), consistently reproducible across repeated
+    // runs. If quantized-weight support is added later, these shaders'
+    // `.comp` sources are untouched (only their `spv!`/`MATVEC_SHADERS`
+    // registration is removed here) — re-registering them is a
+    // one-line-per-shader change.
 
     // ── General matmul (prefill) ─────────────────────────────────────────
     spv!("matmul_f32_f16");
@@ -2895,6 +2897,56 @@ mod pipeline_cache_startup_tests {
             "expected '_r2' matvec variant to no longer be compiled (dead code, never \
              dispatched anywhere), but record_to succeeded: {res_r2:?}"
         );
+    }
+
+    #[test]
+    fn quantized_matvec_variants_are_no_longer_compiled() {
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        // Trivial zero-filled data — see r2_matvec_variant_is_no_longer_compiled
+        // above for why numerical correctness is irrelevant to this test.
+        let k = 64usize;
+        let n = 4usize;
+        let weight = vec![0u8; n * k]; // dummy bytes, layout doesn't matter here
+        let x = vec![0.0f32; k];
+        let wbuf = engine.alloc_host_coherent_storage(weight.len() as u64).unwrap();
+        wbuf.write(&weight).unwrap();
+        let xbuf = engine.alloc_host_coherent_storage((k * 4) as u64).unwrap();
+        xbuf.write(bytemuck::cast_slice(&x)).unwrap();
+        let out = engine.alloc_host_coherent_storage((n * 4) as u64).unwrap();
+        let pc = mv_pc(k, n, 1);
+
+        let cb = engine.begin_batch().unwrap();
+        for name in [
+            "mul_mat_vec_q4_0_f32_f32",
+            "mul_mat_vec_q4_0_f32_f32_subgroup",
+            "mul_mat_vec_q4_1_f32_f32",
+            "mul_mat_vec_q5_0_f32_f32",
+            "mul_mat_vec_q5_1_f32_f32",
+            "mul_mat_vec_q8_0_f32_f32",
+            "mul_mat_vec_q8_0_f32_f32_subgroup",
+            "mul_mat_vec_q2_k_f16_f32",
+            "mul_mat_vec_q3_k_f16_f32",
+            "mul_mat_vec_q4_k_f32_f32_subgroup",
+            "mul_mat_vec_q5_k_f16_f32",
+            "mul_mat_vec_q6_k_f32_f32_subgroup",
+            "mul_mat_vec_iq4_nl_f32_f32",
+        ] {
+            let res = engine.record_to(cb, name, &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, 1, 1));
+            assert!(
+                res.is_err(),
+                "expected quantized matvec variant '{name}' to no longer be compiled \
+                 (dead code, never dispatched anywhere — this backend only ever loads \
+                 f16/f32 weights), but record_to succeeded: {res:?}"
+            );
+        }
+
+        // The f32/f16 variants actually used in production must still work.
+        let res_f32 = engine.record_to(cb, "mul_mat_vec_f32_f32_f32", &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, 1, 1));
+        assert!(res_f32.is_ok(), "mul_mat_vec_f32_f32_f32 should still be compiled: {res_f32:?}");
+        let res_f16 = engine.record_to(cb, "mul_mat_vec_f16_f32_f32", &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, 1, 1));
+        assert!(res_f16.is_ok(), "mul_mat_vec_f16_f32_f32 should still be compiled: {res_f16:?}");
     }
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -73,19 +73,6 @@ impl PipelineCache {
             "mul_mat_vec_f32_f32_f32_subgroup",
             "mul_mat_vec_f16_f32_f32",
             "mul_mat_vec_f16_f32_f32_subgroup",
-            "mul_mat_vec_q4_0_f32_f32",
-            "mul_mat_vec_q4_0_f32_f32_subgroup",
-            "mul_mat_vec_q4_1_f32_f32",
-            "mul_mat_vec_q5_0_f32_f32",
-            "mul_mat_vec_q5_1_f32_f32",
-            "mul_mat_vec_q8_0_f32_f32",
-            "mul_mat_vec_q8_0_f32_f32_subgroup",
-            "mul_mat_vec_q2_k_f16_f32",
-            "mul_mat_vec_q3_k_f16_f32",
-            "mul_mat_vec_q4_k_f32_f32_subgroup",
-            "mul_mat_vec_q5_k_f16_f32",
-            "mul_mat_vec_q6_k_f32_f32_subgroup",
-            "mul_mat_vec_iq4_nl_f32_f32",
         ];
 
         let mut failed = 0usize;


### PR DESCRIPTION
## Summary
Following up on #52 (which removed the dead `_r2` matvec variant): the 13 quantized-weight matvec shader entries (Q4_0, Q4_0_subgroup, Q4_1, Q5_0, Q5_1, Q8_0, Q8_0_subgroup, Q2_K, Q3_K, Q4_K_subgroup, Q5_K, Q6_K_subgroup, IQ4_NL) in `MATVEC_SHADERS` were never actually dispatched anywhere in this codebase.

## Analysis
Confirmed via `grep -rn 'q4_0\|q4_1\|q5_0\|q5_1\|q8_0\|q2_k\|q3_k\|q4_k\|q5_k\|q6_k\|iq4_nl' src/ vllm_vulkan/ tests/` finding zero dispatch call sites outside their own registration. This backend only ever loads f16/f32 weights — nothing in `model_runner.py`/`vulkan_ops.py`'s weight-loading path references any quantization scheme, and `VulkanPlatform.verify_quantization` is a no-op passthrough. So all 13 were pure dead weight, each compiled into 2 pipelines (base + `_r4`) via `compile_matvec` for zero benefit.

## Measurement
Measured `PipelineCache::new()`'s (i.e. model-load) wall time directly before/after removing them:

- **With quantized shaders**: ~1473-1474ms
- **Without**: ~733-747ms

A further **~730ms (~50%) model-load reduction** on top of #52's ~400ms (~22%), consistently reproducible across repeated runs. The full Rust test suite (which creates many `ComputeEngine` instances) dropped from ~34s to ~20s as a side effect, and the Python test suite from ~24s to ~12.5s.

## Changes
- `src/pipeline.rs`: removes the 13 quantized entries from `MATVEC_SHADERS`.
- `src/lib.rs`: removes their `spv!()` registration too (so the SPIR-V bytes aren't even loaded). Their `.comp` shader sources are untouched — only compilation is skipped — so re-adding quantized-weight support later, if ever needed, is a one-line-per-shader change.
- New test `pipeline_cache_startup_tests::quantized_matvec_variants_are_no_longer_compiled`: a deterministic (non-timing-based) regression guard confirming all 13 variants now fail to dispatch ("not found") while the actually-used f32/f16 base variants remain compiled and dispatchable.

## Verification
- `cargo build --release`: clean.
- `cargo test --release`: 26/26 passing (25 baseline + 1 new).
- `cargo clippy --release --all-targets`: 49 warnings (matches established baseline exactly).
- `pytest tests/python/`: 46 passed, 2 skipped (matches baseline).