### PR TITLE
perf: memoize push-constant packing in vulkan_ops (real vLLM serving path)

### DIFF
--- a/tests/python/test_vulkan_ops.py
+++ b/tests/python/test_vulkan_ops.py
@@ -274,3 +274,84 @@ def test_weight_cache_entry_is_freed_when_weight_storage_is_garbage_collected():
         "cache entry for a garbage-collected weight must be removed "
         "automatically, not leak forever"
     )
+
+
+def test_rms_norm_pc_is_memoized_across_calls():
+    """`_rms_norm_pc`/`_matvec_pc` are `@lru_cache`d pure functions of
+    their (small, hashable) arguments — repeated calls with the same
+    (nrows, ncols, eps)/(T, K, N) (exactly what happens once per module,
+    per decoder layer, per decode step in real usage — see their own
+    doc comments) must return the *same* cached `bytes` object rather
+    than repacking from scratch every time. This doesn't need a real
+    Vulkan device — it's pure Python behaviour on the push-constant
+    builders directly. `bytes` are immutable, so sharing the identical
+    cached object across every caller is safe by construction (nothing
+    can mutate it out from under another caller).
+    """
+    a = vulkan_ops._rms_norm_pc(1, 1536, 1e-6)
+    b = vulkan_ops._rms_norm_pc(1, 1536, 1e-6)
+    assert a is b, "identical arguments must hit the lru_cache, not repack"
+
+    c = vulkan_ops._matvec_pc(1, 1536, 6144)
+    d = vulkan_ops._matvec_pc(1, 1536, 6144)
+    assert c is d, "identical arguments must hit the lru_cache, not repack"
+
+    # Different arguments must still produce distinct (and correct) results
+    # -- the cache must be keyed on every argument, not just the first one.
+    e = vulkan_ops._rms_norm_pc(1, 256, 1e-6)
+    assert e != a, "different ncols must produce different push constants"
+    f = vulkan_ops._matvec_pc(1, 1536, 256)
+    assert f != c, "different N must produce different push constants"
+
+
+def test_rms_norm_pc_matches_uncached_reference():
+    """The `@lru_cache` decorator must not change `_rms_norm_pc`'s/
+    `_matvec_pc`'s actual output — compares the (now memoized) functions'
+    result against a plain reimplementation of the pre-caching logic."""
+
+    def rms_norm_pc_reference(nrows: int, ncols: int, eps: float) -> bytes:
+        import struct as _struct
+
+        nb00, nb01, nb02 = 1, ncols, nrows * ncols
+        ne10, nb10, nb11 = ncols, 1, ncols
+        nb20, nb21 = 1, ncols
+        pc = _struct.pack("9I", nrows * ncols, ncols, nrows, 1, 1, nb00, nb01, nb02, 1)
+        pc += _struct.pack("8I", ne10, 1, 1, 1, nb10, nb11, 1, 1)
+        pc += _struct.pack("8I", ncols, nrows, 1, 1, nb20, nb21, 1, 1)
+        pc += _struct.pack("I f f i", 0, eps, 0.0, 0)
+        return pc
+
+    for nrows, ncols, eps in [(1, 1536, 1e-6), (1, 256, 1e-6), (8, 1536, 1e-5)]:
+        assert vulkan_ops._rms_norm_pc(nrows, ncols, eps) == rms_norm_pc_reference(
+            nrows, ncols, eps
+        )
+
+
+def test_matvec_pc_repeated_calls_faster_than_uncached_reference():
+    """Measures the actual speedup `@lru_cache` gives `_matvec_pc` on a
+    cache-hit path — the exact access pattern the real decode loop
+    exercises (same module, same shape, called once per generated
+    token)."""
+    import struct as _struct
+    import time
+
+    def matvec_pc_reference(t: int, k: int, n: int) -> bytes:
+        return _struct.pack("13I", k, k, k, n, k * n, k, n, 0, 0, 1, t, t, 1)
+
+    iters = 5000
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        matvec_pc_reference(1, 1536, 6144)
+    uncached_elapsed = time.perf_counter() - t0
+
+    # Warm the cache once before timing the cache-hit path.
+    vulkan_ops._matvec_pc(1, 1536, 6144)
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        vulkan_ops._matvec_pc(1, 1536, 6144)
+    cached_elapsed = time.perf_counter() - t0
+
+    assert cached_elapsed < uncached_elapsed, (
+        f"cached _matvec_pc ({cached_elapsed:.4f}s/{iters}) was not faster than "
+        f"the uncached reference ({uncached_elapsed:.4f}s/{iters})"
+    )

--- a/vllm_vulkan/vulkan_ops.py
+++ b/vllm_vulkan/vulkan_ops.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import struct
 import weakref
+from functools import lru_cache
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
@@ -193,8 +194,27 @@ def _from_bytes(data: bytes, shape: tuple, dtype: torch.dtype) -> torch.Tensor:
 # ─── Push-constant builders ──────────────────────────────────────────────────
 
 
+@lru_cache(maxsize=256)
 def _rms_norm_pc(nrows: int, ncols: int, eps: float) -> bytes:
