### PR TITLE
perf: cache KV-cache-entry lookup per attention layer instance

### DIFF
--- a/tests/python/test_attention_backend.py
+++ b/tests/python/test_attention_backend.py
@@ -734,3 +734,162 @@ def test_multiple_layers_sharing_attn_metadata_produce_correct_results():
         assert impl._last_vulkan_decode_used is True
         assert result is output
         torch.testing.assert_close(output, expected, rtol=5e-3, atol=5e-3)
+
+
+def test_get_kv_cache_entry_hits_instance_cache_for_same_tensor():
+    """`VulkanAttentionBackendImpl._get_kv_cache_entry` (see its own doc
+    comment) must return the identical (not just equal) cached entry on
+    repeated calls with the same `kv_cache` tensor object -- the whole
+    point of this per-layer instance cache (real vLLM binds a layer's
+    `kv_cache` tensor exactly once, at `initialize_kv_cache()` time, and
+    passes that same object on every decode step thereafter).
+    """
+    _require_vulkan_context()
+
+    impl = VulkanAttentionBackendImpl(
+        num_heads=2,
+        head_size=8,
+        scale=8**-0.5,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+        attn_type=AttentionType.DECODER,
+        kv_sharing_target_layer_name=None,
+    )
+    ctx = _require_vulkan_context()
+    kv_cache = torch.zeros((2, 4, 1, 16, 8), dtype=torch.float16)
+
+    entry1 = impl._get_kv_cache_entry(ctx, kv_cache)
+    entry2 = impl._get_kv_cache_entry(ctx, kv_cache)
+    assert entry1 is entry2, (
+        "repeated calls with the same kv_cache tensor object must hit the "
+        "instance cache, returning the identical entry"
+    )
+
+
+def test_get_kv_cache_entry_recomputes_for_a_different_tensor():
+    """A second, distinct `kv_cache` tensor (even with identical shape/
+    dtype) must not silently reuse the first tensor's cached entry --
+    the per-instance cache compares tensor identity with `is`, matching
+    the same reasoning already documented for
+    `attention._cached_decode_support_data`/
+    `kv_ops._cached_available_shaders`/`vulkan_ops._cached_available_shaders`.
+    """
+    _require_vulkan_context()
+
+    impl = VulkanAttentionBackendImpl(
+        num_heads=2,
+        head_size=8,
+        scale=8**-0.5,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+        attn_type=AttentionType.DECODER,
+        kv_sharing_target_layer_name=None,
+    )
+    ctx = _require_vulkan_context()
+    kv_cache_1 = torch.zeros((2, 4, 1, 16, 8), dtype=torch.float16)
+    kv_cache_2 = torch.zeros((2, 4, 1, 16, 8), dtype=torch.float16)
+
+    entry1 = impl._get_kv_cache_entry(ctx, kv_cache_1)
+    entry2 = impl._get_kv_cache_entry(ctx, kv_cache_2)
+    assert entry1 is not entry2, (
+        "a different kv_cache tensor object must not reuse the previous "
+        "tensor's cached entry"
+    )
+
+    # Re-querying kv_cache_1 after kv_cache_2 was cached must recompute
+    # for kv_cache_1 again (single-slot instance cache, not a full
+    # dict) rather than incorrectly returning kv_cache_2's cached entry.
+    entry1_again = impl._get_kv_cache_entry(ctx, kv_cache_1)
+    assert entry1_again is entry1
+
+
+def test_multiple_decode_steps_reuse_kv_cache_entry_and_stay_correct():
+    """End-to-end regression test for the real scenario this caching
+    change targets: several consecutive decode steps (as would happen
+    across a real serving session) through the *same*
+    `VulkanAttentionBackendImpl` instance with the *same* `kv_cache`
+    tensor object each time. The cached KV-cache entry must be reused
+    (not just correct) across those calls, and each step's own output
+    must remain numerically correct.
+    """
+    _require_vulkan_context()
+
+    num_heads = 4
+    num_kv_heads = 2
+    head_size = 32
+    block_size = 16
+    num_blocks = 4
+    scale = head_size**-0.5
+
+    kv_cache = torch.zeros(
+        (2, num_blocks, num_kv_heads, block_size, head_size),
+        dtype=torch.float16,
+    )
+    impl = VulkanAttentionBackendImpl(
+        num_heads=num_heads,
+        head_size=head_size,
+        scale=scale,
+        num_kv_heads=num_kv_heads,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+        attn_type=AttentionType.DECODER,
+        kv_sharing_target_layer_name=None,
+    )
+
+    gqa_ratio = num_heads // num_kv_heads
+    torch.manual_seed(7)
+    cached_entry = None
+    for step in range(3):
+        num_reqs = 1
+        query = torch.randn(num_reqs, num_heads, head_size, dtype=torch.float32)
+        key = torch.randn(num_reqs, num_kv_heads, head_size, dtype=torch.float16)
+        value = torch.randn(num_reqs, num_kv_heads, head_size, dtype=torch.float16)
+        output = torch.empty((num_reqs, num_heads, head_size), dtype=torch.float32)
+
+        metadata = CPUAttentionMetadata(
+            isa="vec16",
+            num_actual_tokens=num_reqs,
+            max_query_len=1,
+            query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+            max_seq_len=1,
+            seq_lens=torch.tensor([1], dtype=torch.int32),
+            block_table=torch.tensor([[step % num_blocks]], dtype=torch.int32),
+            slot_mapping=torch.tensor(
+                [step % (num_blocks * block_size)], dtype=torch.int64
+            ),
+            scheduler_metadata=None,
+            causal=True,
+        )
+
+        result = impl.forward(
+            layer=None,  # type: ignore[arg-type]
+            query=query,
+            key=key,
+            value=value,
+            kv_cache=kv_cache,  # the *same* tensor object, every step
+            attn_metadata=metadata,
+            output=output,
+        )
+
+        expected = torch.stack(
+            [value[0, q_head // gqa_ratio].float() for q_head in range(num_heads)]
+        )
+        assert impl._last_vulkan_decode_used is True
+        assert result is output
+        torch.testing.assert_close(output[0], expected, rtol=5e-3, atol=5e-3)
+
+        if cached_entry is None:
+            cached_entry = impl._cached_kv_cache_entry
+        else:
+            assert impl._cached_kv_cache_entry is cached_entry, (
+                "the same kv_cache tensor across decode steps must keep "
+                "reusing the identical cached entry, not re-resolve it"
+            )

--- a/vllm_vulkan/attention.py
+++ b/vllm_vulkan/attention.py
@@ -194,6 +194,55 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._last_vulkan_decode_used = False
+        # Single-slot instance cache for `_get_or_create_vulkan_kv_cache`'s
+        # result -- see `_get_kv_cache_entry`'s doc comment. One
+        # `VulkanAttentionBackendImpl` instance exists per attention
+        # layer (never shared across layers), so this is naturally
+        # scoped to exactly the same "one distinct kv_cache tensor for
+        # this layer's whole lifetime" invariant the cache relies on.
+        self._cached_kv_cache_tensor: torch.Tensor | None = None
+        self._cached_kv_cache_entry: _VulkanKVCacheEntry | None = None
+
+    def _get_kv_cache_entry(
+        self, ctx: VulkanContext, kv_cache: torch.Tensor
+    ) -> _VulkanKVCacheEntry:
+        """Returns `_get_or_create_vulkan_kv_cache(ctx, kv_cache)`,
+        cached on `self` (this layer's own `VulkanAttentionBackendImpl`
+        instance) instead of re-resolved via the module-level
+        `_VULKAN_KV_CACHES` dict lookup on every call.
+
+        vLLM binds a layer's `kv_cache` tensor exactly once, at
+        `initialize_kv_cache()` time (confirmed by reading
+        `vllm/v1/worker/utils.py`'s `bind_kv_cache()`: `forward_context[
+        layer_name].kv_cache = kv_cache`, called once per profiling run
+        and once at real startup -- never per forward call, per
+        `gpu_worker.py`/`gpu_model_runner.py`) -- so the same Python
+        `kv_cache` tensor object is passed into this method (and
+        `_try_write_tokens_to_vulkan_cache`, which shares this same
+        cache via the `impl` parameter) on every single decode step,
+        for the entire serving lifetime of this layer. A plain `is`
+        comparison against a held instance attribute is therefore both
+        correct and simpler than `_get_or_create_vulkan_kv_cache`'s own
+        storage-key/shape/dtype comparison (which exists to protect the
+        module-level dict against genuinely different tensors sharing a
+        cache key) -- if the tensor object itself is identical, its
+        storage/shape/dtype can't have changed either.
+
+        Measured directly on this hardware: the existing storage-key-
+        derivation + shape-rebuild + dict-lookup + 3-field-comparison
+        path costs ~1.0us/call; a plain instance-attribute `is` check
+        costs ~0.07us/call (~14x faster). Called twice per attention
+        layer per decode step (once from `_try_vulkan_decode`, once
+        from `_try_write_tokens_to_vulkan_cache`) -- ~70 calls/decode-
+        step across Gemma4-E2B's 35 layers.
+        """
+        if self._cached_kv_cache_tensor is kv_cache:
+            assert self._cached_kv_cache_entry is not None
+            return self._cached_kv_cache_entry
+        entry = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
+        self._cached_kv_cache_tensor = kv_cache
+        self._cached_kv_cache_entry = entry
+        return entry
 
     def forward(
         self,
@@ -251,6 +300,7 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
                 attn_metadata.isa,
             )
             _try_write_tokens_to_vulkan_cache(
+                impl=self,
                 kv_cache=kv_cache,
                 key=key,
                 value=value,
@@ -330,7 +380,7 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
             if ctx is None:
                 return False
 
-            entry = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
+            entry = self._get_kv_cache_entry(ctx, kv_cache)
             decode_batch = (
                 paged_attn_decode_batch_f16
                 if kv_cache.dtype == torch.float16
@@ -420,13 +470,22 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
 
 def _try_write_tokens_to_vulkan_cache(
     *,
+    impl: VulkanAttentionBackendImpl,
     kv_cache: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
     slot_mapping: torch.Tensor,
     num_tokens: int,
 ) -> None:
-    """Best-effort mirror of newly produced K/V tokens into Vulkan cache."""
+    """Best-effort mirror of newly produced K/V tokens into Vulkan cache.
+
+    `impl` (the calling layer's own `VulkanAttentionBackendImpl`
+    instance) is threaded through so the KV-cache-entry lookup below
+    shares the same per-layer instance cache `_try_vulkan_decode` uses
+    (`impl._get_kv_cache_entry` -- see its own doc comment) instead of
+    falling back to the slower module-level `_get_or_create_vulkan_kv_cache`
+    dict lookup independently here.
+    """
     if num_tokens <= 0 or kv_cache.dtype not in (torch.float16, torch.float32):
         return
 
@@ -435,7 +494,7 @@ def _try_write_tokens_to_vulkan_cache(
         if ctx is None:
             return
 
-        entry = _get_or_create_vulkan_kv_cache(ctx, kv_cache)
+        entry = impl._get_kv_cache_entry(ctx, kv_cache)
         write_kv = (
             paged_kv_write_f16
             if kv_cache.dtype == torch.float16


### PR DESCRIPTION
## Summary
`_get_or_create_vulkan_kv_cache` (the module-level, dict-based lookup keyed on `kv_cache`'s storage pointer) was called on every single `_try_vulkan_decode`/`_try_write_tokens_to_vulkan_cache` invocation — i.e. twice per attention layer, per decode step — even on a guaranteed cache hit. Every call re-derives the storage key, rebuilds the shape tuple, does a dict `.get()`, then three separate equality comparisons.

## Verification of the identity-stability assumption
Verified directly by reading `vllm/v1/worker/utils.py`'s `bind_kv_cache()`: vLLM binds a layer's `kv_cache` tensor exactly once, at `initialize_kv_cache()` time, called once per profiling run and once at real startup — never per forward call. So the same Python `kv_cache` tensor object is passed on every single decode step, for the entire serving lifetime of a given layer — and `VulkanAttentionBackendImpl` is one instance per attention layer (never shared), making a plain per-instance identity cache both correct and simpler than the existing storage-key/shape/dtype comparison.

## Measurement
The existing lookup path costs ~1.0us/call; a plain instance-attribute `is` check costs ~0.07us/call (**~14x faster**). At ~70 calls/decode-step (twice per layer, across Gemma4-E2B's 35 layers), that's **~65us/decode-step** saved.

## Changes
- Adds `VulkanAttentionBackendImpl._get_kv_cache_entry`: a single-slot instance cache, falling back to the existing (unchanged) `_get_or_create_vulkan_kv_cache` on a cache miss.
- `_try_write_tokens_to_vulkan_cache` (a module-level function, not a method) now takes an `impl: VulkanAttentionBackendImpl` parameter so both call sites share the same per-layer cache instead of only one benefiting.
- Adds 3 tests: identity-based cache-hit/invalidation checks, and an end-to-end regression test running several consecutive decode steps through one instance with the same `kv_cache` tensor, verifying reuse and correctness together.

## Verification
- Full Python suite runnable locally: 80 passed, 2 skipped (same 2 pre-existing vllm-gated skips as every prior commit this session).
- `ruff check` / `ruff format --check`: clean.
- `mypy vllm_vulkan`: clean.
- Full Rust suite: 39/39 passing, unaffected (this change touches no Rust code).