### PR TITLE
perf: return writable PyByteArray instead of PyBytes from GPU reads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ impl VulkanContext {
             .map(|buf| {
                 let mut data = vec![0u8; buf.size as usize];
                 buf.read(&mut data).map_err(PyRuntimeError::new_err)?;
-                Ok(pyo3::types::PyBytes::new(py, &data).into())
+                Ok(pyo3::types::PyByteArray::new(py, &data).into())
             })
             .collect();
 
@@ -424,7 +424,7 @@ impl VulkanContext {
                 let buf = &out_bufs[meta.out_start + i];
                 let mut data = vec![0u8; buf.size as usize];
                 buf.read(&mut data).map_err(PyRuntimeError::new_err)?;
-                op_out.push(pyo3::types::PyBytes::new(py, &data).into());
+                op_out.push(pyo3::types::PyByteArray::new(py, &data).into());
             }
             all_results.push(op_out);
         }
@@ -457,7 +457,7 @@ impl VulkanContext {
     fn read_activation<'py>(&self, py: Python<'py>, tensor: &GpuTensor) -> PyResult<PyObject> {
         let mut data = vec![0u8; tensor.nbytes as usize];
         tensor.buf.read(&mut data).map_err(PyRuntimeError::new_err)?;
-        Ok(pyo3::types::PyBytes::new(py, &data).into())
+        Ok(pyo3::types::PyByteArray::new(py, &data).into())
     }
 
     /// Execute two chained compute ops in one vkQueueSubmit where Op 1's input
@@ -584,8 +584,8 @@ impl VulkanContext {
         self.engine.return_to_pool(out1_buf);
 
         Ok((
-            pyo3::types::PyBytes::new(py, &data0).into(),
-            pyo3::types::PyBytes::new(py, &data1).into(),
+            pyo3::types::PyByteArray::new(py, &data0).into(),
+            pyo3::types::PyByteArray::new(py, &data1).into(),
         ))
     }
 
@@ -654,7 +654,7 @@ impl VulkanContext {
                 self.engine
                     .download(buf, &mut data)
                     .map_err(PyRuntimeError::new_err)?;
-                Ok(pyo3::types::PyBytes::new(py, &data).into())
+                Ok(pyo3::types::PyByteArray::new(py, &data).into())
             })
             .collect()
     }

--- a/vllm_vulkan/kv_ops.py
+++ b/vllm_vulkan/kv_ops.py
@@ -552,7 +552,11 @@ def _paged_attn_decode(
         scale=scale,
     )
     results = ctx.execute_batch([op])
-    output = np.frombuffer(results[0][0], dtype=np.float32).copy()
+    # ctx.execute_batch returns a writable bytearray (not bytes)
+    # specifically so this frombuffer view doesn't need a defensive
+    # `.copy()` before torch.from_numpy can use it - see
+    # vulkan_ops._from_bytes's doc comment for the measured saving.
+    output = np.frombuffer(results[0][0], dtype=np.float32)
     return torch.from_numpy(output.reshape(num_q_heads, head_size))
 
 
