### PR TITLE
fix: correct slot_mapping/block_table mismatch in multi-decode-step test

### DIFF
--- a/tests/python/test_attention_backend.py
+++ b/tests/python/test_attention_backend.py
@@ -921,8 +921,22 @@ def test_multiple_decode_steps_reuse_kv_cache_entry_and_stay_correct():
             max_seq_len=1,
             seq_lens=torch.tensor([1], dtype=torch.int32),
             block_table=torch.tensor([[step % num_blocks]], dtype=torch.int32),
+            # This is the very first (and only) token of a fresh,
+            # independent single-token sequence each step (seq_lens=[1]
+            # below), so it belongs at offset 0 of whichever block
+            # block_table assigns it - slot = block_id * block_size + 0.
+            # (A previous version of this test computed slot_mapping as
+            # `step % (num_blocks * block_size)`, which only happened to
+            # coincide with the correct slot at step=0; for step>=1 it
+            # named a slot inside a *different* block than block_table
+            # pointed at, so decode read back zeros instead of this
+            # step's just-written key/value - a real, if latent, bug in
+            # this test's own setup that a merged Vulkan write+decode
+            # path (see kv_ops.py's paged_kv_write_and_decode_batch_f32)
+            # surfaced by actually depending on write-then-read
+            # consistency within a single GPU submit.)
             slot_mapping=torch.tensor(
-                [step % (num_blocks * block_size)], dtype=torch.int64
+                [(step % num_blocks) * block_size], dtype=torch.int64
             ),
             scheduler_metadata=None,
             causal=True,


### PR DESCRIPTION
fix: correct slot_mapping/block_table mismatch in multi-decode-step test

test_multiple_decode_steps_reuse_kv_cache_entry_and_stay_correct built
each step's slot_mapping as `step % (num_blocks * block_size)` while
independently building block_table as `[[step % num_blocks]]`. These
only happened to describe the same physical slot at step=0 (both are
0); for step>=1 they diverged (e.g. step=1 wrote to slot 1, but
block_table pointed decode at block 1, i.e. slot 16), so the decode
read back on a later step was reading a slot that was never actually
written for that step - zeros, not the real key/value.

This was a latent bug in the test's own setup, not something any
production code path was exercising or protecting against - it was
never caught because this test (like all of test_attention_backend.py)
had never actually been run before: neither this sandbox nor this
repo's CI had `vllm` installed anywhere until last session's PR #77,
which built vllm 0.20.1 from source into a local throwaway venv
specifically to validate that PR's attention.py changes for the first
time. Running the full suite against that real vllm install (rather
than just the subset touched by #77) surfaced this pre-existing,
unrelated failure - confirmed via `git stash` to fail identically on
unmodified main, i.e. before and independent of #77's own changes.

Fix: slot_mapping must be `block_id * block_size + token_offset`; since
each step in this test represents the very first (and only) token of a
brand new, independent single-token sequence (seq_lens=[1] every
step), token_offset is always 0, so slot_mapping should be
`(step % num_blocks) * block_size`, matching block_table's own
`step % num_blocks` term.

Verified: the full local test suite now passes with zero deselections
for the first time this session - 116/116 tests green against a real
vllm 0.20.1 (CPU) install (up from the 115/116 - 1 pre-existing-bug
deselected reported by the immediately preceding PR), and the vllm-
independent 86 passed/2 skipped subset remains unchanged in the
standard dev venv. No production code (`vllm_vulkan/`) is touched by
this commit - test-only fix.

