### PR TITLE
docs: document why raising _MATVEC_THRESHOLD regresses prefill

### DIFF
--- a/tests/python/test_vulkan_ops.py
+++ b/tests/python/test_vulkan_ops.py
@@ -727,6 +727,69 @@ class TestLinearMatvecDispatchThreshold:
         )
         assert upload_counter["n"] == 1
 
+    def test_matvec_batching_does_not_help_at_prefill_scale_t(self, vulkan_ctx):
+        """Regression guard for `_MATVEC_THRESHOLD=4`: do NOT raise this
+        threshold to also dispatch larger (prefill-scale) T to the GPU
+        matvec shader - see `_MATVEC_THRESHOLD`'s doc comment in
+        vulkan_ops.py for the full measurement and root-cause
+        explanation (mul_mat_vec_f32_f32_f32's per-token dispatch
+        re-reads the entire weight matrix from GPU memory for every one
+        of the T "batch" rows, with none of a real tiled matmul's
+        weight-tile-reuse - bandwidth cost scales as O(T x in_features x
+        out_features), the same order as CPU's cost but at a worse
+        effective rate here).
+
+        Measured at Gemma4-E2B's real q_proj shape (2048x1536) and
+        T=128 (a representative prefill chunk size, well above
+        `_MATVEC_THRESHOLD`): CPU must remain clearly faster. Uses this
+        file's own min-of-N-trials pattern (see
+        test_small_weight_cpu_path_is_faster_than_gpu_dispatch_at_decode_shape
+        just above) - safe here since the underlying effect (measured
+        independently at ~6.5x and widening with T) is far larger than
+        any plausible measurement noise, unlike cases where a similar
+        pattern was found to be misleading for near-tied comparisons
+        (see kv_ops.py's paged_kv_write_and_decode_batch test in this
+        session's history for that finding).
+        """
+        import time
+
+        out_features, in_features = 2048, 1536
+        weight = torch.randn(out_features, in_features, dtype=torch.float32)
+        t_prefill = 128
+        x = torch.randn(t_prefill, in_features, dtype=torch.float32)
+
+        for _ in range(3):
+            vulkan_ops._vulkan_matvec(vulkan_ctx, x, weight)
+            torch.nn.functional.linear(x, weight, None)
+
+        iters = 10
+        trials = 3
+
+        def timed(fn) -> float:
+            best = float("inf")
+            for _ in range(trials):
+                t0 = time.perf_counter()
+                for _ in range(iters):
+                    fn()
+                best = min(best, time.perf_counter() - t0)
+            return best
+
+        gpu_elapsed = timed(lambda: vulkan_ops._vulkan_matvec(vulkan_ctx, x, weight))
+        cpu_elapsed = timed(lambda: torch.nn.functional.linear(x, weight, None))
+
+        print(
+            f"\nmatvec batching at prefill scale (T={t_prefill}, 2048x1536), "
+            f"best-of-{trials}: GPU batched-matvec {gpu_elapsed / iters * 1e6:.1f}us/call, "
+            f"CPU linear {cpu_elapsed / iters * 1e6:.1f}us/call, "
+            f"CPU speedup {gpu_elapsed / cpu_elapsed:.2f}x"
+        )
+        assert cpu_elapsed < gpu_elapsed, (
+            f"CPU ({cpu_elapsed:.4f}s/{iters}) was not faster than GPU batched-matvec "
+            f"({gpu_elapsed:.4f}s/{iters}) at prefill-scale T={t_prefill} - if this "
+            f"genuinely changed (e.g. a future driver/hardware improvement), see "
+            f"_MATVEC_THRESHOLD's doc comment before raising it based on this alone."
+        )
+
 
 class TestWrapRmsNormHoistsStaticLookups:
     """`_wrap_rms_norm` now captures `weight`/`eps`/the disable-ops env

--- a/vllm_vulkan/vulkan_ops.py
+++ b/vllm_vulkan/vulkan_ops.py
@@ -321,6 +321,49 @@ _MATVEC_THRESHOLD = 4  # T < this → matvec shader; T >= this → CPU
 # `linear`'s doc comment for the measurement behind this cutoff.
 _MATVEC_MIN_WEIGHT_ELEMENTS = 1_000_000
 
+# Do NOT "fix" prefill performance by simply raising _MATVEC_THRESHOLD so
+# larger T also dispatches to mul_mat_vec_f32_f32_f32 — measured directly
+# on this hardware, at Gemma4-E2B's real q_proj shape (in_features=1536,
+# out_features=2048), this makes prefill dramatically SLOWER, not faster:
+#
+#   T      CPU (torch.nn.functional.linear)   GPU (mul_mat_vec_f32_f32_f32)
+#   1        873.2us  (873.21us/token)           388.5us  (388.48us/token)
+#   4        815.4us  (203.86us/token)            980.1us  (245.01us/token)
+#  16        988.0us   (61.75us/token)           3387.8us  (211.74us/token)
+#  64       2304.4us   (36.01us/token)          12767.6us  (199.49us/token)
+# 128       3917.5us   (30.61us/token)          25378.4us  (198.27us/token)
+# 256       7370.5us   (28.79us/token)          50219.2us  (196.17us/token)
+# 512      14736.1us   (28.78us/token)          99819.7us  (194.96us/token)
+#
+# GPU is already ~6.5x slower than CPU by T=128, and the gap keeps
+# widening. Root cause: mul_mat_vec's per-token dispatch (workgroups =
+# (N, T, 1), see `_vulkan_matvec`) is a genuine batched matrix-VECTOR
+# multiply — each of the T "batch" workgroup-rows independently re-reads
+# the *entire* weight matrix from GPU memory (see mul_mat_vec_base.glsl's
+# `get_offsets()`: every batch_idx in [0, T) resolves to the same
+# `a_offset` since the shader's ne02/ne12/broadcast2/broadcast3 push
+# constants are set up for "same weight, T independent inputs"
+# broadcasting, not weight-tile reuse across inputs). That's fine at
+# T<4 (decode) where the fixed per-dispatch driver overhead dominates
+# and re-reading a ~3-12MB weight matrix a handful of times is cheap
+# relative to it, but at prefill-scale T it means GPU bandwidth cost
+# scales as O(T x in_features x out_features) — the same order as CPU's
+# cost, with none of a real tiled matmul's weight-tile-reuse advantage,
+# so GPU just pays that cost at a *worse* effective rate than CPU's own
+# BLAS routines here.
+#
+# A real prefill speedup would need the tiled matmul shaders this
+# backend already compiles but has never dispatched anywhere
+# (`matmul_f32_f16`/`matmul_f32_f16_aligned`/`matmul_f32_f32_fp32`/
+# `matmul_f16_f32_fp32`, from shaders/mul_mm.comp — a llama.cpp-derived
+# kernel with its own BM/BN/WM/WN/WMITER/TM/TN/TK/WARP specialization-
+# constant tiling scheme, substantial push-constant surface, and no
+# prior working example anywhere in this codebase's history to build
+# from) - a real, valuable, but substantially larger undertaking than
+# this threshold, deferred rather than attempted piecemeal. See
+# `test_matvec_batching_does_not_help_at_prefill_scale_t` (tests/python/
+# test_vulkan_ops.py) for the regression guard backing the numbers above.
+
 
 def rms_norm(
     x: torch.Tensor,


### PR DESCRIPTION
docs: document why raising _MATVEC_THRESHOLD regresses prefill

Investigated whether the real serving path's GPU/CPU dispatch decision
in linear() (`_MATVEC_THRESHOLD=4`, T<4 -> GPU matvec, T>=4 -> CPU)
could simply be raised to also route prefill-scale T to the GPU, since
CPU prefill cost scales roughly linearly with T (measured ~28.8-30.6us/
token at T>=128 for a real Gemma4-E2B-shaped Linear, i.e. ~3.9ms at
T=128) while a single GPU dispatch's fixed submission overhead
(~400-900us, see this session's other execute_batch-phase
measurements) is already a small fraction of that by T=128 - on paper,
a promising, cheap-looking win reusing the already-integrated, already-
tested mul_mat_vec_f32_f32_f32 shader (no new shader-integration risk).

Measured directly instead of assuming: it's a clear regression, not a
win, and the gap widens with T:

  T      CPU (torch.nn.functional.linear)   GPU (mul_mat_vec_f32_f32_f32)
  1        873.2us  (873.21us/token)           388.5us  (388.48us/token)
  4        815.4us  (203.86us/token)            980.1us  (245.01us/token)
 16        988.0us   (61.75us/token)           3387.8us  (211.74us/token)
 64       2304.4us   (36.01us/token)          12767.6us  (199.49us/token)
128       3917.5us   (30.61us/token)          25378.4us  (198.27us/token)
256       7370.5us   (28.79us/token)          50219.2us  (196.17us/token)
512      14736.1us   (28.78us/token)          99819.7us  (194.96us/token)

Root cause: mul_mat_vec's per-token dispatch (workgroups = (N, T, 1))
is a genuine batched matrix-VECTOR multiply, not a matmul - traced
through mul_mat_vec_base.glsl's get_offsets(): every one of the T
"batch" workgroup-rows independently re-reads the *entire* weight
matrix from GPU memory (the ne02/ne12/broadcast2/broadcast3 push
constants _matvec_pc sets up mean every batch_idx resolves to the same
a_offset - "same weight, T independent inputs" broadcasting, not
weight-tile reuse across inputs). That's the right call at T<4
(decode), where the fixed per-dispatch overhead dominates and
re-reading a few-MB weight matrix a handful of times is cheap relative
to it - but at prefill scale it means GPU bandwidth cost scales as
O(T x in_features x out_features), the same order as CPU's own cost,
with none of a real tiled matmul's weight-tile-reuse advantage, so GPU
pays that cost at a worse effective rate than CPU's BLAS routines.

This rules out "just raise the threshold" as a path to GPU-accelerated
prefill. A real win would need this backend's already-compiled but
never-dispatched-anywhere tiled matmul shaders (matmul_f32_f16/
matmul_f32_f16_aligned/matmul_f32_f32_fp32/matmul_f16_f32_fp32, from
shaders/mul_mm.comp - a llama.cpp-derived kernel with its own
BM/BN/WM/WN/WMITER/TM/TN/TK/WARP specialization-constant tiling scheme
and a substantial push-constant surface, with zero prior working
dispatch example anywhere in this codebase's history to build from) -
a legitimate, valuable, but substantially larger undertaking than
adjusting a threshold, deferred to a dedicated future effort rather
than attempted piecemeal under this turn's time/risk budget.

Documents the finding as a permanent regression guard
(test_matvec_batching_does_not_help_at_prefill_scale_t in
tests/python/test_vulkan_ops.py, following this file's existing
min-of-N-trials measurement pattern - safe here since the effect
measured is ~6x and widening, far larger than any plausible
measurement noise) plus a detailed doc comment at _MATVEC_THRESHOLD's
definition in vulkan_ops.py, so a future change to this threshold has
to actively contend with this data rather than re-discover it (or
worse, ship an untested regression) from scratch.

Verified: 87 passed/2 skipped locally (up from 86/2), 117 passed
against the real vllm 0.20.1 install (up from 116) - the new test
passes, reproducing the ~6.27x CPU speedup measured above at T=128.
No production code path changed - _MATVEC_THRESHOLD's value is
unchanged, this is a documentation/regression-test-only commit. Rust:
40 tests pass, clippy unchanged at 49 warnings (no Rust changes).

