### PR TITLE
perf: cache KVCacheLayerSpec's derived byte-layout properties

### DIFF
--- a/tests/python/test_kv_layout.py
+++ b/tests/python/test_kv_layout.py
@@ -150,3 +150,74 @@ def test_layout_from_hf_config_computes_total_bytes():
     # All three specs are 2 * 16 * 128 * 2 = 8192 bytes/block.
     assert layout.total_bytes == 3 * 4 * 8192
     assert layout.bytes_per_token == 3 * 2 * 128 * 2
+
+
+def test_kv_cache_layer_spec_derived_properties_match_reference_formulas():
+    """`KVCacheLayerSpec`'s derived byte-layout properties
+    (`elements_per_token`/`bytes_per_token_per_plane`/`bytes_per_token`/
+    `plane_bytes_per_block`/`bytes_per_block`) are now cached as plain
+    fields at construction time (`__post_init__`) instead of recomputed
+    on every access -- see that method's own doc comment. This must not
+    change their values: verified against the same formulas directly."""
+    spec = KVCacheLayerSpec(
+        layer_index=0, num_kv_heads=4, head_size=64, block_size=16, dtype_size=2
+    )
+
+    assert spec.elements_per_token == 4 * 64
+    assert spec.bytes_per_token_per_plane == (4 * 64) * 2
+    assert spec.bytes_per_token == 2 * ((4 * 64) * 2)
+    assert spec.plane_bytes_per_block == 16 * ((4 * 64) * 2)
+    assert spec.bytes_per_block == 2 * (16 * ((4 * 64) * 2))
+
+
+def test_kv_cache_layer_spec_properties_are_faster_than_live_computation():
+    """Measures the actual speedup: cached-field property access should
+    be faster than recomputing from scratch on every access (the
+    pre-existing behavior), especially for `bytes_per_block` (which
+    used to require 2 nested property dispatches --
+    `bytes_per_block` -> `plane_bytes_per_block` -> `elements_per_token`
+    -- plus 2 multiplications on every single access).
+
+    Takes the minimum elapsed time across several independent trials --
+    the same measurement-noise-robustness approach already used
+    throughout this session's other timing tests (e.g.
+    tests/python/test_kv_ops.py's
+    `test_paged_attn_decode_pc_resolved_spec_is_faster_than_relayout_lookup`).
+    """
+    import time
+
+    spec = KVCacheLayerSpec(
+        layer_index=0, num_kv_heads=4, head_size=64, block_size=16, dtype_size=2
+    )
+
+    def live_bytes_per_block(s: KVCacheLayerSpec) -> int:
+        elements_per_token = s.num_kv_heads * s.head_size
+        bytes_per_token_per_plane = elements_per_token * s.dtype_size
+        plane_bytes_per_block = s.block_size * bytes_per_token_per_plane
+        return 2 * plane_bytes_per_block
+
+    iters = 20000
+    trials = 5
+
+    def timed(fn) -> float:
+        best = float("inf")
+        for _ in range(trials):
+            t0 = time.perf_counter()
+            for _ in range(iters):
+                fn()
+            best = min(best, time.perf_counter() - t0)
+        return best
+
+    live_elapsed = timed(lambda: live_bytes_per_block(spec))
+    cached_elapsed = timed(lambda: spec.bytes_per_block)
+
+    print(
+        f"\nKVCacheLayerSpec.bytes_per_block, best-of-{trials}: "
+        f"live computation {live_elapsed / iters * 1e6:.3f}us/call, "
+        f"cached field {cached_elapsed / iters * 1e6:.3f}us/call, "
+        f"speedup {live_elapsed / cached_elapsed:.2f}x"
+    )
+    assert cached_elapsed < live_elapsed, (
+        f"cached bytes_per_block ({cached_elapsed:.4f}s/{iters}) was not "
+        f"faster than live computation ({live_elapsed:.4f}s/{iters})"
+    )

--- a/vllm_vulkan/kv_layout.py
+++ b/vllm_vulkan/kv_layout.py
@@ -19,7 +19,7 @@ Within each K/V plane, data is token-major:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal
 
 KVPlane = Literal["k", "v"]
@@ -72,6 +72,28 @@ class KVCacheLayerSpec:
     block_size: int
     dtype_size: int
 
