### PR TITLE
fix: stop using mul_mat_vec_f32_f32_f32_subgroup (silently wrong output)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3066,6 +3066,143 @@ mod pipeline_cache_startup_tests {
 }
 
 #[cfg(test)]
+mod subgroup_matvec_correctness_tests {
+    //! `mul_mat_vec_f32_f32_f32_subgroup` (previously dispatched from
+    //! vulkan_ops.py's `_vulkan_matvec` — the generic PyTorch-facing
+    //! `linear()` op's decode-path, T<4, GPU implementation used
+    //! whenever this backend replaces an arbitrary vLLM model's
+    //! `nn.Linear` layers, not just Gemma4-E2B's native Rust path) was
+    //! found to silently produce WRONG results for any `ncols` (K) >=
+    //! ~256 — i.e. essentially every real transformer hidden/intermediate
+    //! size — while producing correct results for smaller K (e.g. 16,
+    //! 64). Confirmed via direct comparison against a CPU dot-product
+    //! reference across K in {16, 64, 256, 511, 512, 513, 768, 1024,
+    //! 1025, 1536, 6144}: `mul_mat_vec_f32_f32_f32_subgroup`'s error
+    //! jumps from 0.0 (K<=64) to double-digit absolute error (K>=256),
+    //! while `mul_mat_vec_f32_f32_f32` (the plain, non-subgroup variant,
+    //! identical bindings/push-constants/workgroup-dispatch convention)
+    //! stays exactly correct (error 0.0) at every K tested. The root
+    //! cause looks like mul_mat_vec_base.glsl's `USE_SUBGROUP_ADD`
+    //! cross-subgroup shared-memory reduction (`[[unroll]] for (uint s
+    //! = 0; s < gl_NumSubgroups; ++s)`), which unrolls a loop bounded by
+    //! a value that may not be reliably compile-time-constant on every
+    //! driver — not fully root-caused, but irrelevant to the fix: since
+    //! this backend already has a proven-correct alternative
+    //! (`mul_mat_vec_f32_f32_f32`) with an identical calling convention,
+    //! vulkan_ops.py now dispatches that instead (see the fix in
+    //! vulkan_ops.py's `linear`/`_vulkan_matvec`).
+    //!
+    //! This test is the permanent regression guard: it documents the bug
+    //! (subgroup variant, if ever re-introduced as a dispatch target,
+    //! must not silently diverge again) and confirms the shader
+    //! vulkan_ops.py now actually uses remains correct at every one of
+    //! these shapes.
+    use super::*;
+
+    fn fake_random(len: usize, seed: u64) -> Vec<f32> {
+        let mut state = seed.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(1);
+        (0..len)
+            .map(|_| {
+                state ^= state >> 12; state ^= state << 25; state ^= state >> 27;
+                let bits = state.wrapping_mul(0x2545F4914F6CDD1D);
+                ((bits >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0
+            })
+            .collect()
+    }
+
+    fn make_engine() -> Option<compute::ComputeEngine> {
+        let dev = match device::ComputeDevice::create(0) {
+            Ok(d) => d,
+            Err(e) => { eprintln!("skip: no Vulkan device available ({e})"); return None; }
+        };
+        let shader_spvs = include_all_shaders();
+        let refs: std::collections::HashMap<&str, &[u8]> = shader_spvs.iter()
+            .map(|(k, v)| (k.as_str(), v.as_slice())).collect();
+        Some(compute::ComputeEngine::new(
+            dev.instance.clone(), dev.physical_device, dev.device.clone(),
+            dev.compute_queue, dev.compute_queue_family, &refs,
+        ).expect("create ComputeEngine"))
+    }
+
+    #[test]
+    fn mul_mat_vec_f32_f32_f32_subgroup_diverges_from_cpu_reference_at_realistic_k() {
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        let n = 4usize;
+        let t = 1usize;
+        // At K<=64 the subgroup variant happens to still be correct; the
+        // divergence appears at K=256 and persists at every larger size
+        // tested, covering every realistic Gemma4-E2B (and general
+        // transformer) hidden/intermediate dimension.
+        let mut saw_divergence = false;
+        for &k in &[256usize, 512, 1536, 6144] {
+            let weight = fake_random(n * k, 1);
+            let x = fake_random(t * k, 2);
+            let mut cpu_ref = vec![0.0f32; t * n];
+            for ni in 0..n {
+                let wr = &weight[ni * k..(ni + 1) * k];
+                cpu_ref[ni] = wr.iter().zip(x.iter()).map(|(&w, &v)| w * v).sum::<f32>();
+            }
+            let wbuf = engine.alloc_host_coherent_storage((weight.len() * 4) as u64).unwrap();
+            wbuf.write(bytemuck::cast_slice(&weight)).unwrap();
+            let xbuf = engine.alloc_host_coherent_storage((x.len() * 4) as u64).unwrap();
+            xbuf.write(bytemuck::cast_slice(&x)).unwrap();
+            let out = engine.alloc_host_coherent_storage((t * n * 4) as u64).unwrap();
+            let pc = mv_pc(k, n, t);
+
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "mul_mat_vec_f32_f32_f32_subgroup", &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, t as u32, 1)).unwrap();
+            engine.submit_batch(cb).unwrap();
+            let r = read_f32_buf(&out, t * n);
+            let err = r.iter().zip(cpu_ref.iter()).map(|(&a, &b)| (a - b).abs()).fold(0.0f32, f32::max);
+            if err > 1.0 {
+                saw_divergence = true;
+            }
+        }
+        assert!(
+            saw_divergence,
+            "expected mul_mat_vec_f32_f32_f32_subgroup to diverge from the CPU reference at \
+             at least one of the tested (known-bad) K values — if this now passes, the shader \
+             or driver behavior has changed and vulkan_ops.py might safely use this variant \
+             again, but that should be a deliberate decision backed by this test passing \
+             consistently, not just this one run"
+        );
+    }
+
+    #[test]
+    fn mul_mat_vec_f32_f32_f32_matches_cpu_reference_at_realistic_k() {
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        let n = 4usize;
+        let t = 1usize;
+        for &k in &[16usize, 64, 256, 512, 1536, 6144] {
+            let weight = fake_random(n * k, 1);
+            let x = fake_random(t * k, 2);
+            let mut cpu_ref = vec![0.0f32; t * n];
+            for ni in 0..n {
+                let wr = &weight[ni * k..(ni + 1) * k];
+                cpu_ref[ni] = wr.iter().zip(x.iter()).map(|(&w, &v)| w * v).sum::<f32>();
+            }
+            let wbuf = engine.alloc_host_coherent_storage((weight.len() * 4) as u64).unwrap();
+            wbuf.write(bytemuck::cast_slice(&weight)).unwrap();
+            let xbuf = engine.alloc_host_coherent_storage((x.len() * 4) as u64).unwrap();
+            xbuf.write(bytemuck::cast_slice(&x)).unwrap();
+            let out = engine.alloc_host_coherent_storage((t * n * 4) as u64).unwrap();
+            let pc = mv_pc(k, n, t);
+
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "mul_mat_vec_f32_f32_f32", &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, t as u32, 1)).unwrap();
+            engine.submit_batch(cb).unwrap();
+            let r = read_f32_buf(&out, t * n);
+            let err = r.iter().zip(cpu_ref.iter()).map(|(&a, &b)| (a - b).abs()).fold(0.0f32, f32::max);
+            assert!(err < 1e-2, "k={k}: mul_mat_vec_f32_f32_f32 diverged from CPU reference: {err}");
+        }
+    }
+}
+
+#[cfg(test)]
 mod record_to_tests {
     //! Validates `ComputeEngine::record_to`'s stack-allocated descriptor-
     //! write buffers (see its doc comment) — specifically the

--- a/tests/python/test_vulkan_ops.py
+++ b/tests/python/test_vulkan_ops.py
@@ -40,8 +40,8 @@ def _require_vulkan_context():
         ctx = _rs.VulkanContext(0)
     except RuntimeError as exc:
         pytest.skip(f"VulkanContext unavailable: {exc}")
-    if "mul_mat_vec_f32_f32_f32_subgroup" not in ctx.available_shaders():
-        pytest.skip("mul_mat_vec_f32_f32_f32_subgroup shader unavailable")
+    if "mul_mat_vec_f32_f32_f32" not in ctx.available_shaders():
+        pytest.skip("mul_mat_vec_f32_f32_f32 shader unavailable")
     return ctx
 
 
@@ -78,6 +78,32 @@ def upload_counter(monkeypatch):
 
     monkeypatch.setattr(vulkan_ops._WeightCache, "put", counting_put)
     return counts
+
+
+def test_linear_matches_torch_reference_at_realistic_hidden_size(vulkan_ctx):
+    """Direct numerical correctness check for vulkan_ops.linear()'s GPU
+    decode path (T < _MATVEC_THRESHOLD) against `torch.nn.functional.linear`
+    as ground truth, at a realistic transformer hidden size (1536, matching
+    Gemma4-E2B) -- not just the tiny in_features=8 shapes the other tests in
+    this file use to exercise the weight cache.
+
+    This specific gap (no test comparing the GPU decode-matvec path's
+    OUTPUT against a real reference at a realistic K) is what let a real
+    correctness bug in mul_mat_vec_f32_f32_f32_subgroup go unnoticed: that
+    shader silently diverged from the correct result for any K>=~256 while
+    happening to still be correct at the small K (8) every other test here
+    uses -- see subgroup_matvec_correctness_tests in src/lib.rs for the
+    measured divergence, and this file's `_require_vulkan_context` /
+    vulkan_ops.py's `linear`/`_vulkan_matvec` for the fix (now dispatching
+    mul_mat_vec_f32_f32_f32, the plain non-subgroup variant, instead).
+    """
+    out_features, in_features = 512, 1536
+    weight = torch.randn(out_features, in_features, dtype=torch.float32)
+    x = torch.randn(1, in_features, dtype=torch.float32)  # T=1 < _MATVEC_THRESHOLD
+
+    result = vulkan_ops.linear(x, weight, None)
+    expected = torch.nn.functional.linear(x, weight, None)
+    torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
 
 
 def test_get_or_upload_weight_hits_cache_for_same_tensor_object(

--- a/vllm_vulkan/vulkan_ops.py
+++ b/vllm_vulkan/vulkan_ops.py
@@ -206,7 +206,7 @@ def _rms_norm_pc(nrows: int, ncols: int, eps: float) -> bytes:
 
 
 def _matvec_pc(T: int, K: int, N: int) -> bytes:  # noqa: N803
-    """Pack push constants for mul_mat_vec_f32_f32_f32_subgroup."""
+    """Pack push constants for mul_mat_vec_f32_f32_f32."""
     return struct.pack(
         "13I",
         K,
@@ -291,10 +291,7 @@ def linear(
     x_2d = x.float().reshape(-1, in_feat)
     T = x_2d.shape[0]  # noqa: N806
 
-    if (
-        T < _MATVEC_THRESHOLD
-        and "mul_mat_vec_f32_f32_f32_subgroup" in ctx.available_shaders()
-    ):
+    if T < _MATVEC_THRESHOLD and "mul_mat_vec_f32_f32_f32" in ctx.available_shaders():
         result = _vulkan_matvec(ctx, x_2d, weight)
     else:
         result = torch.nn.functional.linear(
@@ -312,7 +309,17 @@ def _vulkan_matvec(
     x: torch.Tensor,  # [T, K] float32
     weight: torch.Tensor,  # [N, K] any dtype
 ) -> torch.Tensor:
-    """Dispatch mul_mat_vec_f32_f32_f32_subgroup for decode (T<4)."""
+    """Dispatch mul_mat_vec_f32_f32_f32 for decode (T<4).
+
+    NOT mul_mat_vec_f32_f32_f32_subgroup: that variant was found to
+    silently diverge from the correct result for ncols>=~256 (i.e.
+    essentially every real hidden/intermediate size) -- see
+    subgroup_matvec_correctness_tests in src/lib.rs for the measured
+    divergence and root-cause discussion. mul_mat_vec_f32_f32_f32 (the
+    plain, non-subgroup variant) has an identical binding/push-constant/
+    workgroup-dispatch convention and was confirmed correct at every
+    size tested.
+    """
     # Cache key on original weight (before .float()) - and the .float()
     # conversion itself only happens lazily, in the `w_gpu is None`
     # fallback branch below, since on the (overwhelmingly common) cache-hit
@@ -332,7 +339,7 @@ def _vulkan_matvec(
     results = ctx.execute_batch(
         [
             (
-                "mul_mat_vec_f32_f32_f32_subgroup",
+                "mul_mat_vec_f32_f32_f32",
                 [w_binding, x_bytes],
                 [out_size],
                 pc,
@@ -377,7 +384,7 @@ def rms_norm_then_linear(
     if (
         T >= _MATVEC_THRESHOLD
         or "rms_norm_f32_mul" not in ctx.available_shaders()
-        or "mul_mat_vec_f32_f32_f32_subgroup" not in ctx.available_shaders()
+        or "mul_mat_vec_f32_f32_f32" not in ctx.available_shaders()
     ):
         normed = rms_norm(x, norm_weight, eps)
         return linear(normed, linear_weight, bias)
@@ -407,7 +414,7 @@ def rms_norm_then_linear(
         norm_out_size,
         norm_pc,
         (nrows, 1, 1),
-        "mul_mat_vec_f32_f32_f32_subgroup",
+        "mul_mat_vec_f32_f32_f32",
         [w_lin_binding],  # Op1 gets [weight, inter_buf(auto), out_buf(auto)]
         matvec_out_size,
         matvec_pc,


### PR DESCRIPTION
## Summary
**Critical correctness bug fix.** `vulkan_ops.py`'s `linear()`/`_vulkan_matvec` and `rms_norm_then_linear` (the generic PyTorch-facing GPU decode-path Linear op this backend provides for arbitrary vLLM models, and its fused RMSNorm+Linear variant) both dispatched `mul_mat_vec_f32_f32_f32_subgroup` for T<4 decode-path matvecs.

That shader silently produces **WRONG output** for any `ncols` (K, the input feature dimension) >= ~256 — i.e. essentially every real transformer hidden/intermediate size, including Gemma4-E2B's own `hidden_size=1536`.

## How this was found and confirmed
While investigating a `BLOCK_SIZE` tuning opportunity for this shader (following the same methodology as #56), a direct correctness comparison against a CPU dot-product reference revealed:

- K in {16, 64}: error = 0.0 (correct)
- K in {256, 511, 512, 513, 768, 1024, 1025, 1536, 6144}: error jumps to double-digit absolute error and stays wrong at every size

Confirmed end-to-end through the actual Python API too: at `out_features=512`/`in_features=1536`, `vulkan_ops.linear()`'s result differed from `torch.nn.functional.linear` in **100% of output elements** (greatest absolute difference **108.55**).

The likely root cause is `mul_mat_vec_base.glsl`'s `USE_SUBGROUP_ADD` cross-subgroup shared-memory reduction, which unrolls a loop (`[[unroll]] for (uint s = 0; s < gl_NumSubgroups; ++s)`) bounded by a value that may not be reliably compile-time-constant on every driver — not fully root-caused, but irrelevant to the fix: this backend already has a proven-correct alternative with an identical binding/push-constant/workgroup-dispatch convention.

## Why this went unnoticed
No test in this codebase compared this GPU decode-matvec path's output against a real reference at a realistic K: `test_vulkan_ops.py`'s existing tests all use `in_features=8` (small enough to happen to still be correct) and only verify weight-cache upload-counting behavior, never numerical output correctness at realistic scale.

## Fix
Dispatch `mul_mat_vec_f32_f32_f32` (the plain, non-subgroup base variant — already compiled and used elsewhere in this codebase) instead. Confirmed correct at every K tested, including the exact shapes where the subgroup variant diverges.

## Changes
- `vllm_vulkan/vulkan_ops.py`: dispatch `mul_mat_vec_f32_f32_f32` instead of `mul_mat_vec_f32_f32_f32_subgroup` in both call sites, update shader-availability checks and docstrings.
- `src/lib.rs`: new `subgroup_matvec_correctness_tests` module — a permanent regression guard documenting the divergence and confirming the now-used shader stays correct.
- `tests/python/test_vulkan_ops.py`: new `test_linear_matches_torch_reference_at_realistic_hidden_size` — closes the actual test-coverage gap that let this bug go unnoticed. Also fixes `_require_vulkan_context`'s shader-availability check.

## Verification
- Reverting just the `vulkan_ops.py` change reproduces the exact 100%-elements-wrong failure in the new Python test, confirming both that the bug is real and that these tests would catch a regression.
- `cargo build --release` / `cargo test --release`: 30/30 passing (28 baseline + 2 new).
- `cargo clippy --release --all-targets`: 49 warnings (matches established baseline exactly).
- `pytest tests/python/`: 50 passed, 2 skipped (49 baseline + 1 new).
- `scripts/lint.sh`'s tools run directly (shellcheck, ruff check, ruff format, mypy): all clean.