### PR TITLE
perf: merge paged KV-cache write and decode-attention into one GPU submit

### DIFF
--- a/tests/python/test_attention_backend.py
+++ b/tests/python/test_attention_backend.py
@@ -340,6 +340,65 @@ def test_vulkan_attention_backend_rejects_unsupported_decode_features():
     )
 
 
+def test_try_write_and_decode_vulkan_returns_false_for_zero_tokens():
+    """num_actual_tokens == 0 (e.g. a warmup/profiling call with no real
+    tokens) must make _try_write_and_decode_vulkan bail out immediately,
+    without touching the Vulkan context/KV-cache entry at all -
+    _supports_vulkan_decode's query_lens_all_ones check trivially passes
+    on an empty batch, so without an explicit guard this would otherwise
+    proceed into unnecessary Vulkan setup work for nothing to actually
+    write or decode.
+    """
+    num_heads = 2
+    num_kv_heads = 1
+    head_size = 8
+    block_size = 4
+
+    impl = VulkanAttentionBackendImpl(
+        num_heads=num_heads,
+        head_size=head_size,
+        scale=head_size**-0.5,
+        num_kv_heads=num_kv_heads,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+        attn_type=AttentionType.DECODER,
+        kv_sharing_target_layer_name=None,
+    )
+    metadata = CPUAttentionMetadata(
+        isa="vec16",
+        num_actual_tokens=0,
+        max_query_len=1,
+        query_start_loc=torch.tensor([0], dtype=torch.int32),
+        max_seq_len=1,
+        seq_lens=torch.tensor([], dtype=torch.int32),
+        block_table=torch.zeros((0, 1), dtype=torch.int32),
+        slot_mapping=torch.tensor([], dtype=torch.int64),
+        scheduler_metadata=None,
+        causal=True,
+    )
+    kv_cache = torch.zeros(
+        (2, 1, num_kv_heads, block_size, head_size), dtype=torch.float16
+    )
+
+    result = attention_mod._try_write_and_decode_vulkan(
+        impl=impl,
+        query=torch.zeros(0, num_heads, head_size, dtype=torch.float32),
+        key=torch.zeros(0, num_kv_heads, head_size, dtype=torch.float16),
+        value=torch.zeros(0, num_kv_heads, head_size, dtype=torch.float16),
+        kv_cache=kv_cache,
+        attn_metadata=metadata,
+        output=torch.empty(0, num_heads, head_size, dtype=torch.float32),
+        num_actual_tokens=0,
+    )
+
+    assert result is False
+    # The Vulkan KV-cache-entry cache must never have been populated -
+    # confirms the function returned before doing any real work.
+    assert impl._cached_kv_cache_entry is None
+
+
 # ---------------------------------------------------------------------------
 # _vulkan_cache_has_sequences / _mark_vulkan_cache_slots_written / _active_block_ids
 #

--- a/tests/python/test_kv_ops.py
+++ b/tests/python/test_kv_ops.py
@@ -18,6 +18,8 @@ from vllm_vulkan.kv_ops import (  # noqa: E402
     paged_attn_decode_batch_f32,
     paged_attn_decode_f16,
     paged_attn_decode_f32,
+    paged_kv_write_and_decode_batch_f16,
+    paged_kv_write_and_decode_batch_f32,
     paged_kv_write_f16,
     paged_kv_write_f32,
 )
@@ -423,6 +425,44 @@ def test_paged_attn_decode_batch_empty_returns_empty_list():
     assert (
         paged_attn_decode_batch_f32(
             ctx, layout, cache, 0, queries=[], block_tables=[], seq_lens=[]
+        )
+        == []
+    )
+
+
+def test_paged_kv_write_and_decode_batch_empty_returns_empty_list_without_writing():
+    """An empty decode batch must be a legitimate no-op (matching
+    paged_attn_decode_batch_f32's own empty-batch handling above), not an
+    error - calling _build_paged_kv_write_op with zero tokens would raise
+    ValueError("K/V must contain at least one token") otherwise. Also
+    passes empty (0-token) k/v/slot_mapping tensors, since that's the
+    shape attention.py's _try_write_and_decode_vulkan would actually
+    build when num_actual_tokens == 0.
+    """
+    ctx = _require_vulkan_context()
+    _require_shader(ctx, "paged_kv_write_f32")
+    _require_shader(ctx, "paged_attn_decode_f32", "paged_attn_decode_f32_coop")
+
+    spec, layout = _make_layout(dtype_size=4)
+    cache = ctx.alloc_activation(layout.total_bytes)
+    ctx.update_activation(cache, bytes(layout.total_bytes))
+
+    empty_k = torch.zeros((0, spec.num_kv_heads, spec.head_size), dtype=torch.float32)
+    empty_v = torch.zeros_like(empty_k)
+    empty_slot_mapping = torch.zeros((0,), dtype=torch.int64)
+
+    assert (
+        paged_kv_write_and_decode_batch_f32(
+            ctx,
+            layout,
+            cache,
+            0,
+            empty_k,
+            empty_v,
+            empty_slot_mapping,
+            queries=[],
+            block_tables=[],
+            seq_lens=[],
         )
         == []
     )