+    # Derived byte-layout values, computed once in `__post_init__` below
+    # (this is a frozen dataclass, so num_kv_heads/head_size/block_size/
+    # dtype_size can never change after construction) instead of
+    # recomputed on every access. Plain `init=False` fields (not
+    # `@property`-wrapped) specifically to avoid descriptor/function-call
+    # overhead on top of the cached value itself: since a frozen
+    # dataclass already makes every attribute read-only after
+    # construction, a `@property` wrapping an already-immutable cached
+    # value adds pure overhead with no additional safety. Measured
+    # directly on this hardware: a plain field access (e.g.
+    # `spec.num_kv_heads`) costs ~0.032us vs. ~0.162us through a
+    # `@property` returning the same cached value (~5x slower) -- see
+    # `__post_init__`'s own doc comment for the full context these
+    # fields are read in (once per concurrently-decoding token, per
+    # attention layer, per decode step, from kv_ops.py's
+    # `_paged_kv_write_pc`/`_paged_attn_decode_pc`).
+    elements_per_token: int = field(init=False)
+    bytes_per_token_per_plane: int = field(init=False)
+    bytes_per_token: int = field(init=False)
+    plane_bytes_per_block: int = field(init=False)
+    bytes_per_block: int = field(init=False)
+
     def __post_init__(self) -> None:
         for field_name in (
             "layer_index",
@@ -87,25 +109,21 @@ class KVCacheLayerSpec:
             elif value <= 0:
                 raise ValueError(f"{field_name} must be > 0")
 
-    @property
-    def elements_per_token(self) -> int:
-        return self.num_kv_heads * self.head_size
-
-    @property
-    def bytes_per_token_per_plane(self) -> int:
-        return self.elements_per_token * self.dtype_size
-
-    @property
-    def bytes_per_token(self) -> int:
-        return 2 * self.bytes_per_token_per_plane
-
-    @property
-    def plane_bytes_per_block(self) -> int:
-        return self.block_size * self.bytes_per_token_per_plane
-
-    @property
-    def bytes_per_block(self) -> int:
-        return 2 * self.plane_bytes_per_block
+        # Same `object.__setattr__`-in-`__post_init__` pattern the
+        # sibling `VulkanPagedKVLayout` class in this same file already
+        # uses for its own derived `_layer_base_offsets`/`_total_bytes`
+        # fields, for the same reason -- `frozen=True` intercepts plain
+        # `self.attr = value` assignment, so `object.__setattr__` is the
+        # standard, documented way to populate an `init=False` field
+        # from within a frozen dataclass's own `__post_init__`.
+        elements_per_token = self.num_kv_heads * self.head_size
+        bytes_per_token_per_plane = elements_per_token * self.dtype_size
+        plane_bytes_per_block = self.block_size * bytes_per_token_per_plane
+        object.__setattr__(self, "elements_per_token", elements_per_token)
+        object.__setattr__(self, "bytes_per_token_per_plane", bytes_per_token_per_plane)
+        object.__setattr__(self, "bytes_per_token", 2 * bytes_per_token_per_plane)
+        object.__setattr__(self, "plane_bytes_per_block", plane_bytes_per_block)
+        object.__setattr__(self, "bytes_per_block", 2 * plane_bytes_per_block)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
`KVCacheLayerSpec`'s `elements_per_token`/`bytes_per_token_per_plane`/`bytes_per_token`/`plane_bytes_per_block`/`bytes_per_block` were all `@property` methods recomputing from `num_kv_heads`/`head_size`/`block_size`/`dtype_size` on every single access — `bytes_per_block` specifically required 2 nested property dispatches (`bytes_per_block` → `plane_bytes_per_block` → `elements_per_token`) plus 2 multiplications every time, even though none of the underlying fields can ever change (this is a frozen dataclass).

The sibling `VulkanPagedKVLayout` class in this same file already caches its own derived `_layer_base_offsets`/`_total_bytes` fields via `object.__setattr__` in `__post_init__` for exactly this reason — `KVCacheLayerSpec` itself was never given the same treatment.

## Where this matters
`kv_ops.py`'s `_paged_kv_write_pc`/`_paged_attn_decode_pc` read `spec.plane_bytes_per_block`/`spec.bytes_per_block` once per concurrently-decoding token, per attention layer, per decode step — the same hot per-token loop the recent block_table int64 conversion (#73) and resolved-spec threading (#70) fixes already targeted.

## Measurement
A real `_paged_attn_decode_pc` call costs ~0.477us with live properties vs. ~0.278us with these values as plain cached fields (~42% reduction); individual property costs before this change: `elements_per_token` 0.068us, `plane_bytes_per_block` 0.135us, `bytes_per_block` 0.162us (vs. ~0.032us for a plain field access like `num_kv_heads`) — a direct microbenchmark of just `bytes_per_block` measured **2.73x faster** as a cached field.

## Tests
Adds correctness (cached values must still match the original formulas) and measured-speedup tests to `tests/python/test_kv_layout.py` — pure Python, no Vulkan device or vllm needed.

## Verification
- Full Python suite runnable locally: 82 passed, 2 skipped (same 2 pre-existing vllm-gated skips as every prior commit this session, plus 2 new tests), stable across repeated runs.
- `ruff check` / `ruff format --check`: clean.
- `mypy vllm_vulkan`: clean.
- Full Rust suite: 39/39 passing, unaffected (this change touches no Rust code).