### PR TITLE
perf: hoist repeated local imports to module level in attention.py

### DIFF
--- a/tests/python/test_attention_backend.py
+++ b/tests/python/test_attention_backend.py
@@ -108,6 +108,94 @@ def test_vulkan_attention_backend_uses_paged_decode_for_single_token_batch(monke
     torch.testing.assert_close(output, expected, rtol=5e-3, atol=5e-3)
 
 
+def test_vulkan_attention_backend_uses_paged_decode_for_single_token_batch_f32(
+    monkeypatch,
+):
+    """Same scenario as
+    `test_vulkan_attention_backend_uses_paged_decode_for_single_token_batch`
+    above, but with a float32 KV cache — every other test in this file
+    uses float16, so this is the only coverage exercising the
+    `paged_attn_decode_batch_f32`/`paged_kv_write_f32` branch of
+    `_try_vulkan_decode`/`_try_write_tokens_to_vulkan_cache`'s dtype
+    selection (now a plain ternary hoisted to module-level imports,
+    rather than a conditional local import — see attention.py's
+    `_get_vulkan_context` doc comment)."""
+    _require_vulkan_context()
+    logged_messages = []
+    monkeypatch.setattr(
+        attention_mod.logger,
+        "debug",
+        lambda msg, *args, **kwargs: logged_messages.append(msg % args),
+    )
+
+    num_heads = 4
+    num_kv_heads = 2
+    head_size = 32
+    block_size = 16
+    num_blocks = 4
+    num_reqs = 2
+    scale = head_size**-0.5
+
+    query = torch.randn(num_reqs, num_heads, head_size, dtype=torch.float32)
+    key = torch.randn(num_reqs, num_kv_heads, head_size, dtype=torch.float32)
+    value = torch.randn(num_reqs, num_kv_heads, head_size, dtype=torch.float32)
+    kv_cache = torch.zeros(
+        (2, num_blocks, num_kv_heads, block_size, head_size),
+        dtype=torch.float32,
+    )
+    output = torch.empty((num_reqs, num_heads, head_size), dtype=torch.float32)
+
+    metadata = CPUAttentionMetadata(
+        isa="vec16",
+        num_actual_tokens=num_reqs,
+        max_query_len=1,
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        max_seq_len=1,
+        seq_lens=torch.tensor([1, 1], dtype=torch.int32),
+        block_table=torch.tensor([[0], [1]], dtype=torch.int32),
+        slot_mapping=torch.tensor([0, block_size], dtype=torch.int64),
+        scheduler_metadata=None,
+        causal=True,
+    )
+    impl = VulkanAttentionBackendImpl(
+        num_heads=num_heads,
+        head_size=head_size,
+        scale=scale,
+        num_kv_heads=num_kv_heads,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+        attn_type=AttentionType.DECODER,
+        kv_sharing_target_layer_name=None,
+    )
+
+    result = impl.forward(
+        layer=None,  # type: ignore[arg-type]
+        query=query,
+        key=key,
+        value=value,
+        kv_cache=kv_cache,
+        attn_metadata=metadata,
+        output=output,
+    )
+
+    expected = []
+    gqa_ratio = num_heads // num_kv_heads
+    for req_idx in range(num_reqs):
+        rows = []
+        for q_head in range(num_heads):
+            rows.append(value[req_idx, q_head // gqa_ratio].float())
+        expected.append(torch.stack(rows))
+    expected = torch.stack(expected)
+
+    assert impl._last_vulkan_decode_used is True
+    assert result is output
+    assert any("Vulkan attention decode used" in msg for msg in logged_messages)
+
+    torch.testing.assert_close(output, expected, rtol=5e-3, atol=5e-3)
+
+
 def test_vulkan_attention_backend_mirrors_prefill_kv_before_decode():
     _require_vulkan_context()
 

--- a/vllm_vulkan/attention.py
+++ b/vllm_vulkan/attention.py
@@ -23,8 +23,14 @@ from vllm.v1.attention.backends.cpu_attn import (
     CPUAttentionMetadata,
 )
 
-from vllm_vulkan import envs
+from vllm_vulkan import envs, vulkan_ops
 from vllm_vulkan.kv_layout import KVCacheLayerSpec, VulkanPagedKVLayout
+from vllm_vulkan.kv_ops import (
+    paged_attn_decode_batch_f16,
+    paged_attn_decode_batch_f32,
+    paged_kv_write_f16,
+    paged_kv_write_f32,
+)
 
 if TYPE_CHECKING:
     from vllm_vulkan._rs import GpuTensor, VulkanContext
@@ -301,18 +307,11 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
                 return False
 
             entry = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
-            if kv_cache.dtype == torch.float16:
-                from vllm_vulkan.kv_ops import (  # noqa: PLC0415
-                    paged_attn_decode_batch_f16,
-                )
-
-                decode_batch = paged_attn_decode_batch_f16
-            else:
-                from vllm_vulkan.kv_ops import (  # noqa: PLC0415
-                    paged_attn_decode_batch_f32,
-                )
-
-                decode_batch = paged_attn_decode_batch_f32
+            decode_batch = (
+                paged_attn_decode_batch_f16
+                if kv_cache.dtype == torch.float16
+                else paged_attn_decode_batch_f32
+            )
 
             _, seq_lens, block_table = _cached_decode_support_data(
                 attn_metadata, num_actual_tokens
@@ -413,14 +412,11 @@ def _try_write_tokens_to_vulkan_cache(
             return
 
         entry = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
-        if kv_cache.dtype == torch.float16:
-            from vllm_vulkan.kv_ops import (  # noqa: PLC0415
-                paged_kv_write_f16 as write_kv,
-            )
-        else:
-            from vllm_vulkan.kv_ops import (  # noqa: PLC0415
-                paged_kv_write_f32 as write_kv,
-            )
+        write_kv = (
+            paged_kv_write_f16
+            if kv_cache.dtype == torch.float16
+            else paged_kv_write_f32
+        )
 
         slots = (
             slot_mapping[:num_tokens]
@@ -562,8 +558,23 @@ def _remember_verified_prefix(
 
 
 def _get_vulkan_context() -> VulkanContext | None:
+    # `vulkan_ops` is imported at module level (top of this file): it's a
+    # pure-Python module whose own references to `vllm_vulkan._rs` are
+    # themselves deferred to `TYPE_CHECKING`/local-import time (see its
+    # own imports), so importing it here doesn't need the compiled Rust
+    # extension to be available at all -- unlike `_rs.VulkanContext`
+    # itself, which genuinely does, and stays a local import so this
+    # function's surrounding try/except can keep gracefully falling back
+    # to CPU_ATTN (returning None) in an environment where the compiled
+    # extension isn't available, rather than failing at *module import*
+    # time merely by importing `attention.py`. Measured directly on this
+    # hardware: repeating `from vllm_vulkan import vulkan_ops` on every
+    # call (previously local here too) cost ~0.375us/call beyond
+    # `is_ready()`'s own ~0.08us -- this function (and the equivalent
+    # `kv_ops` function imports removed from `_try_vulkan_decode`/
+    # `_try_write_tokens_to_vulkan_cache`) runs up to ~70 times/decode
+    # step (once per attention layer for each of the two call sites).
     try:
-        from vllm_vulkan import vulkan_ops  # noqa: PLC0415
         from vllm_vulkan._rs import VulkanContext  # noqa: PLC0415
 
         if not vulkan_ops.is_ready():


### PR DESCRIPTION
## Summary
`_get_vulkan_context`, `_try_vulkan_decode`, and `_try_write_tokens_to_vulkan_cache` each re-imported `vulkan_ops` and/or specific `kv_ops` functions (`paged_attn_decode_batch_f16/f32`, `paged_kv_write_f16/f32`) on every single call via local (function-body) import statements, even though none of these modules/functions can ever change at runtime.

## Why this is safe
`vulkan_ops.py` and `kv_ops.py` are both pure-Python modules whose own references to `vllm_vulkan._rs` (the compiled Rust extension) are themselves deferred to `TYPE_CHECKING`-only or their own local imports — confirmed by reading both files directly — so importing either at module level in `attention.py` doesn't require the compiled extension to be available at all, unlike `vllm_vulkan._rs.VulkanContext` itself, which genuinely does and **stays a local import** in `_get_vulkan_context` so its surrounding try/except can keep gracefully falling back to CPU_ATTN in an environment where the compiled extension isn't available, rather than failing at module-import time merely by importing `attention.py`.

## Measurement
Repeating `from vllm_vulkan import vulkan_ops` on every call costs ~0.375us/call beyond `is_ready()`'s own ~0.08us (Python's import machinery still does a `sys.modules` lookup + attribute binding even when the module is already cached). These functions run up to ~70 times/decode step across their two call sites, so this was **~26us/decode-step** of pure, repeated, avoidable import-machinery overhead — smaller than the other fixes in this real-serving-path optimization series (#65-71), but the same class of avoidable per-call cost.

## Changes
- Moves `vulkan_ops` and the 4 `kv_ops` dtype-variant functions to module-level imports.
- The dtype-conditional local imports collapse into plain ternaries now that both variants are already imported at module level.
- Adds `test_vulkan_attention_backend_uses_paged_decode_for_single_token_batch_f32`: every other test in `test_attention_backend.py` only exercised the float16 KV-cache dtype branch, leaving the float32 branch without any existing coverage — this closes that gap.

## A note on local test execution
As with #71, `vllm_vulkan/attention.py` imports directly from `vllm` at module level, so it cannot be exercised at all in this sandbox (vllm isn't installed locally). Verified via careful manual review (confirmed no circular import and no `_rs` runtime dependency in `vulkan_ops.py`/`kv_ops.py`'s own imports); these vllm-dependent tests run only in CI.

## Verification
- Full Python suite runnable locally: 77 passed, 2 skipped (same 2 pre-existing vllm-gated skips as every prior commit this session).
- `ruff check` / `ruff format --check`: clean.
- `mypy vllm_vulkan`: clean.
- Full Rust suite: 39/39 passing, unaffected (this change touches no Rust code).