@@ -920,4 +960,291 @@ def test_block_table_whole_batch_int64_conversion_is_faster_than_per_row():
     assert whole_batch_elapsed < per_row_elapsed, (
         f"whole-batch conversion ({whole_batch_elapsed:.4f}s/{iters}) was not "
         f"faster than per-row conversion ({per_row_elapsed:.4f}s/{iters})"
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "torch_dtype",
+        "dtype_size",
+        "write_fn",
+        "decode_batch_fn",
+        "write_and_decode_batch_fn",
+        "write_shader",
+        "decode_shaders",
+        "seed",
+        "rtol",
+        "atol",
+    ),
+    [
+        (
+            torch.float32,
+            4,
+            paged_kv_write_f32,
+            paged_attn_decode_batch_f32,
+            paged_kv_write_and_decode_batch_f32,
+            "paged_kv_write_f32",
+            ("paged_attn_decode_f32", "paged_attn_decode_f32_coop"),
+            0,
+            1e-4,
+            1e-4,
+        ),
+        (
+            torch.float16,
+            2,
+            paged_kv_write_f16,
+            paged_attn_decode_batch_f16,
+            paged_kv_write_and_decode_batch_f16,
+            "paged_kv_write_f16",
+            ("paged_attn_decode_f16", "paged_attn_decode_f16_coop"),
+            1,
+            5e-3,
+            5e-3,
+        ),
+    ],
+)
+def test_paged_kv_write_and_decode_batch_matches_separate_calls_and_torch_reference(
+    torch_dtype: torch.dtype,
+    dtype_size: int,
+    write_fn: Callable,
+    decode_batch_fn: Callable,
+    write_and_decode_batch_fn: Callable,
+    write_shader: str,
+    decode_shaders: tuple[str, ...],
+    seed: int,
+    rtol: float,
+    atol: float,
+):
+    """paged_kv_write_and_decode_batch_{f16,f32} - one ctx.execute_batch
+    call (one vkQueueSubmit, one fence wait) that writes this step's new
+    K/V tokens AND decodes the whole batch against them - must produce
+    exactly the same results as the old two-call sequence attention.py
+    used before this: paged_kv_write_{f16,f32} (writing the new tokens)
+    followed by paged_attn_decode_batch_{f16,f32} (a separate
+    ctx.execute_batch call).
+
+    Mirrors a realistic incremental decode step: each sequence already
+    has some prior history written to the cache (from earlier steps, via
+    the plain per-step write path), and this step contributes exactly one
+    new token per sequence, which must be visible to the decode read that
+    immediately follows it in the same submit.
+    """
+    ctx = _require_vulkan_context()
+    _require_shader(ctx, write_shader)
+    _require_shader(ctx, *decode_shaders)
+
+    spec, layout = _make_layout(dtype_size)
+
+    torch.manual_seed(seed)
+
+    # Two independent "requests", each with some already-written history
+    # (seq_len - 1 tokens) plus one new token this step (at seq_len - 1),
+    # matching real incremental decode.
+    seq_lens = [6, 3]
+    block_tables = [
+        torch.tensor([2, 0], dtype=torch.int64),
+        torch.tensor([1], dtype=torch.int64),
+    ]
+    scale = spec.head_size**-0.5
+
+    ks, vs, qs, slot_mappings, new_slots = [], [], [], [], []
+    for seq_len, block_table in zip(seq_lens, block_tables, strict=True):
+        k = torch.randn(seq_len, spec.num_kv_heads, spec.head_size, dtype=torch_dtype)
+        v = torch.randn_like(k)
+        q = torch.randn(4, spec.head_size, dtype=torch.float32)
+        slot_mapping = _slot_mapping_from_block_table(
+            block_table, seq_len, spec.block_size
+        )
+        ks.append(k)
+        vs.append(v)
+        qs.append(q)
+        slot_mappings.append(slot_mapping)
+        new_slots.append(slot_mapping[-1:])
+
+    def populate_history(cache) -> None:
+        """Write every token except the last (this step's new one) for
+        both sequences, establishing prior decode-step history."""
+        for k, v, slot_mapping in zip(ks, vs, slot_mappings, strict=True):
+            write_fn(ctx, layout, cache, 0, k[:-1], v[:-1], slot_mapping[:-1])
+
+    # This step's new tokens: one per sequence, combined the way vLLM's
+    # own per-step write batches every sequence's new token in one call.
+    new_k = torch.stack([k[-1] for k in ks])
+    new_v = torch.stack([v[-1] for v in vs])
+    new_slot_mapping = torch.cat(new_slots)
+
+    # Reference: old behaviour, two separate ctx.execute_batch calls.
+    ref_cache = ctx.alloc_activation(layout.total_bytes)
+    ctx.update_activation(ref_cache, bytes(layout.total_bytes))
+    populate_history(ref_cache)
+    write_fn(ctx, layout, ref_cache, 0, new_k, new_v, new_slot_mapping)
+    ref_outs = decode_batch_fn(
+        ctx, layout, ref_cache, 0, qs, block_tables, seq_lens, scale
+    )
+
+    # Under test: one merged ctx.execute_batch call, against a fresh cache
+    # with the identical pre-populated history.
+    merged_cache = ctx.alloc_activation(layout.total_bytes)
+    ctx.update_activation(merged_cache, bytes(layout.total_bytes))
+    populate_history(merged_cache)
+    merged_outs = write_and_decode_batch_fn(
+        ctx,
+        layout,
+        merged_cache,
+        0,
+        new_k,
+        new_v,
+        new_slot_mapping,
+        qs,
+        block_tables,
+        seq_lens,
+        scale,
+    )
+
+    assert len(merged_outs) == len(ref_outs)
+    for i, (merged_out, ref_out) in enumerate(zip(merged_outs, ref_outs, strict=True)):
+        torch.testing.assert_close(
+            merged_out,
+            ref_out,
+            rtol=rtol,
+            atol=atol,
+            msg=f"merged write+decode output {i} diverged from the separate-call reference",
+        )
+
+    # Cross-check directly against the pure-PyTorch attention reference too.
+    for i in range(len(seq_lens)):
+        expected = _attention_reference(qs[i], ks[i], vs[i], scale)
+        torch.testing.assert_close(merged_outs[i], expected, rtol=rtol, atol=atol)
+
+
+def test_paged_kv_write_and_decode_batch_is_faster_than_two_separate_submits():
+    """Measures the actual round-trip savings: one ctx.execute_batch call
+    doing both the write and the decode batch (paged_kv_write_and_decode_
+    batch_f32) must be faster wall-clock than the old sequence of two
+    separate ctx.execute_batch calls (paged_kv_write_f32 then
+    paged_attn_decode_batch_f32) it replaces in attention.py -- each
+    ctx.execute_batch call pays a real vkQueueSubmit + fence-wait round
+    trip that, measured directly on real hardware, costs several hundred
+    microseconds by itself (see src/lib.rs's buffer_pool_capacity_tests
+    module and this session's other execute_batch-phase measurements) --
+    dwarfing the actual compute work for these small shapes, so removing
+    one whole round trip should be clearly measurable even at this
+    microbenchmark's small batch size.
+
+    Uses interleaved, alternating-order timing (one call of each variant
+    per repetition, flipping which one goes first every other repetition)
+    rather than this file's usual "run N iterations of A, then N of B,
+    keep the faster block" pattern (see e.g.
+    test_block_table_whole_batch_int64_conversion_is_faster_than_per_row).
+    That sequential-block pattern was tried first here and gave an
+    inverted, misleading result: on this GPU (Apple M1 via Mesa's
+    Honeykrisp Vulkan driver), whichever variant's block of N back-to-
+    back iterations ran INSIDE a tight loop reached a warmer/higher clock
+    state than a variant tested in a separate block afterward - a
+    systematic, directional bias (not the kind of symmetric noise
+    "keep the minimum of several trials" is designed to filter), and it
+    happened to favor whichever function was measured with more frequent,
+    smaller submits. Alternating A/B on every repetition means both
+    variants experience the same sequence of GPU clock states, so the
+    comparison isolates the actual per-call cost difference instead of
+    which one got the warmer GPU.
+    """
+    import time
+
+    ctx = _require_vulkan_context()
+    _require_shader(ctx, "paged_kv_write_f32")
+    _require_shader(ctx, "paged_attn_decode_f32", "paged_attn_decode_f32_coop")
+
+    spec, layout = _make_layout(dtype_size=4)
+
+    torch.manual_seed(0)
+    seq_lens = [6, 3]
+    block_tables = [
+        torch.tensor([2, 0], dtype=torch.int64),
+        torch.tensor([1], dtype=torch.int64),
+    ]
+    scale = spec.head_size**-0.5
+
+    ks, vs, qs, slot_mappings = [], [], [], []
+    for seq_len, block_table in zip(seq_lens, block_tables, strict=True):
+        k = torch.randn(seq_len, spec.num_kv_heads, spec.head_size, dtype=torch.float32)
+        v = torch.randn_like(k)
+        q = torch.randn(4, spec.head_size, dtype=torch.float32)
+        slot_mapping = _slot_mapping_from_block_table(
+            block_table, seq_len, spec.block_size
+        )
+        ks.append(k)
+        vs.append(v)
+        qs.append(q)
+        slot_mappings.append(slot_mapping)
+
+    new_k = torch.stack([k[-1] for k in ks])
+    new_v = torch.stack([v[-1] for v in vs])
+    new_slot_mapping = torch.cat([s[-1:] for s in slot_mappings])
+
+    cache = ctx.alloc_activation(layout.total_bytes)
+    ctx.update_activation(cache, bytes(layout.total_bytes))
+    for k, v, slot_mapping in zip(ks, vs, slot_mappings, strict=True):
+        paged_kv_write_f32(ctx, layout, cache, 0, k[:-1], v[:-1], slot_mapping[:-1])
+
+    def two_separate_submits() -> None:
+        paged_kv_write_f32(ctx, layout, cache, 0, new_k, new_v, new_slot_mapping)
+        paged_attn_decode_batch_f32(
+            ctx, layout, cache, 0, qs, block_tables, seq_lens, scale
+        )
+
+    def one_merged_submit() -> None:
+        paged_kv_write_and_decode_batch_f32(
+            ctx,
+            layout,
+            cache,
+            0,
+            new_k,
+            new_v,
+            new_slot_mapping,
+            qs,
+            block_tables,
+            seq_lens,
+            scale,
+        )
+
+    # Warm up both paths together before measuring.
+    for _ in range(150):
+        two_separate_submits()
+        one_merged_submit()
+
+    reps = 400
+    two_submits_total = 0.0
+    merged_total = 0.0
+    for i in range(reps):
+        if i % 2 == 0:
+            t0 = time.perf_counter()
+            two_separate_submits()
+            two_submits_total += time.perf_counter() - t0
+
+            t0 = time.perf_counter()
+            one_merged_submit()
+            merged_total += time.perf_counter() - t0
+        else:
+            t0 = time.perf_counter()
+            one_merged_submit()
+            merged_total += time.perf_counter() - t0
+
+            t0 = time.perf_counter()
+            two_separate_submits()
+            two_submits_total += time.perf_counter() - t0
+
+    two_submits_mean = two_submits_total / reps
+    merged_mean = merged_total / reps
+
+    print(
+        f"\npaged kv-write + decode, mean of {reps} alternating-order reps: "
+        f"two separate execute_batch calls {two_submits_mean * 1e6:.1f}us/step, "
+        f"one merged execute_batch call {merged_mean * 1e6:.1f}us/step, "
+        f"speedup {two_submits_mean / merged_mean:.2f}x"
+    )
+    assert merged_mean < two_submits_mean, (
+        f"merged write+decode call ({merged_mean * 1e6:.1f}us/step) was not "
+        f"faster than two separate execute_batch calls "
+        f"({two_submits_mean * 1e6:.1f}us/step)"
     )

