### PR TITLE
perf: add a BLOCK_SIZE=512 paged-attention decode shader variant

### DIFF
--- a/scripts/compile_shaders.sh
+++ b/scripts/compile_shaders.sh
@@ -346,9 +346,11 @@ echo "=== Paged KV cache ==="
 compile "paged_kv_write_f16" "paged_kv_write_f16.comp"
 compile "paged_kv_write_f32" "paged_kv_write_f32.comp"
 compile "paged_attn_decode_f16" "paged_attn_decode_f16.comp"
-compile "paged_attn_decode_f16_coop" "paged_attn_decode_f16_coop.comp"
+compile "paged_attn_decode_f16_coop" "paged_attn_decode_f16_coop.comp" BLOCK_SIZE=256
+compile "paged_attn_decode_f16_coop_512" "paged_attn_decode_f16_coop.comp" BLOCK_SIZE=512
 compile "paged_attn_decode_f32" "paged_attn_decode_f32.comp"
-compile "paged_attn_decode_f32_coop" "paged_attn_decode_f32_coop.comp"
+compile "paged_attn_decode_f32_coop" "paged_attn_decode_f32_coop.comp" BLOCK_SIZE=256
+compile "paged_attn_decode_f32_coop_512" "paged_attn_decode_f32_coop.comp" BLOCK_SIZE=512
 
 # ── Summary ────────────────────────────────────────────────────────────────────
 echo ""

--- a/shaders/paged_attn_decode_f16_coop.comp
+++ b/shaders/paged_attn_decode_f16_coop.comp
@@ -2,7 +2,19 @@
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 #extension GL_EXT_shader_16bit_storage : require
 
-layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+// BLOCK_SIZE (local_size_x / dot_sums reduction width) is compile-time
+// configurable: this shader is compiled twice, as BLOCK_SIZE=256 (the
+// default, optimal when head_size==256 — Gemma4-E2B's sliding-window
+// layers) and BLOCK_SIZE=512 ("_512" name suffix, optimal when
+// head_size==512 — Gemma4-E2B's full-attention layers). See
+// paged_attn_decode_f32_coop.comp's identical comment for the measured
+// rationale, and kv_ops.py's `_select_decode_shader` for the head_size-
+// based selection between the two compiled variants.
+#ifndef BLOCK_SIZE
+#define BLOCK_SIZE 256
+#endif
+
+layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer QInput {
     float q[];
@@ -32,7 +44,7 @@ layout(push_constant) uniform parameter {
     float scale;
 } p;
 
-shared float dot_sums[256];
+shared float dot_sums[BLOCK_SIZE];
 
 uint kv_base_for_token(uint token_idx, uint kv_head) {
     const uint logical_block_id = token_idx / p.block_size;

--- a/shaders/paged_attn_decode_f32_coop.comp
+++ b/shaders/paged_attn_decode_f32_coop.comp
@@ -1,6 +1,25 @@
 #version 450
 
-layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+// BLOCK_SIZE (local_size_x / dot_sums reduction width) is compile-time
+// configurable: this shader is compiled twice, as BLOCK_SIZE=256 (the
+// default, optimal when head_size==256 — Gemma4-E2B's sliding-window
+// layers) and BLOCK_SIZE=512 ("_512" name suffix, optimal when
+// head_size==512 — Gemma4-E2B's full-attention layers). Measured
+// directly (marginal per-dispatch cost): BLOCK_SIZE=256 is ~9-14%
+// faster than 512 at head_size=256, while BLOCK_SIZE=512 is ~5-9%
+// faster than 256 at head_size=512 — matching BLOCK_SIZE to head_size
+// avoids wasted/idle threads in the cooperative dot-product reduction
+// (each thread handles `head_size / BLOCK_SIZE` elements via the
+// `for (d=tid; d<head_size; d+=BLOCK_SIZE)` loop below; when
+// BLOCK_SIZE > head_size, threads with `tid >= head_size` do zero
+// useful work in that loop but still pay the full barrier/reduction
+// cost). See kv_ops.py's `_select_decode_shader` for the head_size-
+// based selection between the two compiled variants.
+#ifndef BLOCK_SIZE
+#define BLOCK_SIZE 256
+#endif
+
+layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer QInput {
     float q[];
@@ -30,7 +49,7 @@ layout(push_constant) uniform parameter {
     float scale;
 } p;
 
-shared float dot_sums[256];
+shared float dot_sums[BLOCK_SIZE];
 
 uint kv_base_for_token(uint token_idx, uint kv_head) {
     const uint logical_block_id = token_idx / p.block_size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -783,8 +783,10 @@ fn include_all_shaders() -> std::collections::HashMap<String, Vec<u8>> {
     spv!("paged_kv_write_f32");
     spv!("paged_attn_decode_f16");
     spv!("paged_attn_decode_f16_coop");
+    spv!("paged_attn_decode_f16_coop_512");
     spv!("paged_attn_decode_f32");
     spv!("paged_attn_decode_f32_coop");
+    spv!("paged_attn_decode_f32_coop_512");
 
     map
 }
@@ -3054,8 +3056,8 @@ mod pipeline_cache_startup_tests {
             "rms_norm_f32", "rms_norm_f32_mul",
             "mul_mat_vec_f32_f32_f32", "mul_mat_vec_f16_f32_f32", "mul_mat_vec_f32_f32_f32_subgroup",
             "paged_kv_write_f16", "paged_kv_write_f32",
-            "paged_attn_decode_f16", "paged_attn_decode_f16_coop",
-            "paged_attn_decode_f32", "paged_attn_decode_f32_coop",
+            "paged_attn_decode_f16", "paged_attn_decode_f16_coop", "paged_attn_decode_f16_coop_512",
+            "paged_attn_decode_f32", "paged_attn_decode_f32_coop", "paged_attn_decode_f32_coop_512",
         ] {
             let res = engine.record_to(cb, name, &[&dummy], &pc, (1, 1, 1));
             assert!(res.is_ok(), "shader '{name}' should still be compiled: {res:?}");

--- a/tests/python/test_kv_ops.py
+++ b/tests/python/test_kv_ops.py
@@ -13,6 +13,7 @@ _rs = pytest.importorskip("vllm_vulkan._rs", exc_type=ImportError)
 
 from vllm_vulkan.kv_layout import KVCacheLayerSpec, VulkanPagedKVLayout  # noqa: E402
 from vllm_vulkan.kv_ops import (  # noqa: E402
+    _select_decode_shader,
     paged_attn_decode_batch_f16,
     paged_attn_decode_batch_f32,
     paged_attn_decode_f16,
@@ -425,3 +426,126 @@ def test_paged_attn_decode_batch_empty_returns_empty_list():
         )
         == []
     )
+
+
+@pytest.mark.parametrize(
+    (
+        "torch_dtype",
+        "dtype_size",
+        "write_fn",
+        "decode_fn",
+        "write_shader",
+        "decode_shaders",
+        "seed",
+        "rtol",
+        "atol",
+    ),
+    [
+        (
+            torch.float32,
+            4,
+            paged_kv_write_f32,
+            paged_attn_decode_f32,
+            "paged_kv_write_f32",
+            ("paged_attn_decode_f32", "paged_attn_decode_f32_coop_512"),
+            2,
+            1e-4,
+            1e-4,
+        ),
+        (
+            torch.float16,
+            2,
+            paged_kv_write_f16,
+            paged_attn_decode_f16,
+            "paged_kv_write_f16",
+            ("paged_attn_decode_f16", "paged_attn_decode_f16_coop_512"),
+            3,
+            5e-3,
+            5e-3,
+        ),
+    ],
+)
+def test_paged_attn_decode_matches_torch_reference_at_head_size_512(
+    torch_dtype: torch.dtype,
+    dtype_size: int,
+    write_fn: Callable,
+    decode_fn: Callable,
+    write_shader: str,
+    decode_shaders: tuple[str, ...],
+    seed: int,
+    rtol: float,
+    atol: float,
+):
+    """Exercises the BLOCK_SIZE=512 `_coop_512` shader variant specifically
+    (head_size=512 matches Gemma4-E2B's full-attention layers, and
+    _select_decode_shader prefers the 512-wide variant at this size — see
+    test_select_decode_shader_prefers_block_size_matching_head_size below)
+    against the same pure-PyTorch attention reference used at the smaller
+    default head_size=8 shape above, to confirm the 512-wide cooperative
+    reduction is numerically correct, not just "faster in isolation".
+    """
+    ctx = _require_vulkan_context()
+    _require_shader(ctx, write_shader)
+    _require_shader(ctx, *decode_shaders)
+
+    spec = KVCacheLayerSpec(
+        layer_index=0,
+        num_kv_heads=1,
+        head_size=512,
+        block_size=16,
+        dtype_size=dtype_size,
+    )
+    layout = VulkanPagedKVLayout((spec,), num_blocks=8)
+    cache = ctx.alloc_activation(layout.total_bytes)
+    ctx.update_activation(cache, bytes(layout.total_bytes))
+
+    seq_len = 40
+    block_table = torch.tensor([3, 5, 0], dtype=torch.int64)
+    slot_mapping = _slot_mapping_from_block_table(block_table, seq_len, spec.block_size)
+
+    torch.manual_seed(seed)
+    k = torch.randn(seq_len, spec.num_kv_heads, spec.head_size, dtype=torch_dtype)
+    v = torch.randn_like(k)
+    q = torch.randn(8, spec.head_size, dtype=torch.float32)  # 8 q_heads, GQA ratio 8
+    scale = spec.head_size**-0.5
+
+    write_fn(ctx, layout, cache, 0, k, v, slot_mapping)
+    out = decode_fn(ctx, layout, cache, 0, q, block_table, seq_len, scale)
+
+    expected = _attention_reference(q, k, v, scale)
+    torch.testing.assert_close(out, expected, rtol=rtol, atol=atol)
+
+
+def test_select_decode_shader_prefers_block_size_matching_head_size():
+    """_select_decode_shader should prefer the `_coop_512` variant when
+    head_size>=512 (Gemma4-E2B's full-attention layers) and the plain
+    `_coop` (BLOCK_SIZE=256) variant otherwise (e.g. head_size=256, its
+    sliding-window layers) — matching BLOCK_SIZE to head_size avoids
+    wasted/idle threads in the cooperative dot-product reduction (see
+    paged_attn_decode_f32_coop.comp's BLOCK_SIZE comment for the measured
+    rationale). Both are real, always-available shaders in this codebase
+    (not a hypothetical), so this also implicitly confirms both compiled
+    successfully.
+    """
+    ctx = _require_vulkan_context()
+    _require_shader(ctx, "paged_attn_decode_f32_coop", "paged_attn_decode_f32_coop_512")
+
+    name_256, wg_256 = _select_decode_shader(
+        ctx,
+        "paged_attn_decode_f32",
+        "paged_attn_decode_f32_coop",
+        "paged_attn_decode_f32_coop_512",
+        head_size=256,
+    )
+    assert name_256 == "paged_attn_decode_f32_coop"
+    assert wg_256 == 256
+
+    name_512, wg_512 = _select_decode_shader(
+        ctx,
+        "paged_attn_decode_f32",
+        "paged_attn_decode_f32_coop",
+        "paged_attn_decode_f32_coop_512",
+        head_size=512,
+    )
+    assert name_512 == "paged_attn_decode_f32_coop_512"
+    assert wg_512 == 512

--- a/vllm_vulkan/kv_ops.py
+++ b/vllm_vulkan/kv_ops.py
@@ -21,8 +21,20 @@ _PAGED_KV_WRITE_F16_SHADER = "paged_kv_write_f16"
 _PAGED_ATTN_DECODE_F16_SHADER = "paged_attn_decode_f16"
 _PAGED_ATTN_DECODE_COOP_SHADER = "paged_attn_decode_f32_coop"
 _PAGED_ATTN_DECODE_F16_COOP_SHADER = "paged_attn_decode_f16_coop"
+# "_512" variants: same shader source, compiled with BLOCK_SIZE=512
+# instead of the default 256 (see paged_attn_decode_f32_coop.comp's
+# BLOCK_SIZE comment) — preferred over the 256 variant when head_size is
+# large enough (>=512, e.g. Gemma4-E2B's full-attention layers) to avoid
+# wasted/idle threads in the cooperative dot-product reduction. Measured
+# ~5-9% faster than BLOCK_SIZE=256 at head_size=512, while BLOCK_SIZE=256
+# remains ~9-14% faster at head_size=256 — matching BLOCK_SIZE to
+# head_size in both directions, not just unconditionally preferring the
+# larger one.
+_PAGED_ATTN_DECODE_COOP_512_SHADER = "paged_attn_decode_f32_coop_512"
+_PAGED_ATTN_DECODE_F16_COOP_512_SHADER = "paged_attn_decode_f16_coop_512"
 _PAGED_KV_WRITE_WORKGROUP_SIZE = 256
 _PAGED_ATTN_DECODE_WORKGROUP_SIZE = 256
+_PAGED_ATTN_DECODE_WORKGROUP_SIZE_LARGE = 512
 _F32_NBYTES = np.dtype(np.float32).itemsize
 
 
@@ -173,6 +185,7 @@ def paged_attn_decode_f16(
         scale=scale,
         shader_name=_PAGED_ATTN_DECODE_F16_SHADER,
         coop_shader_name=_PAGED_ATTN_DECODE_F16_COOP_SHADER,
+        coop_512_shader_name=_PAGED_ATTN_DECODE_F16_COOP_512_SHADER,
         dtype_size=2,
     )
 
@@ -205,6 +218,7 @@ def paged_attn_decode_f32(
         scale=scale,
         shader_name=_PAGED_ATTN_DECODE_SHADER,
         coop_shader_name=_PAGED_ATTN_DECODE_COOP_SHADER,
+        coop_512_shader_name=_PAGED_ATTN_DECODE_COOP_512_SHADER,
         dtype_size=4,
     )
 
@@ -234,6 +248,7 @@ def paged_attn_decode_batch_f16(
         scale=scale,
         shader_name=_PAGED_ATTN_DECODE_F16_SHADER,
         coop_shader_name=_PAGED_ATTN_DECODE_F16_COOP_SHADER,
+        coop_512_shader_name=_PAGED_ATTN_DECODE_F16_COOP_512_SHADER,
         dtype_size=2,
     )
 
@@ -263,6 +278,7 @@ def paged_attn_decode_batch_f32(
         scale=scale,
         shader_name=_PAGED_ATTN_DECODE_SHADER,
         coop_shader_name=_PAGED_ATTN_DECODE_COOP_SHADER,
+        coop_512_shader_name=_PAGED_ATTN_DECODE_COOP_512_SHADER,
         dtype_size=4,
     )
 
@@ -274,8 +290,9 @@ def _resolve_paged_attn_decode_dispatch(
     layer_index: int,
     shader_name: str,
     coop_shader_name: str,
+    coop_512_shader_name: str,
     dtype_size: int,
-) -> tuple[str, KVCacheLayerSpec]:
+) -> tuple[str, int, KVCacheLayerSpec]:
     """Resolve everything about a decode dispatch that's constant across
     every token in a batch - which shader variant to use, and the shared
     cache buffer/layout dtype validation - exactly once.
@@ -287,12 +304,21 @@ def _resolve_paged_attn_decode_dispatch(
     _paged_attn_decode_batch's single execute_batch call actually cheap
     per-token, not just "one submit instead of N" with the same per-token
     Python/FFI overhead still paid beforehand.
+
+    Returns (dispatch_shader_name, coop_workgroup_size, spec):
+    coop_workgroup_size is 0 when the plain (non-coop) shader was
+    selected (its workgroup formula doesn't depend on this value at
+    all — see _build_paged_attn_decode_op), otherwise it's the
+    BLOCK_SIZE (256 or 512) the selected `_coop`/`_coop_512` shader was
+    compiled with.
     """
     spec = layout.layer_spec(layer_index)
-    dispatch_shader_name = _select_decode_shader(ctx, shader_name, coop_shader_name)
+    dispatch_shader_name, coop_workgroup_size = _select_decode_shader(
+        ctx, shader_name, coop_shader_name, coop_512_shader_name, spec.head_size
+    )
     _validate_cache_buffer(cache, layout)
     _validate_layout_dtype(spec.dtype_size, dtype_size, shader_name)
-    return dispatch_shader_name, spec
+    return dispatch_shader_name, coop_workgroup_size, spec
 
 
 def _build_paged_attn_decode_op(
@@ -301,7 +327,7 @@ def _build_paged_attn_decode_op(
     layer_index: int,
     spec: KVCacheLayerSpec,
     dispatch_shader_name: str,
-    coop_shader_name: str,
+    coop_workgroup_size: int,
     q: torch.Tensor,
     block_table: torch.Tensor | list[int] | tuple[int, ...],
     seq_len: int,
@@ -312,8 +338,8 @@ def _build_paged_attn_decode_op(
     it. Everything shared across a whole batch (shader selection, cache/
     dtype validation) must already be resolved by
     _resolve_paged_attn_decode_dispatch and passed in via
-    dispatch_shader_name/spec - this function only does work that
-    genuinely varies per token.
+    dispatch_shader_name/coop_workgroup_size/spec - this function only
+    does work that genuinely varies per token.
 
     Returns (op_tuple, num_q_heads, head_size) so callers can either submit
     it alone (_paged_attn_decode, one token) or collect several from
@@ -355,10 +381,10 @@ def _build_paged_attn_decode_op(
         scale=scale if scale is not None else 1.0 / math.sqrt(spec.head_size),
     )
     total_elements = num_q_heads * spec.head_size
-    if dispatch_shader_name == coop_shader_name:
+    if coop_workgroup_size > 0:
         workgroups = (
             num_q_heads,
-            math.ceil(spec.head_size / _PAGED_ATTN_DECODE_WORKGROUP_SIZE),
+            math.ceil(spec.head_size / coop_workgroup_size),
             1,
         )
     else:
@@ -395,16 +421,20 @@ def _paged_attn_decode(
     scale: float | None,
     shader_name: str,
     coop_shader_name: str,
+    coop_512_shader_name: str,
     dtype_size: int,
 ) -> torch.Tensor:
-    dispatch_shader_name, spec = _resolve_paged_attn_decode_dispatch(
-        ctx=ctx,
-        layout=layout,
-        cache=cache,
-        layer_index=layer_index,
-        shader_name=shader_name,
-        coop_shader_name=coop_shader_name,
-        dtype_size=dtype_size,
+    dispatch_shader_name, coop_workgroup_size, spec = (
+        _resolve_paged_attn_decode_dispatch(
+            ctx=ctx,
+            layout=layout,
+            cache=cache,
+            layer_index=layer_index,
+            shader_name=shader_name,
+            coop_shader_name=coop_shader_name,
+            coop_512_shader_name=coop_512_shader_name,
+            dtype_size=dtype_size,
+        )
     )
     op, num_q_heads, head_size = _build_paged_attn_decode_op(
         layout=layout,
@@ -412,7 +442,7 @@ def _paged_attn_decode(
         layer_index=layer_index,
         spec=spec,
         dispatch_shader_name=dispatch_shader_name,
-        coop_shader_name=coop_shader_name,
+        coop_workgroup_size=coop_workgroup_size,
         q=q,
         block_table=block_table,
         seq_len=seq_len,
@@ -434,6 +464,7 @@ def _paged_attn_decode_batch(
     scale: float | None,
     shader_name: str,
     coop_shader_name: str,
+    coop_512_shader_name: str,
     dtype_size: int,
 ) -> list[torch.Tensor]:
     """Decode a whole batch of (query, block_table, seq_len) triples - one
@@ -450,14 +481,17 @@ def _paged_attn_decode_batch(
     if not queries:
         return []
 
-    dispatch_shader_name, spec = _resolve_paged_attn_decode_dispatch(
-        ctx=ctx,
-        layout=layout,
-        cache=cache,
-        layer_index=layer_index,
-        shader_name=shader_name,
-        coop_shader_name=coop_shader_name,
-        dtype_size=dtype_size,
+    dispatch_shader_name, coop_workgroup_size, spec = (
+        _resolve_paged_attn_decode_dispatch(
+            ctx=ctx,
+            layout=layout,
+            cache=cache,
+            layer_index=layer_index,
+            shader_name=shader_name,
+            coop_shader_name=coop_shader_name,
+            coop_512_shader_name=coop_512_shader_name,
+            dtype_size=dtype_size,
+        )
     )
 
     ops = []
@@ -469,7 +503,7 @@ def _paged_attn_decode_batch(
             layer_index=layer_index,
             spec=spec,
             dispatch_shader_name=dispatch_shader_name,
-            coop_shader_name=coop_shader_name,
+            coop_workgroup_size=coop_workgroup_size,
             q=q,
             block_table=block_table,
             seq_len=seq_len,
@@ -492,13 +526,34 @@ def _require_shader(ctx: VulkanContext, shader_name: str) -> None:
 
 
 def _select_decode_shader(
-    ctx: VulkanContext, shader_name: str, coop_shader_name: str
-) -> str:
+    ctx: VulkanContext,
+    shader_name: str,
+    coop_shader_name: str,
+    coop_512_shader_name: str,
+    head_size: int,
+) -> tuple[str, int]:
+    """Returns (dispatch_shader_name, coop_workgroup_size).
+
+    Prefers whichever `_coop`/`_coop_512` variant's BLOCK_SIZE best
+    matches `head_size` (see paged_attn_decode_f32_coop.comp's BLOCK_SIZE
+    comment for the measured rationale) — large enough head_size prefers
+    the 512-wide variant, otherwise the default 256-wide one, each falling
+    back to whichever coop variant IS available if the preferred one
+    isn't (e.g. an older build), and finally to the plain non-coop shader
+    if neither coop variant is available at all. `coop_workgroup_size` is
+    0 when the plain shader was selected (see _build_paged_attn_decode_op,
+    whose workgroup formula doesn't use this value in that case).
+    """
     available_shaders = ctx.available_shaders()
+    prefer_512 = head_size >= _PAGED_ATTN_DECODE_WORKGROUP_SIZE_LARGE
+    if prefer_512 and coop_512_shader_name in available_shaders:
+        return coop_512_shader_name, _PAGED_ATTN_DECODE_WORKGROUP_SIZE_LARGE
     if coop_shader_name in available_shaders:
-        return coop_shader_name
+        return coop_shader_name, _PAGED_ATTN_DECODE_WORKGROUP_SIZE
+    if coop_512_shader_name in available_shaders:
+        return coop_512_shader_name, _PAGED_ATTN_DECODE_WORKGROUP_SIZE_LARGE
     if shader_name in available_shaders:
-        return shader_name
+        return shader_name, 0
     raise RuntimeError(f"{shader_name} shader is not available")
 
 


### PR DESCRIPTION
## Summary
`paged_attn_decode_f32_coop.comp`/`paged_attn_decode_f16_coop.comp` (the shaders actually dispatched for GPU-accelerated decode attention in this codebase's vLLM-integrated serving path — `kv_ops.py`'s `_select_decode_shader` always prefers the `_coop` variant when available) use a workgroup-cooperative reduction: `BLOCK_SIZE` (`local_size_x`) threads jointly compute the QK dot product for one q_head via a shared-memory tree reduction, reusing it across up to `BLOCK_SIZE` output elements.

`BLOCK_SIZE` was hardcoded to 256, which is optimal for Gemma4-E2B's sliding-window layers (`head_dim=256`, 28 of 35 layers) but leaves half the reduction's threads idle for its full-attention layers (`global_head_dim=512`, 7 of 35 layers, at indices 4/9/14/19/24/29/34).

## Measurement
Measured directly (marginal per-dispatch cost, standalone submit, at `num_q_heads=8`/`num_kv_heads=1` with representative decode-time `seq_len`s of 128/512/2048):

- `BLOCK_SIZE=256` is **~9-14% faster** than 512 at `head_size=256`
- `BLOCK_SIZE=512` is **~5-9% faster** than 256 at `head_size=512`

Consistent and reproducible across repeated runs, in both directions. (A separate investigation into `local_size_x` tuning for the plain, non-coop `paged_attn_decode_f32.comp` — which is NOT selected in production once a `_coop` variant is available — found no consistent winner there: that shader is compute-bound with each thread doing the full O(seq_len) sequential scan regardless of workgroup size, unlike the coop variant's genuinely workgroup-size-sensitive cooperative reduction.)

## Changes
- `shaders/paged_attn_decode_f32_coop.comp`, `paged_attn_decode_f16_coop.comp`: `BLOCK_SIZE` is now a compile-time macro (`#ifndef BLOCK_SIZE #define BLOCK_SIZE 256 #endif`), used for both `local_size_x` and the `dot_sums` shared-memory array size.
- `scripts/compile_shaders.sh`: compiles both `BLOCK_SIZE=256` (unchanged name) and `BLOCK_SIZE=512` (`_512` name suffix) variants for each dtype.
- `src/lib.rs`: registers the two new `_512` shader names.
- `vllm_vulkan/kv_ops.py`: `_select_decode_shader` now takes `head_size` and chooses whichever coop variant's `BLOCK_SIZE` best matches it (falling back gracefully if the preferred one isn't available), returning the matching workgroup size for `_build_paged_attn_decode_op`'s dispatch formula instead of the previously-hardcoded constant.
- `tests/python/test_kv_ops.py`: two new tests — `test_paged_attn_decode_matches_torch_reference_at_head_size_512` (validates the new `BLOCK_SIZE=512` variant's numerical correctness against the same pure-PyTorch attention reference used elsewhere in this file, for both f32 and f16) and `test_select_decode_shader_prefers_block_size_matching_head_size` (confirms the selection logic picks the right variant at both `head_size=256` and 512).

## Verification
- `cargo build --release` / `cargo test --release`: 28/28 passing.
- `cargo clippy --release --all-targets`: 49 warnings (matches established baseline exactly).
- `pytest tests/python/`: 49 passed, 2 skipped (matches baseline + 3 new tests).
- `scripts/lint.sh`'s tools run directly (shellcheck, ruff check, ruff format --check, mypy): all clean.