@@ -617,8 +621,9 @@ def _paged_attn_decode_batch(
 
     results = ctx.execute_batch(ops)
     outputs = []
+    # No `.copy()` needed - see the single-token _paged_attn_decode above.
     for (num_q_heads, head_size), result in zip(shapes, results, strict=True):
-        output = np.frombuffer(result[0], dtype=np.float32).copy()
+        output = np.frombuffer(result[0], dtype=np.float32)
         outputs.append(torch.from_numpy(output.reshape(num_q_heads, head_size)))
     return outputs
 
@@ -807,10 +812,11 @@ def _paged_kv_write_and_decode_batch(
 
     results = ctx.execute_batch(ops)
     # results[0] is the write op's (empty) output list; decode outputs
-    # start at index 1.
+    # start at index 1. No `.copy()` needed - see the single-token
+    # _paged_attn_decode above.
     outputs = []
     for (num_q_heads, head_size), result in zip(shapes, results[1:], strict=True):
-        output = np.frombuffer(result[0], dtype=np.float32).copy()
+        output = np.frombuffer(result[0], dtype=np.float32)
         outputs.append(torch.from_numpy(output.reshape(num_q_heads, head_size)))
     return outputs
 

--- a/vllm_vulkan/vulkan_ops.py
+++ b/vllm_vulkan/vulkan_ops.py
@@ -215,10 +215,29 @@ def _to_bytes(t: torch.Tensor) -> bytes:
     return t.numpy().tobytes()
 
 
-def _from_bytes(data: bytes, shape: tuple, dtype: torch.dtype) -> torch.Tensor:
+def _from_bytes(
+    data: bytes | bytearray, shape: tuple, dtype: torch.dtype
+) -> torch.Tensor:
+    """Reconstructs a tensor from `ctx.execute_batch`/`execute_chained`'s
+    raw output.
+
+    Those Rust methods return a `bytearray` (not `bytes`) specifically so
+    `np.frombuffer` here produces a *writable* array — skipping the
+    `.copy()` a read-only (`bytes`-backed) buffer would otherwise force
+    on every single call before `torch.from_numpy` can use it. Measured
+    directly against real GPU-produced output (not a synthetic buffer,
+    which understates this): ~31.9us/call with the copy vs ~27.2us/call
+    without, on this hardware — a real, if modest next to the ~400-900us
+    GPU dispatch this follows, saving that adds up across the ~150+ GPU-
+    dispatched Linear calls per decode step (see kv_ops.py's
+    paged_kv_write_and_decode_batch_f32 docstring for that count). If
+    ever called with a genuine (read-only) `bytes` object instead, this
+    still works correctly — just re-pays the writability warning/copy
+    PyTorch itself falls back to internally in that case.
+    """
     if dtype == torch.bfloat16:
         arr = np.frombuffer(data, dtype=np.int16).reshape(shape)
-        return torch.from_numpy(arr.copy()).view(torch.bfloat16)
+        return torch.from_numpy(arr).view(torch.bfloat16)
     np_dtype = {
         torch.float32: np.float32,
         torch.float16: np.float16,
@@ -226,7 +245,7 @@ def _from_bytes(data: bytes, shape: tuple, dtype: torch.dtype) -> torch.Tensor:
         torch.int64: np.int64,
     }.get(dtype, np.float32)
     arr = np.frombuffer(data, dtype=np_dtype).reshape(shape)
-    return torch.from_numpy(arr.copy())
+    return torch.from_numpy(arr)
 
 
 # ─── Push-constant builders ──────────────────────────────────────────────────


### PR DESCRIPTION
perf: return writable PyByteArray instead of PyBytes from GPU reads

`execute_mixed`/`execute_batch`/`read_activation`/`execute_chained`
all read a Vulkan buffer's contents back into a Rust `Vec<u8>` and
handed it to Python as an immutable `PyBytes`. Every real caller on the
Python side (`vulkan_ops._from_bytes`, and three call sites in
kv_ops.py's paged-attention decode path) then had to
`np.frombuffer(...).copy()` before `torch.from_numpy()` could use the
result, purely because `np.frombuffer` over an immutable `bytes`
object produces a read-only array, and PyTorch does not support
non-writable tensors (emits "the given NumPy array is not writable...
this means writing to this tensor will result in undefined behavior").

Returning a `PyByteArray` instead (mutable, same buffer-protocol
support, same allocation cost as `PyBytes::new`) makes `np.frombuffer`
produce a genuinely writable array from the start, so every one of
those four call sites can drop its defensive `.copy()` entirely -
fixing the root cause (an unnecessarily immutable output type) rather
than paying to work around it downstream every single call.

Measured directly against real GPU-produced output on this hardware
(not a synthetic buffer, which understates this - a freshly-written
host-coherent Vulkan buffer's first CPU read pays real cache-coherency
cost that a repeatedly-touched CPU-only buffer doesn't): the
frombuffer+torch.from_numpy conversion itself drops from ~31.9us/call
to ~27.2us/call. At the level of a single `vulkan_ops.linear()` call
end-to-end (~580-600us, GPU submit+wait dominated - see this session's
other execute_batch-phase measurements), that ~4.7us saving is not
reliably distinguishable from run-to-run GPU dispatch noise on its own
(confirmed via an interleaved single-call A/B: means of 597.17us vs
596.97us across 10 alternating-order runs of 8000 iterations each -
statistically indistinguishable). Simulating a full decode step's
actual call volume instead (~150 GPU-dispatched Linear calls/token
across a real model - see kv_ops.py's paged_kv_write_and_decode_batch_
f32 docstring for that estimate) makes the effect visible above noise:
an interleaved A/B of 150-calls-per-"token" batches (8 alternating-
order runs each) shows a consistent, if modest, ~1.16% aggregate
speedup (mean 90450us/token old vs 89402us/token new), with the new
build faster in 6 of 8 runs.

Verified correctness: all 116 tests pass against a real vllm 0.20.1
install (this session's now-standard validation bar, see PR #77/#78),
including kv_ops.py's paged-attention decode correctness tests (which
directly exercise the three kv_ops.py call sites this touches) and
vulkan_ops.py's linear()/matvec correctness tests - with zero
"non-writable array" warnings appearing anywhere in the test output,
confirming the writability fix takes effect as intended. The
vllm-independent 86-passed/2-skipped subset is unchanged. Rust: 40
tests pass, clippy unchanged at 49 warnings (no new lint surface - only
the output type name of already-existing `PyObject`-returning
functions changed, not their signatures or any newly-introduced logic).

Only output-creation call sites are changed (`PyBytes::new(...)` -> `
PyByteArray::new(...)` in `execute_mixed`, `execute_batch`,
`read_activation`, `execute_chained`, and `execute`); the four
input-binding `downcast_bound::<PyBytes>` checks in `execute_batch`/
`execute_chained` are untouched, since `vulkan_ops._to_bytes` still
correctly produces immutable `bytes` for inputs (write-once, dispatched
into a Vulkan buffer, never read back through this path) - there is no
corresponding downstream copy to eliminate on the input side.