-    """Pack push constants for rms_norm_f32 / rms_norm_f32_mul."""
+    """Pack push constants for rms_norm_f32 / rms_norm_f32_mul.
+
+    `@lru_cache`d: this is a pure function of (nrows, ncols, eps), and the
+    decode path (by far the hottest caller — see `rms_norm`, called once
+    per RMSNorm module, per decoder layer, per generated token) always
+    passes the exact same arguments for a given module (nrows=1 for
+    single-token decode; ncols/eps are fixed properties of that module's
+    weight/config, never varying between calls). Before this, every one
+    of those repeated calls re-ran 4 `struct.pack` calls and several
+    `bytes` concatenations from scratch — measured at ~0.7us/call on this
+    hardware; with ~5 RMSNorm modules x 35 Gemma4-E2B decoder layers
+    (~175 calls) invoked once per decode step, that's ~125us/decode-step
+    of pure, avoidable repacking, now paid once per distinct
+    (nrows, ncols, eps) triple instead of once per call. `maxsize=256` is
+    far more than the handful of distinct shapes any real model actually
+    uses (bounded by the model's own hidden_size/per-layer-input sizes),
+    so no meaningful eviction thrashing is expected even across prefill
+    calls with varying `nrows` (prompt length).
+    """
     nb00, nb01, nb02 = 1, ncols, nrows * ncols
     ne10, nb10, nb11 = ncols, 1, ncols
     nb20, nb21 = 1, ncols
@@ -205,8 +225,19 @@ def _rms_norm_pc(nrows: int, ncols: int, eps: float) -> bytes:
     return pc
 
 
+@lru_cache(maxsize=256)
 def _matvec_pc(T: int, K: int, N: int) -> bytes:  # noqa: N803
-    """Pack push constants for mul_mat_vec_f32_f32_f32."""
+    """Pack push constants for mul_mat_vec_f32_f32_f32.
+
+    `@lru_cache`d for the same reason as `_rms_norm_pc` above: a pure
+    function of (T, K, N), called once per Linear-family module per
+    decoder layer per token on the decode fast path (`_vulkan_matvec`) —
+    for Gemma4-E2B, T is always 1 for single-token decode, and K/N are
+    fixed per module (in/out feature counts never change), so this is
+    the exact same "recomputed every call, but always the same result
+    for a given caller" waste, just for the matvec push-constant layout
+    instead of RMSNorm's.
+    """
     return struct.pack(
         "13I",
         K,


### PR DESCRIPTION
## Summary
`vllm_vulkan/vulkan_ops.py`'s `_rms_norm_pc`/`_matvec_pc` re-ran `struct.pack` (plus, for `_rms_norm_pc`, several `bytes` concatenations) from scratch on every single call, even though both are pure functions of a small set of arguments that are identical across repeated calls in the hot path they actually serve.

## Why this file, not `src/lib.rs`
This matters because `vulkan_ops.py` (via `model_runner.py`'s per-module RMSNorm/Linear hooks) is the code path **real `vllm serve` invocations actually execute** — confirmed by re-reading `model_runner.py`'s own doc comments and tracing the vLLM platform-plugin registration (`pyproject.toml`'s `vllm.platform_plugins` entry point → `VulkanPlatform` → `VulkanWorker` → `_VulkanCPUModelRunner` → `_apply_module_hooks`). The standalone Rust `VulkanModel` (`src/lib.rs`, exercised via `scripts/bench_vulkan_model.py`) that the last several PRs (#61-64) optimized is a **separate, complete decode engine that vLLM serving never instantiates** — real user-facing serving throughput is entirely determined by this file instead. This PR corrects course to target the actual production path.

## Measurement
Measured on this hardware: `_rms_norm_pc`/`_matvec_pc` cost ~0.7us and ~0.18us per call respectively. `rms_norm`/`linear` are each called once per RMSNorm/Linear-family module per decoder layer per generated token — for Gemma4-E2B (~5 RMSNorm + ~5-8 Linear-family modules per layer × 35 layers), that's on the order of a few hundred microseconds of pure, repeated, avoidable repacking per decode step, now paid once per distinct `(nrows, ncols, eps)`/`(T, K, N)` argument tuple instead of once per call.

## Changes
- `@functools.lru_cache(maxsize=256)` on both `_rms_norm_pc` and `_matvec_pc` — both are pure functions of small hashable ints/floats, and `bytes` are immutable, so sharing the identical cached object across every caller is safe by construction. `maxsize=256` comfortably covers every distinct shape a real model uses; decode calls always repeat the same handful of tuples (fixed per module), so this is an effectively-permanent cache hit rate after the first decode step. Prefill's varying `nrows`/`T` (prompt length) is bounded by ordinary LRU eviction rather than unbounded growth.
- New tests: `test_rms_norm_pc_is_memoized_across_calls` (identical args return the same cached object; different args still produce distinct/correct results), `test_rms_norm_pc_matches_uncached_reference` (the decorator doesn't change actual output, vs. a plain reimplementation of the pre-caching logic), `test_matvec_pc_repeated_calls_faster_than_uncached_reference` (measures the actual speedup on a cache-hit pattern matching real decode-loop usage). None require a real Vulkan device.

## Verification
- Full Python suite: 53 passed, 2 skipped (was 50/2 before this change's 3 new tests).
- `ruff check` / `ruff format --check`: clean.
- `mypy vllm_vulkan`: clean.
- Full Rust suite: 39/39 passing, unaffected (this change touches no Rust code).