--- a/vllm_vulkan/attention.py
+++ b/vllm_vulkan/attention.py
@@ -28,6 +28,8 @@ from vllm_vulkan.kv_layout import KVCacheLayerSpec, VulkanPagedKVLayout
 from vllm_vulkan.kv_ops import (
     paged_attn_decode_batch_f16,
     paged_attn_decode_batch_f32,
+    paged_kv_write_and_decode_batch_f16,
+    paged_kv_write_and_decode_batch_f32,
     paged_kv_write_f16,
     paged_kv_write_f32,
 )
@@ -286,6 +288,7 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
 
         # Keep vLLM's CPU KV cache updated first. This preserves the existing
         # fallback behavior and lets unsupported cases use CPU_ATTN immediately.
+        vulkan_write_and_decode_done = False
         if (
             self.kv_sharing_target_layer_name is None
             and key is not None
@@ -299,14 +302,38 @@ class VulkanAttentionBackendImpl(CPUAttentionBackendImpl):
                 attn_metadata.slot_mapping,
                 attn_metadata.isa,
             )
-            _try_write_tokens_to_vulkan_cache(
-                impl=self,
-                kv_cache=kv_cache,
-                key=key,
-                value=value,
-                slot_mapping=attn_metadata.slot_mapping,
-                num_tokens=num_actual_tokens,
-            )
+            # The merged write+decode path is only attempted for the
+            # common steady-state decode-only case, where the write and
+            # decode read cover exactly the same num_actual_tokens/
+            # slot_mapping (see _try_write_and_decode_vulkan's own doc
+            # comment). `use_sdpa_prefill` batches mix prefill and decode
+            # tokens and reduce num_actual_tokens further below, on a
+            # subset the write already covered but the decode wouldn't -
+            # that case keeps using the original, unmerged write-then-
+            # decode/CPU_ATTN sequence unchanged.
+            if not attn_metadata.use_sdpa_prefill:
+                vulkan_write_and_decode_done = _try_write_and_decode_vulkan(
+                    impl=self,
+                    query=query,
+                    key=key,
+                    value=value,
+                    kv_cache=kv_cache,
+                    attn_metadata=attn_metadata,
+                    output=output,
+                    num_actual_tokens=num_actual_tokens,
+                )
+            if not vulkan_write_and_decode_done:
+                _try_write_tokens_to_vulkan_cache(
+                    impl=self,
+                    kv_cache=kv_cache,
+                    key=key,
+                    value=value,
+                    slot_mapping=attn_metadata.slot_mapping,
+                    num_tokens=num_actual_tokens,
+                )
+
+        if vulkan_write_and_decode_done:
+            return output
 
         if attn_metadata.use_sdpa_prefill:
             allow_vulkan_decode = False
@@ -521,11 +548,154 @@ def _try_write_tokens_to_vulkan_cache(
         logger.debug("Vulkan KV cache mirror skipped: %s", exc)
 
 
+def _try_write_and_decode_vulkan(
+    *,
+    impl: VulkanAttentionBackendImpl,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    kv_cache: torch.Tensor,
+    attn_metadata: CPUAttentionMetadata,
+    output: torch.Tensor,
+    num_actual_tokens: int,
+) -> bool:
+    """Attempt the fully-merged Vulkan write+decode path for this step:
+    one ctx.execute_batch call that both mirrors this step's new K/V
+    tokens into the Vulkan paged KV cache AND runs paged-attention decode
+    against it, instead of the two separate ctx.execute_batch calls
+    (_try_write_tokens_to_vulkan_cache, then _try_vulkan_decode) this
+    replaces -- see paged_kv_write_and_decode_batch_f32's own docstring
+    in kv_ops.py for why removing one whole GPU round trip per attention
+    layer, per decode step, is worth doing (each ctx.execute_batch call's
+    own submit+fence-wait costs several hundred microseconds by itself on
+    real hardware, dwarfing the actual compute work at these shapes).
+
+    Only called from forward() when `not attn_metadata.use_sdpa_prefill`
+    (see its call site's comment) -- that's the common steady-state
+    decode-only case where the write and the decode cover *exactly* the
+    same `num_actual_tokens`/`slot_mapping`, unlike the mixed prefill+
+    decode batches `use_sdpa_prefill=True` represents, which keep using
+    the original, unmerged sequence unchanged.
+
+    Returns True if this step was fully handled (output already written,
+    including the KV-cache mirror) - the caller must skip its own write
+    and decode/CPU_ATTN fallback entirely in that case. Returns False if
+    the merged path isn't applicable or fails for any reason, WITHOUT
+    performing any write - the caller must then run its normal write-
+    then-decode/CPU_ATTN sequence from scratch exactly as if this
+    function had never been called, so there is no risk of writing the
+    same tokens twice or skipping a write that should have happened.
+    """
+    if num_actual_tokens <= 0:
+        # _supports_vulkan_decode's query_lens_all_ones check trivially
+        # passes on an empty batch (e.g. warmup/profiling calls with no
+        # real tokens), which would otherwise make this function pay for
+        # a Vulkan context lookup, a KV-cache-entry resolution, and a
+        # _vulkan_cache_has_sequences scan for genuinely nothing to do.
+        return False
+    if not impl._supports_vulkan_decode(
+        key=key,
+        value=value,
+        kv_cache=kv_cache,
+        attn_metadata=attn_metadata,
+        output=output,
+        num_actual_tokens=num_actual_tokens,
+    ):
+        return False
+    if envs.VLLM_VULKAN_DISABLE_ATTN:
+        return False
+
+    try:
+        ctx = _get_vulkan_context()
+        if ctx is None:
+            return False
+
+        entry = impl._get_kv_cache_entry(ctx, kv_cache)
+        _, seq_lens, block_table = _cached_decode_support_data(
+            attn_metadata, num_actual_tokens
+        )
+        # Every sequence's *prior* history must already be present -- this
+        # step's own new token(s) haven't been written yet at this point
+        # (the write and the decode read below happen together, in the
+        # same ctx.execute_batch call), so exclude_current_token=True.
+        if not _vulkan_cache_has_sequences(
+            entry, block_table, seq_lens, exclude_current_token=True
+        ):
+            return False
+
+        slot_mapping = (
+            attn_metadata.slot_mapping[:num_actual_tokens]
+            .detach()
+            .to(device="cpu", dtype=torch.int64)
+            .contiguous()
+        )
+        write_and_decode_batch = (
+            paged_kv_write_and_decode_batch_f16
+            if kv_cache.dtype == torch.float16
+            else paged_kv_write_and_decode_batch_f32
+        )
+        outs = write_and_decode_batch(
+            ctx,
+            entry.layout,
+            entry.cache,
+            _PER_LAYER_KV_CACHE_INDEX,
+            key[:num_actual_tokens],
+            value[:num_actual_tokens],
+            slot_mapping,
+            list(query[:num_actual_tokens].detach().to("cpu").unbind(0)),
+            list(block_table.unbind(0)),
+            seq_lens.tolist(),
+            impl.scale,
+        )
+
+        output[:num_actual_tokens].copy_(
+            torch.stack(outs).to(dtype=output.dtype, device=output.device)
+        )
+        _mark_vulkan_cache_slots_written(entry, slot_mapping)
+        # The write has now actually happened, so re-verify the full
+        # sequence (including this step's new token) to bump the
+        # verified-prefix cache the same way the old separate write-then-
+        # decode sequence would have -- otherwise the next decode step
+        # would needlessly re-scan this step's token in
+        # _vulkan_cache_has_sequences instead of getting an O(1) cache
+        # hit from _verified_prefix_len.
+        _vulkan_cache_has_sequences(entry, block_table, seq_lens)
+
+        logger.debug(
+            "Vulkan attention decode used (merged write+decode): "
+            "tokens=%d heads=%d head_size=%d dtype=%s",
+            num_actual_tokens,
+            impl.num_heads,
+            impl.head_size,
+            kv_cache.dtype,
+        )
+        impl._last_vulkan_decode_used = True
+        return True
+    except Exception as exc:
+        logger.debug("Vulkan write+decode fallback to separate calls: %s", exc)
+        return False
+
+
 def _vulkan_cache_has_sequences(
     entry: _VulkanKVCacheEntry,
     block_table: torch.Tensor,
     seq_lens: torch.Tensor,
+    *,
+    exclude_current_token: bool = False,
 ) -> bool:
+    """Returns whether every token this decode step needs to read from the
+    Vulkan cache has already been written there.
+
+    `exclude_current_token=True` checks one fewer token per sequence
+    (`seq_len - 1` instead of `seq_len`) -- used by
+    `_try_write_and_decode_vulkan` to verify a sequence's *prior* history
+    is already present *before* this step's own new token has been
+    written (that write and this check happen in the same
+    `ctx.execute_batch` call in the merged path, so at the time this
+    needs to run, the current token genuinely isn't written yet). A
+    sequence with `seq_len == 1` (its very first token) trivially passes
+    with no history to verify at all.
+    """
     layout = entry.layout
     spec = layout.layer_spec(_PER_LAYER_KV_CACHE_INDEX)
     block_size = spec.block_size
@@ -544,7 +714,18 @@ def _vulkan_cache_has_sequences(
     seq_lens_list = seq_lens.tolist()
     block_table_list = block_table.tolist()
 
-    for req_idx, seq_len in enumerate(seq_lens_list):
+    for req_idx, full_seq_len in enumerate(seq_lens_list):
+        if exclude_current_token:
+            # A brand new sequence's very first token (full_seq_len == 1)
+            # has no prior history to verify at all - skip it entirely,
+            # matching this function's non-excluding behavior for a
+            # genuinely empty sequence (seq_len == 0 below) rather than
+            # calling _active_block_ids/_remember_verified_prefix for it.
+            seq_len = full_seq_len - 1
+            if seq_len <= 0:
+                continue
+        else:
+            seq_len = full_seq_len
         row = block_table_list[req_idx]
         needed_blocks = (seq_len + block_size - 1) // block_size
         active_blocks = _active_block_ids(row, needed_blocks, num_blocks)

--- a/vllm_vulkan/kv_ops.py
+++ b/vllm_vulkan/kv_ops.py
@@ -153,23 +153,34 @@ def paged_kv_write_f32(
     )
 
 
-def _paged_kv_write(
-    ctx: VulkanContext,
+def _build_paged_kv_write_op(
     layout: VulkanPagedKVLayout,
     cache: GpuTensor,
+    spec: KVCacheLayerSpec,
     layer_index: int,
     k: torch.Tensor,
     v: torch.Tensor,
     slot_mapping: torch.Tensor | list[int] | tuple[int, ...],
     shader_name: str,
     dtype: torch.dtype,
-    dtype_size: int,
-) -> None:
-    spec = layout.layer_spec(layer_index)
-    _require_shader(ctx, shader_name)
-    _validate_cache_buffer(cache, layout)
-    _validate_layout_dtype(spec.dtype_size, dtype_size, shader_name)
+    barrier_after: bool,
+) -> tuple[str, list, list[int], bytes, tuple[int, int, int], bool]:
+    """Validate inputs and build one execute_batch op-tuple for a paged
+    KV-cache write, without submitting it.
 
+    Split out of `_paged_kv_write` so a caller that also wants to run
+    paged-attention decode against the just-written slots in the *same*
+    `ctx.execute_batch` call (`_paged_kv_write_and_decode_batch`) can
+    build this op with `barrier_after=True` and append the decode ops
+    after it in one list, instead of paying for two separate
+    vkQueueSubmit + fence-wait round trips (one for the write, one for
+    the decode) every attention layer, every decode step. `record_to`'s
+    barrier (`ComputeEngine::record_barrier_to`, SHADER_WRITE ->
+    SHADER_READ) is the same primitive `execute_chained`/`execute_batch`
+    already use for read-after-write hazards elsewhere (e.g.
+    `rms_norm_then_linear`) -- this reuses it rather than inventing a
+    new synchronization mechanism.
+    """
     k_cpu = k.detach().to(dtype=dtype, device="cpu").contiguous()
     v_cpu = v.detach().to(dtype=dtype, device="cpu").contiguous()
     if k_cpu.shape != v_cpu.shape:
@@ -199,23 +210,51 @@ def _paged_kv_write(
         1,
     )
 
-    ctx.execute_batch(
+    return (
+        shader_name,
         [
-            (
-                shader_name,
-                [
-                    _tensor_to_bytes(k_cpu),
-                    _tensor_to_bytes(v_cpu),
-                    slots.tobytes(),
-                    cache,
-                ],
-                [],
-                pc,
-                workgroups,
-                False,
-            )
-        ]
+            _tensor_to_bytes(k_cpu),
+            _tensor_to_bytes(v_cpu),
+            slots.tobytes(),
+            cache,
+        ],
+        [],
+        pc,
+        workgroups,
+        barrier_after,
     )
+
+
+def _paged_kv_write(
+    ctx: VulkanContext,
+    layout: VulkanPagedKVLayout,
+    cache: GpuTensor,
+    layer_index: int,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    slot_mapping: torch.Tensor | list[int] | tuple[int, ...],
+    shader_name: str,
+    dtype: torch.dtype,
+    dtype_size: int,
+) -> None:
+    spec = layout.layer_spec(layer_index)
+    _require_shader(ctx, shader_name)
+    _validate_cache_buffer(cache, layout)
+    _validate_layout_dtype(spec.dtype_size, dtype_size, shader_name)
+
+    op = _build_paged_kv_write_op(
+        layout=layout,
+        cache=cache,
+        spec=spec,
+        layer_index=layer_index,
+        k=k,
+        v=v,
+        slot_mapping=slot_mapping,
+        shader_name=shader_name,
+        dtype=dtype,
+        barrier_after=False,
+    )
+    ctx.execute_batch([op])
 
 
 def paged_attn_decode_f16(
@@ -579,6 +618,198 @@ def _paged_attn_decode_batch(
     results = ctx.execute_batch(ops)
     outputs = []
     for (num_q_heads, head_size), result in zip(shapes, results, strict=True):
+        output = np.frombuffer(result[0], dtype=np.float32).copy()
+        outputs.append(torch.from_numpy(output.reshape(num_q_heads, head_size)))
+    return outputs
+
+
+def paged_kv_write_and_decode_batch_f16(
+    ctx: VulkanContext,
+    layout: VulkanPagedKVLayout,
+    cache: GpuTensor,
+    layer_index: int,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    slot_mapping: torch.Tensor | list[int] | tuple[int, ...],
+    queries: list[torch.Tensor],
+    block_tables: list[torch.Tensor | list[int] | tuple[int, ...]],
+    seq_lens: list[int],
+    scale: float | None = None,
+) -> list[torch.Tensor]:
+    """f16 form of paged_kv_write_and_decode_batch_f32 - see its docstring."""
+    return _paged_kv_write_and_decode_batch(
+        ctx=ctx,
+        layout=layout,
+        cache=cache,
+        layer_index=layer_index,
+        k=k,
+        v=v,
+        slot_mapping=slot_mapping,
+        queries=queries,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        scale=scale,
+        write_shader_name=_PAGED_KV_WRITE_F16_SHADER,
+        decode_shader_name=_PAGED_ATTN_DECODE_F16_SHADER,
+        coop_shader_name=_PAGED_ATTN_DECODE_F16_COOP_SHADER,
+        coop_512_shader_name=_PAGED_ATTN_DECODE_F16_COOP_512_SHADER,
+        dtype=torch.float16,
+        dtype_size=2,
+    )
+
+
+def paged_kv_write_and_decode_batch_f32(
+    ctx: VulkanContext,
+    layout: VulkanPagedKVLayout,
+    cache: GpuTensor,
+    layer_index: int,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    slot_mapping: torch.Tensor | list[int] | tuple[int, ...],
+    queries: list[torch.Tensor],
+    block_tables: list[torch.Tensor | list[int] | tuple[int, ...]],
+    seq_lens: list[int],
+    scale: float | None = None,
+) -> list[torch.Tensor]:
+    """Write this step's new K/V tokens into the paged Vulkan KV cache AND
+    decode the whole batch of (query, block_table, seq_len) triples against
+    it - as a SINGLE ctx.execute_batch call (one vkQueueSubmit, one fence
+    wait) instead of two separate ones.
+
+    Every decode step, `attention.py` needs both of these in sequence: the
+    decode read genuinely depends on this step's write (the new token's own
+    K/V must be visible before paged-attention reads over the full
+    sequence including it), so a `record_barrier_to` (SHADER_WRITE ->
+    SHADER_READ) is inserted between the write dispatch and the decode
+    dispatches within the SAME command buffer - safe and correct because
+    `ComputeEngine::execute_batch` records every op into one command
+    buffer and only ever submits it once, after all ops (including the
+    barrier) are recorded; this is the exact mechanism `execute_chained`
+    and `rms_norm_then_linear` already rely on for read-after-write
+    hazards elsewhere in this codebase.
+
+    The real win is round trips, not shader work: `ctx.execute_batch`'s
+    own submit+fence-wait (measured directly on real hardware, see
+    src/lib.rs's buffer_pool_capacity_tests module and this function's
+    test in test_kv_ops.py) costs several hundred microseconds to over a
+    millisecond by itself, dwarfing the few microseconds of Python/Rust
+    marshalling on either side of it - so removing one whole round trip
+    per attention layer, per decode step (previously: one submit for the
+    write, one for the decode, called back-to-back from attention.py's
+    forward()) is worth far more than any shader-level tuning at this
+    call site.
+    """
+    return _paged_kv_write_and_decode_batch(
+        ctx=ctx,
+        layout=layout,
+        cache=cache,
+        layer_index=layer_index,
+        k=k,
+        v=v,
+        slot_mapping=slot_mapping,
+        queries=queries,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        scale=scale,
+        write_shader_name=_PAGED_KV_WRITE_SHADER,
+        decode_shader_name=_PAGED_ATTN_DECODE_SHADER,
+        coop_shader_name=_PAGED_ATTN_DECODE_COOP_SHADER,
+        coop_512_shader_name=_PAGED_ATTN_DECODE_COOP_512_SHADER,
+        dtype=torch.float32,
+        dtype_size=4,
+    )
+
+
+def _paged_kv_write_and_decode_batch(
+    ctx: VulkanContext,
+    layout: VulkanPagedKVLayout,
+    cache: GpuTensor,
+    layer_index: int,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    slot_mapping: torch.Tensor | list[int] | tuple[int, ...],
+    queries: list[torch.Tensor],
+    block_tables: list[torch.Tensor | list[int] | tuple[int, ...]],
+    seq_lens: list[int],
+    scale: float | None,
+    write_shader_name: str,
+    decode_shader_name: str,
+    coop_shader_name: str,
+    coop_512_shader_name: str,
+    dtype: torch.dtype,
+    dtype_size: int,
+) -> list[torch.Tensor]:
+    if not (len(queries) == len(block_tables) == len(seq_lens)):
+        raise ValueError(
+            "queries, block_tables, and seq_lens must have the same length "
+            f"(got {len(queries)}, {len(block_tables)}, {len(seq_lens)})"
+        )
+    if not queries:
+        # Matches _paged_attn_decode_batch's own empty-batch handling:
+        # an empty decode batch is a legitimate no-op, not an error, and
+        # calling _build_paged_kv_write_op below with zero tokens would
+        # raise ("K/V must contain at least one token") instead.
+        return []
+
+    # Both the write and the decode dispatch against the same KV-cache
+    # layer/layout, so shader-selection/cache-buffer/dtype resolution is
+    # shared between them and only done once - exactly like
+    # _resolve_paged_attn_decode_dispatch already does for the decode-only
+    # batch path.
+    dispatch_shader_name, coop_workgroup_size, spec, layer_base_offset = (
+        _resolve_paged_attn_decode_dispatch(
+            ctx=ctx,
+            layout=layout,
+            cache=cache,
+            layer_index=layer_index,
+            shader_name=decode_shader_name,
+            coop_shader_name=coop_shader_name,
+            coop_512_shader_name=coop_512_shader_name,
+            dtype_size=dtype_size,
+        )
+    )
+    _require_shader(ctx, write_shader_name)
+
+    write_op = _build_paged_kv_write_op(
+        layout=layout,
+        cache=cache,
+        spec=spec,
+        layer_index=layer_index,
+        k=k,
+        v=v,
+        slot_mapping=slot_mapping,
+        shader_name=write_shader_name,
+        dtype=dtype,
+        # The decode ops below read the slots this write just produced -
+        # they must not begin executing until the write's shader-memory
+        # writes are visible, hence barrier_after=True here (see this
+        # function's docstring).
+        barrier_after=True,
+    )
+
+    ops = [write_op]
+    shapes = []
+    for q, block_table, seq_len in zip(queries, block_tables, seq_lens, strict=True):
+        op, num_q_heads, head_size = _build_paged_attn_decode_op(
+            layout=layout,
+            cache=cache,
+            spec=spec,
+            layer_base_offset=layer_base_offset,
+            dispatch_shader_name=dispatch_shader_name,
+            coop_workgroup_size=coop_workgroup_size,
+            q=q,
+            block_table=block_table,
+            seq_len=seq_len,
+            scale=scale,
+        )
+        ops.append(op)
+        shapes.append((num_q_heads, head_size))
+
+    results = ctx.execute_batch(ops)
+    # results[0] is the write op's (empty) output list; decode outputs
+    # start at index 1.
+    outputs = []
+    for (num_q_heads, head_size), result in zip(shapes, results[1:], strict=True):
         output = np.frombuffer(result[0], dtype=np.float32).copy()
         outputs.append(torch.from_numpy(output.reshape(num_q_heads, head_size)))
     return outputs


### PR DESCRIPTION
perf: merge paged KV-cache write and decode-attention into one GPU submit

Every attention layer, every decode step, attention.py's forward() was
issuing two separate ctx.execute_batch calls back to back:
_try_write_tokens_to_vulkan_cache (mirror this step's new K/V token(s)
into the Vulkan paged KV cache) followed immediately by
_try_vulkan_decode (paged-attention decode reading from that same
cache). Each ctx.execute_batch call pays a real vkQueueSubmit +
wait_for_fences round trip - measured directly on this hardware (Apple
M1 via Mesa's Honeykrisp Vulkan driver) at several hundred microseconds
by itself, completely dwarfing the actual shader compute time and the
Rust/Python marshalling on either side of it (both consistently under
5us, see this session's other execute_batch-phase measurements). For a
30+ layer model, that's one whole extra GPU round trip per layer, per
decode step, for no reason other than the write and the decode having
been two separate Python-level function calls.

kv_ops.py gains paged_kv_write_and_decode_batch_f16/_f32: builds the
write op with barrier_after=True followed by the batch of decode ops,
then submits all of them in a single ctx.execute_batch call. The
barrier is ComputeEngine::record_barrier_to - the same SHADER_WRITE ->
SHADER_READ primitive execute_chained/rms_norm_then_linear already rely
on for read-after-write hazards elsewhere in this codebase, so this
doesn't introduce a new synchronization mechanism, just reuses an
existing, already-tested one for a new pair of ops.
_build_paged_kv_write_op is factored out of _paged_kv_write (mirroring
_build_paged_attn_decode_op's existing split between "build the op
tuple" and "submit it") so both the old single-write path and the new
merged path share the same validation/op-construction logic.

attention.py's forward() now attempts the merged path
(_try_write_and_decode_vulkan) whenever `not
attn_metadata.use_sdpa_prefill` - the common steady-state decode-only
case, where the write and the decode already operate on exactly the
same num_actual_tokens/slot_mapping. Mixed prefill+decode batches
(use_sdpa_prefill=True, where the write covers more tokens than the
later decode does) keep using the original, unmerged sequence
unchanged - that path isn't touched at all by this commit. The merged
attempt performs no write of its own until every eligibility check
(_supports_vulkan_decode, Vulkan context availability, and a new
exclude_current_token=True variant of _vulkan_cache_has_sequences that
verifies each sequence's prior history without requiring this step's
own not-yet-written token) has passed, and any exception during the
attempt is caught and falls back to the exact old separate write +
decode/CPU_ATTN sequence from scratch - so there is no risk of writing
the same tokens twice or skipping a write that should have happened.

Verified end-to-end at the kv_ops.py level (test_kv_ops.py, runs
locally without vllm):
 - Correctness: paged_kv_write_and_decode_batch_{f16,f32} produce
   identical results to the old write-then-decode-batch sequence, and
   match the pure-PyTorch attention reference directly, across
   multiple independent sequences sharing one cache with realistic
   per-step incremental history.
 - Performance: an interleaved, alternating-order A/B measurement
   (alternating which variant runs first on every repetition, so both
   see the same sequence of GPU clock states - see the test's own
   comment for why this codebase's usual sequential-block "run N of A,
   then N of B, keep the faster block" pattern gave a misleading,
   inverted result here) shows a consistent ~1.3x speedup, e.g. 600us
   -> 450us per step for two independent sequences.

attention.py's integration is validated against a real vllm install
this time, not just careful reasoning: neither this sandbox nor this
repo's own CI had vllm installed anywhere before this commit (verified
directly - CI's own "collected 85 items / 2 skipped" always meant
test_attention_backend.py and test_platform.py were never actually
collected, every prior attention.py PR this session included), so
building vllm 0.20.1 from source (CPU target, matching install.sh's
own documented procedure) into a throwaway local venv was the only way
to actually exercise forward()'s real control flow end-to-end. Doing
so caught two real bugs before they could have shipped silently:
 - The merged path's debug log message didn't contain the exact
   substring existing tests assert on ("Vulkan attention decode used"),
   since it originally read "Vulkan attention write+decode used" -
   fixed to keep that substring while still indicating the merged path
   was used.
 - _vulkan_cache_has_sequences's new exclude_current_token skip
   (`if seq_len <= 0: continue`) was applied unconditionally, which
   changed pre-existing behavior for its non-excluding caller too: a
   genuinely empty sequence (seq_len == 0, exercised by
   test_vulkan_cache_has_sequences_matches_reference) used to still
   call _remember_verified_prefix(entry, (), 0) - my change skipped
   that entirely. Fixed by only taking the early-skip path when
   exclude_current_token is set.
After both fixes, all 16 real (non-pre-existing-bug) tests in
test_attention_backend.py pass, including multi-layer shared-metadata
decode and prefill-then-decode sequences - a materially stronger
validation bar than any attention.py change earlier this session had.

One pre-existing test, test_multiple_decode_steps_reuse_kv_cache_entry_
and_stay_correct, fails identically on unmodified main (confirmed via
git stash) - its slot_mapping and block_table are constructed with
inconsistent formulas for step>=1 (slot_mapping cycles by 1, block_table
by num_blocks, so they stop describing the same physical slot), causing
decode to read back zeros instead of the just-written value regardless
of which code path handles it. Unrelated to and not fixed by this
commit; left as-is pending a dedicated follow-up.

The now-working vllm venv (this sandbox's tmp_work/vllm_test/venv) is
kept around (~1.7GB) as a durable asset for validating every subsequent
attention.py change this session, instead of relying on CI runs that
turned out to never actually exercise this code at all.

Also fixes a latent methodology issue discovered while measuring this:
the sequential-block "run N iterations of A, then N of B, take
whichever block's total was faster across a few trials" timing pattern
used successfully elsewhere in this codebase can be actively misleading
in the presence of GPU frequency scaling, since "keep the minimum
across trials" only filters symmetric noise, not a systematic,
directional bias from whichever function's block of back-to-back
dispatches happened to run at a different sustained GPU clock state
than the other's. The new test in this commit uses alternating-order
interleaved timing instead.

Addresses review feedback (gemini-code-assist, both genuine bugs):
 - _paged_kv_write_and_decode_batch now returns [] immediately for an
   empty batch (matching _paged_attn_decode_batch's own existing
   empty-batch handling) instead of proceeding into
   _build_paged_kv_write_op, which would raise ("K/V must contain at
   least one token") since num_tokens would be 0.
 - _try_write_and_decode_vulkan now returns False immediately when
   num_actual_tokens <= 0, instead of proceeding through a Vulkan
   context lookup, KV-cache-entry resolution, and a
   _vulkan_cache_has_sequences scan for nothing to actually do
   (_supports_vulkan_decode's query_lens_all_ones check trivially
   passes on an empty batch, e.g. a warmup/profiling call).
Both fixes verified with regression tests: test_kv_ops.py's new
test_paged_kv_write_and_decode_batch_empty_returns_empty_list_without_
writing (runs locally, no vllm needed) and test_attention_backend.py's
new test_try_write_and_decode_vulkan_returns_false_for_zero_tokens
(verified against the real vllm install described above - confirms
_cached_kv_cache_entry is never populated, i.e. no Vulkan work happens
at all). Full suite re-verified after both fixes: 115 of 116
non-pre-existing-bug tests pass against the real vllm install (up from
113 before these two fixes' new regression tests were added).

