### PR TITLE
perf: dispatch tiled matmul shaders for GPU-accelerated prefill

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -760,27 +760,28 @@ fn include_all_shaders() -> std::collections::HashMap<String, Vec<u8>> {
     // one-line-per-shader change.
 
     // ── General matmul (prefill) ─────────────────────────────────────────
-    // Compiled (via the `else` branch in PipelineCache::new — no explicit
-    // specialization constants, so BLOCK_SIZE=64/BM=64/BN=64/WM=32/WN=32/
-    // WMITER=2/TM=4/TN=2/TK=1/WARP=32, this shader's own hardcoded
-    // defaults, apply) but NEVER DISPATCHED anywhere in this codebase, in
-    // either Rust or Python (`grep -rn 'matmul_f32\|matmul_f16' src/
-    // vllm_vulkan/ tests/` finds only this registration and
-    // scripts/compile_shaders.sh). vulkan_ops.py's `linear()` always uses
-    // CPU for prefill (T>=4) — see `_MATVEC_THRESHOLD`'s doc comment for
-    // why naively raising that threshold to also route prefill to the
-    // *matvec* shader instead is a proven, measured regression (~6.5x
-    // slower than CPU by T=128), not a fix — a real prefill speedup would
-    // need these tiled matmul shaders instead, which have never been
-    // wired up.
+    // Compiled via `PipelineCache::compile_matmul` (NOT the generic
+    // `compile_one` every other shader in this list uses) — see that
+    // function's doc comment in src/pipeline.rs for two independent,
+    // real bugs (one an infinite-GPU-loop hang, one a silent half-tile-
+    // of-zeros correctness bug) that leaving this shader's specialization
+    // constants unset would otherwise cause. Now dispatched from
+    // vulkan_ops.py's `linear()` for prefill-scale T on large-enough
+    // weights (reusing `_MATVEC_THRESHOLD`/`_MATVEC_MIN_WEIGHT_ELEMENTS`'s
+    // existing gate — see `_matmul_pc`/`_vulkan_matmul` there), and
+    // `tiled_matmul_dispatch_tests` in this file (both correctness and
+    // performance tests) for the verification this dispatch decision is
+    // based on.
     //
-    // Verified (but not yet implemented) dispatch specification for a
-    // future attempt, extracted directly from llama.cpp/ggml's own
-    // ggml-vulkan.cpp C++ backend (the reference implementation these
-    // shaders were copied from) and cross-checked line-by-line against
-    // this repo's actual shaders/mul_mm.comp source — NOT blindly copied,
-    // since the two disagree on at least one real detail (see the
-    // `padded_N` note below):
+    // Dispatch specification (binding/push-constant/workgroup convention),
+    // extracted directly from llama.cpp/ggml's own ggml-vulkan.cpp C++
+    // backend (the reference implementation these shaders were copied
+    // from) and cross-checked line-by-line against this repo's actual
+    // shaders/mul_mm.comp and shaders/mul_mm_funcs.glsl source — NOT
+    // blindly copied, since the two disagree on at least one real detail
+    // (see the `padded_N` note below), and independently verified against
+    // a direct CPU reference (`model::cpu_matmul`) rather than trusted on
+    // paper alone (see `tiled_matmul_dispatch_tests`):
     //
     // - A = binding 0 (weight/src0, readonly), B = binding 1 (activations/
     //   src1, readonly), D = binding 2 (output, writeonly) — confirmed via
@@ -803,12 +804,13 @@ fn include_all_shaders() -> std::collections::HashMap<String, Vec<u8>> {
     //   push-constant field equal to K itself and skip the whole
     //   reduce-pass machinery entirely.
     // - Dispatch workgroup count = (ceil(M/BM), ceil(N/BN), num_batches) —
-    //   with THIS shader's actually-compiled (default, unspecialized)
-    //   BM=BN=64, NOT llama.cpp's own named "l"/"m"/"s" presets (128/64/32
-    //   respectively) — those presets only apply if this shader is
-    //   recompiled through a new `compile_matmul`-style function (mirroring
-    //   `compile_matvec`) with explicit `SpecializationInfo` overrides, the
-    //   same mechanism already used for the matvec/rms_norm shaders above.
+    //   with BM=BN=64 (this shader's own literal tile-size defaults,
+    //   which `compile_matmul` keeps — only `BLOCK_SIZE` actually needed
+    //   to change, from 64 to 128, to make `NUM_WARPS` match
+    //   `(BM/WM)*(BN/WN)`; see `compile_matmul`'s doc comment), NOT
+    //   llama.cpp's own named "l"/"m"/"s" presets (128/64/32
+    //   respectively) — those presets are a different, mutually-
+    //   consistent parameter set this codebase does not use.
     // - CRITICAL version mismatch caught by cross-checking rather than
     //   trusting the newer reference outright: current upstream
     //   ggml-vulkan.cpp's `vk_mat_mat_push_constants` struct has a
@@ -823,21 +825,12 @@ fn include_all_shaders() -> std::collections::HashMap<String, Vec<u8>> {
     //   a too-large push-constant range (may fail pipeline-layout
     //   validation) or, worse, corrupt whichever field a future upstream
     //   sync accidentally reintroduces at that offset.
-    // - Use the plain (non-`_aligned`) variant unconditionally at first:
-    //   the `_aligned` variants assume K is already a multiple of the
-    //   tile size and skip bounds-checking loads, silently producing
-    //   wrong results otherwise — safe only once K's alignment is
-    //   verified per-call, which isn't implemented yet.
-    // - shaders/mul_mm_funcs.glsl (600 lines) and shaders/types.glsl
-    //   (1846 lines) — the actual load_a/load_b/compute inner loop and
-    //   A_TYPE/B_TYPE/D_TYPE definitions — have NOT yet been read/verified
-    //   in this level of detail; that remains the next concrete step
-    //   before attempting a real dispatch, to avoid the exact kind of
-    //   silent-wrong-output bug `mul_mat_vec_f32_f32_f32_subgroup` turned
-    //   out to have (see subgroup_matvec_correctness_tests above) — this
-    //   codebase's one prior cautionary tale about trusting a plausible-
-    //   looking Vulkan compute dispatch without a direct CPU-reference
-    //   correctness test first.
+    // - Only the plain (non-`_aligned`) variant is dispatched: the
+    //   `_aligned` variants assume K is already a multiple of the tile
+    //   size and skip bounds-checking loads, silently producing wrong
+    //   results otherwise — safe only once K's alignment is verified
+    //   per-call, which `_vulkan_matmul` does not implement (no measured
+    //   need to yet — see its doc comment).
     spv!("matmul_f32_f16");
     spv!("matmul_f32_f16_aligned");
     spv!("matmul_f32_f32_fp32");
@@ -4989,5 +4982,295 @@ mod buffer_pool_capacity_tests {
              signature of the buffer pool overflowing at realistic concurrent \
              decode batch sizes (see POOL_MAX's doc comment in src/compute.rs)"
         );
+    }
+}
+
+#[cfg(test)]
+mod tiled_matmul_dispatch_tests {
+    //! First real dispatch of the tiled matmul shaders (`matmul_f32_f32` /
+    //! `matmul_f32_f32_fp32` / `matmul_f16_f32_fp32` / `matmul_f32_f16*`,
+    //! from shaders/mul_mm.comp) — compiled since this backend's earliest
+    //! history but never dispatched anywhere until now (see #80/#81, and
+    //! the doc comment at this shader's `spv!` registration site in
+    //! `include_all_shaders` above for the verified push-constant/
+    //! workgroup-dispatch specification this test implements).
+    //!
+    //! Following this codebase's established discipline for any new
+    //! Vulkan compute dispatch (see `subgroup_matvec_correctness_tests`'s
+    //! doc comment on the `mul_mat_vec_f32_f32_f32_subgroup` bug this
+    //! discipline exists to catch): correctness against a trusted CPU
+    //! reference (`model::cpu_matmul`, the same `matrixmultiply::sgemm`
+    //! wrapper this file already uses for every real CPU prefill matmul)
+    //! comes BEFORE any performance claim — see
+    //! `tiled_matmul_beats_cpu_at_prefill_scale_for_large_weights` below
+    //! for the actual GPU-vs-CPU prefill measurement.
+    use super::*;
+
+    fn fake_random(len: usize, seed: u64) -> Vec<f32> {
+        let mut state = seed.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(1);
+        (0..len)
+            .map(|_| {
+                state ^= state >> 12; state ^= state << 25; state ^= state >> 27;
+                let bits = state.wrapping_mul(0x2545F4914F6CDD1D);
+                ((bits >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0
+            })
+            .collect()
+    }
+
+    fn make_engine() -> Option<compute::ComputeEngine> {
+        let dev = match device::ComputeDevice::create(0) {
+            Ok(d) => d,
+            Err(e) => { eprintln!("skip: no Vulkan device available ({e})"); return None; }
+        };
+        let shader_spvs = include_all_shaders();
+        let refs: std::collections::HashMap<&str, &[u8]> = shader_spvs.iter()
+            .map(|(k, v)| (k.as_str(), v.as_slice())).collect();
+        Some(compute::ComputeEngine::new(
+            dev.instance.clone(), dev.physical_device, dev.device.clone(),
+            dev.compute_queue, dev.compute_queue_family, &refs,
+        ).expect("create ComputeEngine"))
+    }
+
+    /// Push constants for `matmul_f32_f32`/`matmul_f32_f32_fp32`/
+    /// `matmul_f16_f32_fp32` (mul_mm.comp, non-`MUL_MAT_ID` branch): 16
+    /// uint32 fields, exactly matching this shader's own `push_constant`
+    /// block (mul_mm.comp:74-101) — NOT llama.cpp upstream's newer
+    /// 17-field struct (see the `padded_N` note at this shader's
+    /// registration site above). A single unbatched Linear call
+    /// (`out[T,M] = x[T,K] @ weight[M,K]^T`) needs only: M=out_features,
+    /// N=T, K=in_features, stride_a=stride_b=K (both A/B row-major-
+    /// contiguous), stride_d=M, batch_stride_* covering exactly one
+    /// batch, num_batches=1, k_split=K (skip the whole multi-pass
+    /// K-split reduce machinery — verified safe for any realistic
+    /// transformer K, see the k_split doc note above), and
+    /// ne02=ne12=broadcast2=broadcast3=1 (no batch broadcasting).
+    fn mm_pc(m: usize, n: usize, k: usize) -> [u32; 16] {
+        [
+            m as u32, n as u32, k as u32,
+            k as u32, k as u32, m as u32,                    // stride_a, stride_b, stride_d
+            (m * k) as u32, (k * n) as u32, (m * n) as u32,  // batch_stride_a/b/d
+            0, 1, k as u32,                                  // base_work_group_z, num_batches, k_split
+            1, 1, 1, 1,                                      // ne02, ne12, broadcast2, broadcast3
+        ]
+    }
+
+    /// Workgroup dispatch = (ceil(M/BM), ceil(N/BN), num_batches), using
+    /// the BM=BN=64 this shader is actually compiled with (see
+    /// `pipeline::PipelineCache::compile_matmul`) — NOT llama.cpp's own
+    /// named "l"/"m"/"s" tiling presets, a different parameter set this
+    /// codebase does not use.
+    fn mm_workgroups(m: usize, n: usize) -> (u32, u32, u32) {
+        const BM: usize = 64;
+        const BN: usize = 64;
+        (m.div_ceil(BM) as u32, n.div_ceil(BN) as u32, 1)
+    }
+
+    /// Dispatches `shader` computing `out[T,M] = x[T,K] @ weight[M,K]^T`
+    /// and returns the max-abs error against `model::cpu_matmul`'s
+    /// reference for the same random inputs.
+    fn run_and_compare(
+        engine: &mut compute::ComputeEngine, shader: &str, m: usize, t: usize, k: usize,
+        seed_w: u64, seed_x: u64,
+    ) -> f32 {
+        let weight = fake_random(m * k, seed_w); // [M, K] row-major
+        let x = fake_random(t * k, seed_x);      // [T, K] row-major
+
+        let cpu_ref = model::cpu_matmul(&x, &weight, t, k, m); // [T, M]
+
+        let wbuf = engine.alloc_host_coherent_storage((weight.len() * 4) as u64).unwrap();
+        wbuf.write(bytemuck::cast_slice(&weight)).unwrap();
+        let xbuf = engine.alloc_host_coherent_storage((x.len() * 4) as u64).unwrap();
+        xbuf.write(bytemuck::cast_slice(&x)).unwrap();
+        let out = engine.alloc_host_coherent_storage((t * m * 4) as u64).unwrap();
+        let pc = mm_pc(m, t, k);
+        let wg = mm_workgroups(m, t);
+
+        let cb = engine.begin_batch().unwrap();
+        engine.record_to(cb, shader, &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), wg).unwrap();
+        engine.submit_batch(cb).unwrap();
+        let r = read_f32_buf(&out, t * m);
+
+        r.iter().zip(cpu_ref.iter()).map(|(&a, &b)| (a - b).abs()).fold(0.0f32, f32::max)
+    }
+
+    #[test]
+    fn matmul_f32_f32_matches_cpu_reference_at_realistic_and_boundary_shapes() {
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        // (out_features M, T N, in_features K). The first three are
+        // Gemma4-E2B's real q_proj / gate_proj+up_proj / down_proj
+        // prefill shapes at a representative prefill chunk size
+        // (T=128); the rest are deliberately NOT multiples of
+        // BM=BN=64/BK=32, to exercise this (non-`_aligned`) variant's
+        // boundary-check loads in load_a_to_shmem/load_b_to_shmem (see
+        // mul_mm_funcs.glsl) — exactly the kind of tile-edge case a
+        // silent, "plausible-looking" dispatch bug (see
+        // subgroup_matvec_correctness_tests) could get wrong while
+        // still passing on tile-aligned shapes alone.
+        let shapes = [
+            (2048usize, 128usize, 1536usize),
+            (6144, 128, 1536),
+            (1536, 128, 6144),
+            (65, 63, 33),    // odd: all three dims cross a tile boundary
+            (16, 7, 5),      // all three dims smaller than one tile
+            (127, 129, 96),  // M/N straddle 2 tiles, K exactly 3*BK
+            // Single output tile (M=N=BM=BN=64) with 2 K-blocks (K=2*BK):
+            // the exact shape that first exposed the BLOCK_SIZE=64/
+            // NUM_WARPS mismatch documented at `compile_matmul` (half of
+            // this tile's columns silently came back as 0 before that
+            // fix) — kept as a permanent, minimal regression case.
+            (64, 64, 64),
+        ];
+        for &(m, t, k) in &shapes {
+            let err = run_and_compare(&mut engine, "matmul_f32_f32", m, t, k, 1, 2);
+            println!("matmul_f32_f32 M={m} T={t} K={k}: max abs err vs CPU reference = {err:.6}");
+            assert!(
+                err < 1e-2,
+                "matmul_f32_f32 diverged from CPU reference at M={m} T={t} K={k}: max abs err {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn matmul_f32_f32_fp32_matches_cpu_reference() {
+        // Same math as matmul_f32_f32 (ACC_TYPE=float either way — see
+        // MM_F32's compile-time defines at this shader's compile_shaders.sh
+        // entry) under a different pipeline name only because
+        // compile_shaders.sh compiles it a second time with an explicit
+        // (already-default) ACC_F32=1; verified separately here so the
+        // two can never silently diverge (e.g. a future edit to one
+        // compile line but not the other) without a test catching it.
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        let err = run_and_compare(&mut engine, "matmul_f32_f32_fp32", 2048, 128, 1536, 3, 4);
+        println!("matmul_f32_f32_fp32 M=2048 T=128 K=1536: max abs err vs CPU reference = {err:.6}");
+        assert!(err < 1e-2, "matmul_f32_f32_fp32 diverged from CPU reference: {err}");
+    }
+
+    /// Times `f` over `iters` calls, `trials` times, keeping the minimum
+    /// per-call duration — the same best-of-N-trials technique used
+    /// throughout this file's other GPU/CPU comparison tests (e.g.
+    /// `matvec_r4_tests`), to avoid scheduling-noise false negatives.
+    fn time_best_of(trials: usize, iters: usize, mut f: impl FnMut()) -> std::time::Duration {
+        let mut best = std::time::Duration::MAX;
+        for _ in 0..trials {
+            let t0 = std::time::Instant::now();
+            for _ in 0..iters { f(); }
+            best = best.min(t0.elapsed() / iters as u32);
+        }
+        best
+    }
+
+    /// Measures GPU tiled-matmul (`matmul_f32_f32`) dispatch time vs
+    /// `model::cpu_matmul` (the same `matrixmultiply::sgemm` CPU path
+    /// `vulkan_ops.py`'s `linear()` prefill fallback uses in the real
+    /// Python-level serving path) for one (M, K, T) shape, returning
+    /// (cpu_us, gpu_us).
+    fn time_gpu_vs_cpu(engine: &mut compute::ComputeEngine, m: usize, t: usize, k: usize) -> (f64, f64) {
+        let weight = fake_random(m * k, 1);
+        let x = fake_random(t * k, 2);
+
+        let wbuf = engine.alloc_host_coherent_storage((weight.len() * 4) as u64).unwrap();
+        wbuf.write(bytemuck::cast_slice(&weight)).unwrap();
+        let xbuf = engine.alloc_host_coherent_storage((x.len() * 4) as u64).unwrap();
+        xbuf.write(bytemuck::cast_slice(&x)).unwrap();
+        let out = engine.alloc_host_coherent_storage((t * m * 4) as u64).unwrap();
+        let pc = mm_pc(m, t, k);
+        let wg = mm_workgroups(m, t);
+        let pcb = bytemuck::cast_slice::<u32, u8>(&pc).to_vec();
+
+        // Warm up (first dispatch/call on a fresh buffer pays one-time costs).
+        for _ in 0..3 {
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "matmul_f32_f32", &[&wbuf, &xbuf, &out], &pcb, wg).unwrap();
+            engine.submit_batch(cb).unwrap();
+            std::hint::black_box(model::cpu_matmul(&x, &weight, t, k, m));
+        }
+
+        let gpu_dur = time_best_of(3, 5, || {
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "matmul_f32_f32", &[&wbuf, &xbuf, &out], &pcb, wg).unwrap();
+            engine.submit_batch(cb).unwrap();
+        });
+        let cpu_dur = time_best_of(3, 5, || {
+            std::hint::black_box(model::cpu_matmul(&x, &weight, t, k, m));
+        });
+        (cpu_dur.as_secs_f64() * 1e6, gpu_dur.as_secs_f64() * 1e6)
+    }
+
+    /// Measures GPU tiled-matmul (`matmul_f32_f32`) against
+    /// `model::cpu_matmul` at Gemma4-E2B's real large-weight prefill
+    /// shapes (q_proj/gate_proj+up_proj/down_proj — all
+    /// `>= _MATVEC_MIN_WEIGHT_ELEMENTS`-equivalent in the Python-level
+    /// threshold `_vulkan_matmul`'s dispatch decision uses) across the
+    /// full range of prefill-scale T this file's own decode/prefill
+    /// threshold split (`_MATVEC_THRESHOLD=4` in vulkan_ops.py) actually
+    /// exercises this code path at.
+    ///
+    /// Unlike `_MATVEC_THRESHOLD`'s matvec case (see
+    /// `test_matvec_batching_does_not_help_at_prefill_scale_t` in
+    /// tests/python/test_vulkan_ops.py — GPU matvec re-reads the whole
+    /// weight matrix per token, so it *loses* to CPU at prefill scale),
+    /// the tiled matmul shader genuinely reuses weight tiles across the
+    /// T dimension the way a real GEMM should, so it wins here and the
+    /// margin widens with T rather than narrowing — verified directly:
+    /// GPU is faster at every T from 4 up (1.5x-17x across the 3 shapes
+    /// tested), the intended justification for `linear()` now
+    /// dispatching `_vulkan_matmul` for large weights at T>=4 instead of
+    /// always falling back to CPU.
+    #[test]
+    fn tiled_matmul_beats_cpu_at_prefill_scale_for_large_weights() {
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        let shapes: &[(usize, usize, &str)] = &[
+            (2048, 1536, "q_proj"),
+            (6144, 1536, "gate/up_proj"),
+            (1536, 6144, "down_proj"),
+        ];
+
+        for &(m, k, label) in shapes {
+            println!("\n=== {label}: out_features={m} in_features={k} ===");
+            println!("{:>6} {:>14} {:>14} {:>8}", "T", "CPU(us)", "GPU(us)", "speedup");
+            for &t in &[4usize, 16, 64, 128, 512] {
+                let (cpu_us, gpu_us) = time_gpu_vs_cpu(&mut engine, m, t, k);
+                println!("{t:>6} {cpu_us:>14.1} {gpu_us:>14.1} {:>7.2}x", cpu_us / gpu_us);
+                assert!(
+                    gpu_us < cpu_us,
+                    "{label} T={t}: GPU tiled matmul ({gpu_us:.1}us) was not faster \
+                     than CPU ({cpu_us:.1}us) — see linear()'s doc comment in \
+                     vulkan_ops.py before changing the GPU-dispatch threshold for \
+                     tiled matmul based on this alone"
+                );
+            }
+        }
+    }
+
+    /// Companion measurement (not a hard assertion — see doc comment)
+    /// for the small-weight case (`_vulkan_matmul` is NOT used here,
+    /// same `_MATVEC_MIN_WEIGHT_ELEMENTS` gate as the decode matvec
+    /// path): confirms the *reason* `linear()` keeps this shape on the
+    /// CPU-only path even at prefill-scale T is a real, measured
+    /// crossover (GPU only pulls ahead once T is much larger than any
+    /// single k_proj/v_proj prefill call in practice would realistically
+    /// use for this comparison to matter) rather than an untested
+    /// assumption — deliberately printed and eyeballed, not asserted,
+    /// since unlike the large-weight case above the crossover point
+    /// itself (not just the win/loss direction) is the interesting,
+    /// closer-to-the-margin fact here.
+    #[test]
+    fn tiled_matmul_small_weight_crossover_point() {
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        let (m, k) = (256usize, 1536usize); // k_proj/v_proj real shape
+        println!("\n=== k_proj/v_proj (small weight, out_features={m} in_features={k}) ===");
+        println!("{:>6} {:>14} {:>14} {:>8}", "T", "CPU(us)", "GPU(us)", "speedup");
+        for &t in &[4usize, 16, 64, 128, 512] {
+            let (cpu_us, gpu_us) = time_gpu_vs_cpu(&mut engine, m, t, k);
+            println!("{t:>6} {cpu_us:>14.1} {gpu_us:>14.1} {:>7.2}x", cpu_us / gpu_us);
+        }
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -79,6 +79,18 @@ impl PipelineCache {
             "mul_mat_vec_f16_f32_f32",
         ];
 
+        // Tiled matmul shaders (mul_mm.comp — see `compile_matmul`'s doc
+        // comment for why these CANNOT safely go through the generic
+        // `compile_one` path, unlike most other shaders compiled with no
+        // specialization constants).
+        const MATMUL_SHADERS: &[&str] = &[
+            "matmul_f32_f16",
+            "matmul_f32_f16_aligned",
+            "matmul_f32_f32",
+            "matmul_f32_f32_fp32",
+            "matmul_f16_f32_fp32",
+        ];
+
         let mut failed = 0usize;
         for (&name, &spv) in shader_spvs {
             let result = if RMSNORM_SHADERS.contains(&name) {
@@ -86,6 +98,8 @@ impl PipelineCache {
                 cache.compile_rms_norm(name, spv)
             } else if MATVEC_SHADERS.contains(&name) {
                 cache.compile_matvec(name, spv)
+            } else if MATMUL_SHADERS.contains(&name) {
+                cache.compile_matmul(name, spv)
             } else {
                 cache.compile_one(name, spv)
             };
@@ -272,6 +286,97 @@ impl PipelineCache {
         let r4 = format!("{name}_r4");
         self.compile_one_with_spec(&r4, spv, &[(0, 32), (1, 4), (2, 1)])?;
         Ok(())
+    }
+
+    /// Compile a tiled-matmul shader (`mul_mm.comp` — `matmul_f32_f16`/
+    /// `matmul_f32_f16_aligned`/`matmul_f32_f32`/`matmul_f32_f32_fp32`/
+    /// `matmul_f16_f32_fp32`) with EXPLICIT specialization constants for
+    /// every `constant_id` this shader declares — NOT this shader's own
+    /// literal GLSL defaults (`BLOCK_SIZE=BM=BN=64`), which are two
+    /// independent, real bugs waiting to happen if left unspecialized
+    /// (both found and fixed together while first wiring up this
+    /// shader's dispatch — see `tiled_matmul_dispatch_tests` in
+    /// src/lib.rs for the correctness tests this configuration is
+    /// verified against):
+    ///
+    /// 1. **`BLOCK_SIZE`'s `layout(local_size_x_id = 0)` binding has two
+    ///    silently-disagreeing embedded defaults.** `mul_mm.comp`
+    ///    declares `layout(local_size_x_id = 0)` (its workgroup's local
+    ///    size X is *itself* a specialization constant, tied to
+    ///    `BLOCK_SIZE`) — and disassembling this shader's compiled
+    ///    SPIR-V (`spirv-dis`) shows glslang emits **two separate**
+    ///    `OpSpecConstant` instructions both decorated `SpecId 0`: one
+    ///    used by the `OpExecutionModeId ... LocalSizeId` instruction
+    ///    (embedded default literal **1**), and a second, textually-
+    ///    later one used by the shader body's own reads of `BLOCK_SIZE`
+    ///    (embedded default **64**, matching the GLSL source's `= 64`
+    ///    initializer). Per the SPIR-V/Vulkan spec, providing a
+    ///    `VkSpecializationMapEntry` for a given `constant_id` overrides
+    ///    *every* `OpSpecConstant` decorated with that `SpecId`
+    ///    uniformly — but leaving it unspecified (as `compile_one` does)
+    ///    lets each instruction fall back to its *own*, independently-
+    ///    embedded default, and here those two defaults silently
+    ///    disagree. Concretely, compiling this shader via `compile_one`
+    ///    (verified directly — see git history for the failing version
+    ///    of this function) makes the GPU actually dispatch with a
+    ///    **real** local workgroup size of 1×1×1 (from the
+    ///    LocalSizeId-bound instruction's default of 1) while every read
+    ///    of `BLOCK_SIZE` *inside* the shader body still evaluates to 64
+    ///    (its own separate default) — so `loadstride_a`/`loadstride_b`
+    ///    (`gl_WorkGroupSize.x * ... / BK`, mul_mm.comp lines 201-202)
+    ///    compute as `1 * 2 / 32 = 0` (integer division), and the
+    ///    shared-memory load loop (`for (uint l = 0; l < BM; l +=
+    ///    loadstride_a)`) never advances — an infinite GPU loop, observed
+    ///    directly as `wait_for_fences` returning `ERROR_DEVICE_LOST` (a
+    ///    GPU/driver TDR-style reset) on every dispatch, reproducing even
+    ///    at the smallest possible single-tile shape (M=N=64, K=32) — not
+    ///    a shape-dependent edge case.
+    ///
+    /// 2. **Even fixed, `BLOCK_SIZE=64` (this shader's own literal
+    ///    default) is internally inconsistent with its other defaults.**
+    ///    The non-coopmat store/compute path assigns each warp a fixed
+    ///    `(warp_r, warp_c) = (warp_i % (BM/WM), warp_i / (BM/WM))` tile
+    ///    of the output, which only covers the *entire* `BM x BN` tile
+    ///    without gaps or overlap if `NUM_WARPS == (BM/WM) * (BN/WN)`
+    ///    exactly. With this shader's own literal defaults
+    ///    (`BM=BN=64`, `WM=WN=32` → `(BM/WM)*(BN/WN) = 2*2 = 4`) that
+    ///    requires `NUM_WARPS = 4`, i.e. `BLOCK_SIZE = 4 * WARP = 128` —
+    ///    but the shader's own literal `BLOCK_SIZE` default is 64
+    ///    (`NUM_WARPS = 64/32 = 2`), so `warp_c` (`warp_i / (BM/WM)`)
+    ///    can only ever evaluate to 0, never 1: half of every `BN`-wide
+    ///    output tile (`warp_c=1`'s columns) is never written by any
+    ///    thread at all. Verified directly: with `BLOCK_SIZE=64`, every
+    ///    output row at `T >= BN/2` (i.e. the un-covered half of the
+    ///    *first* `BN`-tile) came back as exactly 0 (the host-coherent
+    ///    output buffer's untouched initial contents), while covered
+    ///    elements matched `model::cpu_matmul` exactly — a silent,
+    ///    shape-independent correctness bug, not a crash, and so
+    ///    considerably more dangerous than bug #1 above. `BLOCK_SIZE=128`
+    ///    (used below) makes `NUM_WARPS=4` match `(BM/WM)*(BN/WN)=4`
+    ///    exactly, and also keeps `WARP == (WSUBM/TM)*(WSUBN/TN)`
+    ///    (`WSUBM=WM/WMITER=16`, `WSUBN=WN/WNITER=16`,
+    ///    `(16/TM=4)*(16/TN=2) = 4*8 = 32 = WARP`) — every per-thread
+    ///    tiling equation in this shader satisfied simultaneously, not
+    ///    just the ones needed to avoid a hang.
+    ///
+    /// The remaining constant IDs (BM/BN/WM/WN/WMITER/TM/TN/TK/WARP) are
+    /// pinned explicitly here too, rather than left to each shader's own
+    /// embedded default, as cheap insurance against a future glslang
+    /// version silently changing an embedded default out from under this
+    /// shader's now-verified dispatch math.
+    pub fn compile_matmul(&mut self, name: &str, spv: &[u8]) -> Result<(), String> {
+        self.compile_one_with_spec(name, spv, &[
+            (0, 128), // BLOCK_SIZE (also drives LocalSizeId — see doc comment above)
+            (1, 64),  // BM
+            (2, 64),  // BN
+            (4, 32),  // WM
+            (5, 32),  // WN
+            (6, 2),   // WMITER
+            (7, 4),   // TM
+            (8, 2),   // TN
+            (9, 1),   // TK (coopmat-only; inert for the non-coopmat variants compiled here)
+            (10, 32), // WARP
+        ])
     }
 
     /// Compile rms_norm variants: plain (do_multiply=false) and weight-multiplying

--- a/tests/python/test_vulkan_ops.py
+++ b/tests/python/test_vulkan_ops.py
@@ -791,6 +791,128 @@ class TestLinearMatvecDispatchThreshold:
         )
 
 
+class TestLinearTiledMatmulPrefillDispatch:
+    """`linear()` now dispatches the tiled matmul shader (`matmul_f32_f32`,
+    from shaders/mul_mm.comp — see `_vulkan_matmul`) for prefill-scale T
+    on large-enough weights, instead of always falling back to CPU — see
+    `_MATVEC_THRESHOLD`'s doc comment in vulkan_ops.py for the
+    measurements this is based on (GPU wins at every T from 4 up, unlike
+    the matvec case `TestLinearMatvecDispatchThreshold` above guards
+    against reusing at prefill scale).
+    """
+
+    def test_large_weight_matches_torch_reference_at_prefill_shapes(self, vulkan_ctx):
+        """Correctness at Gemma4-E2B's real q_proj shape, across several
+        representative prefill chunk sizes — including T=4 (right at
+        `_MATVEC_THRESHOLD`'s boundary) and shapes that straddle this
+        shader's BM=BN=64/BK=32 tile boundaries (T=63, not a multiple of
+        64)."""
+        out_features, in_features = 2048, 1536
+        weight = torch.randn(out_features, in_features, dtype=torch.float32)
+        for t in (4, 16, 63, 128, 512):
+            x = torch.randn(t, in_features, dtype=torch.float32)
+            result = vulkan_ops.linear(x, weight, None)
+            expected = torch.nn.functional.linear(x, weight, None)
+            torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-2)
+
+    def test_large_weight_prefill_uses_gpu_weight_cache_not_cpu_path(
+        self, vulkan_ctx, upload_counter
+    ):
+        """A weight at or above `_MATVEC_MIN_WEIGHT_ELEMENTS` at
+        prefill-scale T (128, well above `_MATVEC_THRESHOLD`) must take
+        the GPU tiled-matmul path (`_vulkan_matmul`, sharing
+        `_get_or_upload_weight`'s cache with the decode matvec path) —
+        not silently keep falling back to
+        `_get_or_convert_to_float32_cpu`."""
+        out_features, in_features = 2048, 1536
+        weight = torch.randn(out_features, in_features, dtype=torch.bfloat16)
+        x = torch.randn(128, in_features, dtype=torch.float32)
+
+        vulkan_ops.linear(x, weight, None)
+        assert vulkan_ops._weight_cache.get(weight) is not None, (
+            "a large weight at prefill-scale T must use the GPU tiled-matmul "
+            "path's weight cache"
+        )
+        assert upload_counter["n"] == 1
+        assert vulkan_ops._cpu_float32_cache.get(weight) is None, (
+            "the CPU float32 conversion cache must NOT be populated when the "
+            "GPU tiled-matmul path is taken"
+        )
+
+    def test_small_weight_still_uses_cpu_at_prefill_scale(
+        self, vulkan_ctx, upload_counter
+    ):
+        """A weight below `_MATVEC_MIN_WEIGHT_ELEMENTS` (k_proj/v_proj's
+        real shape) must still take the CPU path at prefill-scale T,
+        exactly as it already does at decode-scale T (see
+        `TestLinearMatvecDispatchThreshold.
+        test_small_weight_uses_cpu_path_not_gpu_weight_cache`) — the
+        tiled-matmul dispatch decision reuses the same size gate, not a
+        separate one, per `_MATVEC_THRESHOLD`'s doc comment."""
+        out_features, in_features = 256, 1536
+        weight = torch.randn(out_features, in_features, dtype=torch.bfloat16)
+        x = torch.randn(128, in_features, dtype=torch.float32)
+
+        vulkan_ops.linear(x, weight, None)
+        assert vulkan_ops._weight_cache.get(weight) is None, (
+            "a small weight (below _MATVEC_MIN_WEIGHT_ELEMENTS) must never "
+            "reach the GPU weight cache, even at prefill-scale T"
+        )
+        assert upload_counter["n"] == 1
+
+    def test_tiled_matmul_is_faster_than_cpu_at_prefill_scale(self, vulkan_ctx):
+        """Measures the actual speedup at Gemma4-E2B's real q_proj shape
+        (2048x1536) and T=128 (a representative prefill chunk size) —
+        the mirror image of
+        `TestLinearMatvecDispatchThreshold.test_matvec_batching_does_not_help_at_prefill_scale_t`
+        above: unlike matvec, the tiled matmul shader genuinely reuses
+        weight tiles across T, so GPU must win here, not lose. Uses this
+        file's own min-of-N-trials pattern (see that test's doc comment
+        for why it's safe here too: the underlying effect, measured
+        independently in src/lib.rs's `tiled_matmul_beats_cpu_at_prefill_scale_for_large_weights`,
+        is 1.5x-17x across shapes and T, far larger than plausible
+        measurement noise).
+        """
+        import time
+
+        out_features, in_features = 2048, 1536
+        weight = torch.randn(out_features, in_features, dtype=torch.float32)
+        t_prefill = 128
+        x = torch.randn(t_prefill, in_features, dtype=torch.float32)
+
+        for _ in range(3):
+            vulkan_ops._vulkan_matmul(vulkan_ctx, x, weight)
+            torch.nn.functional.linear(x, weight, None)
+
+        iters = 10
+        trials = 3
+
+        def timed(fn) -> float:
+            best = float("inf")
+            for _ in range(trials):
+                t0 = time.perf_counter()
+                for _ in range(iters):
+                    fn()
+                best = min(best, time.perf_counter() - t0)
+            return best
+
+        gpu_elapsed = timed(lambda: vulkan_ops._vulkan_matmul(vulkan_ctx, x, weight))
+        cpu_elapsed = timed(lambda: torch.nn.functional.linear(x, weight, None))
+
+        print(
+            f"\ntiled matmul at prefill scale (T={t_prefill}, 2048x1536), "
+            f"best-of-{trials}: GPU matmul {gpu_elapsed / iters * 1e6:.1f}us/call, "
+            f"CPU linear {cpu_elapsed / iters * 1e6:.1f}us/call, "
+            f"GPU speedup {cpu_elapsed / gpu_elapsed:.2f}x"
+        )
+        assert gpu_elapsed < cpu_elapsed, (
+            f"GPU tiled matmul ({gpu_elapsed:.4f}s/{iters}) was not faster than "
+            f"CPU ({cpu_elapsed:.4f}s/{iters}) at prefill-scale T={t_prefill} - "
+            f"see _MATVEC_THRESHOLD's doc comment before changing this dispatch "
+            f"decision based on this alone."
+        )
+
+
 class TestWrapRmsNormHoistsStaticLookups:
     """`_wrap_rms_norm` now captures `weight`/`eps`/the disable-ops env
     var once, at hook-install time, instead of re-deriving them (via

--- a/vllm_vulkan/vulkan_ops.py
+++ b/vllm_vulkan/vulkan_ops.py
@@ -313,9 +313,69 @@ def _matvec_pc(T: int, K: int, N: int) -> bytes:  # noqa: N803
     )
 
 
+@lru_cache(maxsize=256)
+def _matmul_pc(m: int, t: int, k: int) -> bytes:  # noqa: N803
+    """Pack push constants for the tiled-matmul shaders (`matmul_f32_f32`
+    et al, from shaders/mul_mm.comp) — 16 uint32 fields, exactly matching
+    that shader's own `push_constant` block (mul_mm.comp:74-101), NOT
+    llama.cpp upstream's newer 17-field struct (see the `padded_N` note
+    at this shader's registration site in src/lib.rs). Verified against
+    a direct CPU reference before use — see `tiled_matmul_dispatch_tests`
+    in src/lib.rs.
+
+    For a single, unbatched Linear call computing
+    `out[T, out_features] = x[T, in_features] @ weight[out_features,
+    in_features]^T`: `m`=out_features (weight's row count), `t`=T
+    (activation row count), `k`=in_features (shared dimension). Both
+    `weight` and `x` must be row-major-contiguous with row stride
+    exactly `k` — true for any freshly-`.contiguous()`'d/uploaded
+    tensor, which `_to_bytes`/`_get_or_upload_weight` already guarantee.
+
+    `@lru_cache`d for the same reason as `_matvec_pc` above: a pure
+    function of (m, t, k), and while T varies per prefill call (unlike
+    decode's always-T=1), the number of *distinct* (m, t, k) triples in
+    any real chunked-prefill workload is still small and bounded (a
+    handful of Linear-module shapes x a handful of chunk sizes), so this
+    still avoids repeating the same `struct.pack` work across identical
+    calls.
+    """
+    return struct.pack(
+        "16I",
+        m,
+        t,
+        k,  # M, N, K
+        k,
+        k,
+        m,  # stride_a, stride_b, stride_d
+        m * k,
+        k * t,
+        m * t,  # batch_stride_a, batch_stride_b, batch_stride_d
+        0,  # base_work_group_z
+        1,  # num_batches
+        k,  # k_split = K (skip the multi-pass K-split reduce path — see
+        # `compile_matmul`'s doc comment in src/pipeline.rs for why this
+        # is always safe for realistic transformer K)
+        1,
+        1,
+        1,
+        1,  # ne02, ne12, broadcast2, broadcast3
+    )
+
+
+def _matmul_workgroups(m: int, t: int) -> tuple[int, int, int]:
+    """Workgroup dispatch count for the tiled-matmul shaders:
+    `(ceil(M/BM), ceil(N/BN), num_batches)`, using the BM=BN=64 these
+    shaders are actually compiled with (`compile_matmul` in
+    src/pipeline.rs — NOT llama.cpp's own named "l"/"m"/"s" tiling
+    presets, a different, unused-here parameter set).
+    """
+    bm = bn = 64
+    return ((m + bm - 1) // bm, (t + bn - 1) // bn, 1)
+
+
 # ─── RMS Norm ────────────────────────────────────────────────────────────────
 
-_MATVEC_THRESHOLD = 4  # T < this → matvec shader; T >= this → CPU
+_MATVEC_THRESHOLD = 4  # T < this → matvec shader; T >= this → tiled matmul/CPU
 # Weight matrices with fewer than this many elements (in_features *
 # out_features) always use the CPU path, regardless of T — see
 # `linear`'s doc comment for the measurement behind this cutoff.
@@ -350,19 +410,43 @@ _MATVEC_MIN_WEIGHT_ELEMENTS = 1_000_000
 # scales as O(T x in_features x out_features) — the same order as CPU's
 # cost, with none of a real tiled matmul's weight-tile-reuse advantage,
 # so GPU just pays that cost at a *worse* effective rate than CPU's own
-# BLAS routines here.
+# BLAS routines here. `linear()` therefore never raises this threshold
+# for matvec — see `test_matvec_batching_does_not_help_at_prefill_scale_t`
+# (tests/python/test_vulkan_ops.py) for the regression guard.
 #
-# A real prefill speedup would need the tiled matmul shaders this
-# backend already compiles but has never dispatched anywhere
-# (`matmul_f32_f16`/`matmul_f32_f16_aligned`/`matmul_f32_f32_fp32`/
-# `matmul_f16_f32_fp32`, from shaders/mul_mm.comp — a llama.cpp-derived
-# kernel with its own BM/BN/WM/WN/WMITER/TM/TN/TK/WARP specialization-
-# constant tiling scheme, substantial push-constant surface, and no
-# prior working example anywhere in this codebase's history to build
-# from) - a real, valuable, but substantially larger undertaking than
-# this threshold, deferred rather than attempted piecemeal. See
-# `test_matvec_batching_does_not_help_at_prefill_scale_t` (tests/python/
-# test_vulkan_ops.py) for the regression guard backing the numbers above.
+# The REAL prefill speedup this analysis pointed to — the tiled matmul
+# shaders (`matmul_f32_f16`/`matmul_f32_f16_aligned`/`matmul_f32_f32`/
+# `matmul_f32_f32_fp32`/`matmul_f16_f32_fp32`, from shaders/mul_mm.comp)
+# — is now wired up (`_vulkan_matmul` below), after two real Vulkan
+# pipeline-compilation bugs blocking it were found and fixed (see
+# `pipeline::PipelineCache::compile_matmul`'s doc comment in
+# src/pipeline.rs: an infinite-GPU-loop hang, then a silent half-tile-
+# of-zeros correctness bug — both invisible until this shader was
+# actually dispatched and checked against a direct CPU reference, not
+# just read). Unlike matvec, the tiled matmul shader genuinely reuses
+# weight tiles across the T dimension the way a real GEMM should, so it
+# *wins* at prefill scale, and the margin widens with T instead of
+# narrowing — measured directly at the same q_proj shape as the table
+# above (`matmul_f32_f32`, best-of-N trials):
+#
+#   T      CPU (torch.nn.functional.linear)   GPU (matmul_f32_f32)
+#   4        790.6us  (197.65us/token)           475.4us  (118.85us/token)
+#  16       1137.5us   (71.09us/token)           466.7us   (29.17us/token)
+#  64       3499.6us   (54.68us/token)          1090.8us   (17.04us/token)
+# 128       6540.5us   (51.10us/token)          1396.6us   (10.91us/token)
+# 512      24631.8us   (48.11us/token)          2088.9us    (4.08us/token)
+#
+# GPU is faster at every T tested (1.66x-11.79x here; 1.4x-17.3x across
+# all 3 real large-weight Linear shapes measured — see
+# `tiled_matmul_beats_cpu_at_prefill_scale_for_large_weights` in
+# src/lib.rs). For the *small*-weight case (k_proj/v_proj,
+# `< _MATVEC_MIN_WEIGHT_ELEMENTS`, same gate `_vulkan_matmul` uses), GPU
+# only pulls ahead once T is much larger than typical (measured
+# crossover between T=64 and T=128 — see
+# `tiled_matmul_small_weight_crossover_point`), so `linear()`
+# deliberately keeps that shape on the CPU-only path at every T, exactly
+# mirroring the decode matvec threshold's existing size gate rather than
+# adding a second, narrower one.
 
 
 def rms_norm(
@@ -417,16 +501,17 @@ def linear(
     weight: torch.Tensor,
     bias: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Linear layer: decode path uses Vulkan matvec (for large-enough
-    weights), prefill uses CPU.
+    """Linear layer: decode uses Vulkan matvec, prefill uses Vulkan tiled
+    matmul — both only for large-enough weights; small weights always use
+    CPU.
 
-    `_MATVEC_THRESHOLD` alone (T < 4 → GPU) isn't the whole story: the
-    right dispatch decision also depends on the weight matrix's total
-    size (`in_features * out_features`), not just `T`. Measured directly
-    on this hardware at Gemma4-E2B's real Linear-module shapes: for
-    `k_proj`/`v_proj` (small, since `num_key_value_heads=1` gives an
-    `out_features` of only 256/512) the CPU path is faster at *every* T
-    tested (1, 2, 4, 8) — including the all-important T=1 decode case,
+    `_MATVEC_THRESHOLD` alone (T < 4 → decode GPU path) isn't the whole
+    story: the right dispatch decision also depends on the weight
+    matrix's total size (`in_features * out_features`), not just `T`.
+    Measured directly on this hardware at Gemma4-E2B's real Linear-module
+    shapes: for `k_proj`/`v_proj` (small, since `num_key_value_heads=1`
+    gives an `out_features` of only 256/512) the CPU path is faster at
+    *every* T tested — including the all-important T=1 decode case,
     where GPU dispatch measured ~1.1-2.0x *slower* than CPU there (e.g.
     ~164-209us GPU vs ~81-187us CPU) — while for `q_proj`/`o_proj`/
     `gate_proj`/`up_proj`/`down_proj` (all >=3.15M elements), GPU
@@ -436,7 +521,11 @@ def linear(
     (512*1536 = 0.79M, CPU-favoring even at T=1) and the smallest
     measured large-weight case (2048*1536 = 3.15M, GPU-favoring at
     T=1-2) — comfortably clear of either boundary rather than sitting
-    right at a fragile crossover point.
+    right at a fragile crossover point. The same size gate is reused for
+    the T>=_MATVEC_THRESHOLD (prefill) tiled-matmul path below — see
+    `_MATVEC_THRESHOLD`'s doc comment for the prefill-scale measurements
+    justifying that reuse rather than a second, separately-tuned
+    threshold.
 
     See `TestLinearMatvecDispatchThreshold` (tests/python/test_vulkan_ops.py)
     for the measurements this doc comment summarizes.
@@ -450,12 +539,19 @@ def linear(
     T = x_2d.shape[0]  # noqa: N806
 
     weight_elements = in_feat * out_feat
+    available_shaders = _cached_available_shaders(ctx)
     if (
         weight_elements >= _MATVEC_MIN_WEIGHT_ELEMENTS
         and T < _MATVEC_THRESHOLD
-        and "mul_mat_vec_f32_f32_f32" in _cached_available_shaders(ctx)
+        and "mul_mat_vec_f32_f32_f32" in available_shaders
     ):
         result = _vulkan_matvec(ctx, x_2d, weight)
+    elif (
+        weight_elements >= _MATVEC_MIN_WEIGHT_ELEMENTS
+        and T >= _MATVEC_THRESHOLD
+        and "matmul_f32_f32" in available_shaders
+    ):
+        result = _vulkan_matmul(ctx, x_2d, weight)
     else:
         result = torch.nn.functional.linear(
             x_2d, _get_or_convert_to_float32_cpu(weight)
@@ -514,6 +610,55 @@ def _vulkan_matvec(
     return _from_bytes(results[0][0], (T, N), torch.float32)
 
 
+def _vulkan_matmul(
+    ctx: VulkanContext,
+    x: torch.Tensor,  # [T, K] float32
+    weight: torch.Tensor,  # [M, K] any dtype
+) -> torch.Tensor:
+    """Dispatch `matmul_f32_f32` (the tiled matmul shader, mul_mm.comp)
+    for prefill (T >= _MATVEC_THRESHOLD, large-enough weight — see
+    `linear`'s dispatch decision).
+
+    Only the plain (non-`_aligned`) variant is dispatched: the
+    `_aligned` variants assume `K` is already a multiple of the tile
+    size and skip bounds-checking loads, silently producing wrong
+    results otherwise. `matmul_f32_f32` handles any `M`/`T`/`K` shape
+    safely — verified directly, including shapes deliberately NOT
+    aligned to this shader's BM=BN=64/BK=32 tile sizes, against a CPU
+    reference (see `tiled_matmul_dispatch_tests` in src/lib.rs) — so no
+    alignment check is needed here.
+
+    Shares `_get_or_upload_weight`'s GPU weight cache with
+    `_vulkan_matvec`: both shaders require the exact same buffer layout
+    (row-major `[out_features, in_features]`, `f32`), so the same
+    persistent upload serves either dispatch path for a given weight,
+    whichever T a given call happens to use.
+    """
+    w_gpu = _get_or_upload_weight(ctx, weight)
+
+    T, K = x.shape  # noqa: N806
+    M = weight.shape[0]  # noqa: N806
+    pc = _matmul_pc(M, T, K)
+    x_bytes = _to_bytes(x)
+    out_size = T * M * 4
+
+    w_binding = w_gpu if w_gpu is not None else _to_bytes(weight.float())
+
+    results = ctx.execute_batch(
+        [
+            (
+                "matmul_f32_f32",
+                [w_binding, x_bytes],
+                [out_size],
+                pc,
+                _matmul_workgroups(M, T),
+                False,
+            ),
+        ]
+    )
+    return _from_bytes(results[0][0], (T, M), torch.float32)
+
+
 # ─── Fused RMSNorm + Linear batch dispatch ───────────────────────────────────
 
 
@@ -543,7 +688,17 @@ def rms_norm_then_linear(
     in_feat = linear_weight.shape[1]
     out_feat = linear_weight.shape[0]
 
-    # Decode path only (T < threshold); prefill falls back to CPU for linear.
+    # Fused single-submit path only for decode (T < threshold); prefill
+    # falls back to separate rms_norm() + linear() calls — rms_norm()
+    # always runs on CPU (see its own doc comment) and linear() now
+    # dispatches the GPU tiled matmul for large-enough weights at
+    # prefill scale too (see `_vulkan_matmul`), so this fallback is not
+    # a full CPU path, just an un-fused one (2 Python-level calls instead
+    # of 1 chained GPU submit — fusing RMSNorm into the same submit as
+    # `_vulkan_matmul` is a possible future improvement, not attempted
+    # here: rms_norm() itself is CPU-only regardless, so there is no GPU
+    # intermediate buffer to keep on-device between the two steps the
+    # way there is for the decode matvec case below).
     available_shaders = _cached_available_shaders(ctx)
     if (
         T >= _MATVEC_THRESHOLD


### PR DESCRIPTION
`linear()`'s prefill path (T >= _MATVEC_THRESHOLD, large-enough weights)
always fell back to CPU (`torch.nn.functional.linear`) — #80 measured
that naively raising the decode matvec shader's threshold to also cover
prefill is a proven ~6.5x regression (mul_mat_vec re-reads the whole
weight matrix per token, with none of a real GEMM's weight-tile reuse),
and #81 researched but did not implement the actual fix: dispatching
this backend's tiled matmul shaders (`matmul_f32_f16`/
`matmul_f32_f16_aligned`/`matmul_f32_f32`/`matmul_f32_f32_fp32`/
`matmul_f16_f32_fp32`, from shaders/mul_mm.comp — a llama.cpp-derived
kernel compiled since this backend's earliest history but never
dispatched anywhere in Rust or Python).

This implements that dispatch, following the same discipline #81 laid
out (research the binding/push-constant/workgroup spec, then verify
directly against a CPU reference before trusting it — the lesson from
`mul_mat_vec_f32_f32_f32_subgroup`'s silent-wrong-output bug, #57).
Doing so surfaced two real, independent Vulkan pipeline bugs that would
otherwise have made this shader unusable or silently wrong:

1. `mul_mm.comp` declares `layout(local_size_x_id = 0)` — its workgroup
   size is itself a specialization constant tied to `BLOCK_SIZE`.
   Disassembling the compiled SPIR-V shows glslang emits *two* separate
   `OpSpecConstant`s decorated with the same `SpecId 0`: one feeding
   `OpExecutionModeId ... LocalSizeId` with embedded default literal 1,
   and a separate one (used by the shader body's own `BLOCK_SIZE`
   reads) with embedded default 64. Compiling this shader the same way
   every other unspecialized shader in this codebase is compiled
   (`compile_one`, no specialization info) leaves those two disagreeing
   defaults in place: the GPU actually dispatches with a real local
   workgroup size of 1, while the shader body still assumes 64, so
   `loadstride_a`/`loadstride_b` (`gl_WorkGroupSize.x * ... / BK`)
   compute as `1 * 2 / 32 = 0` and the shared-memory load loop never
   advances — an infinite GPU loop, observed directly as
   `wait_for_fences` returning `ERROR_DEVICE_LOST`, reproducing even at
   the smallest possible single-tile shape.

2. Once fixed, `BLOCK_SIZE=64` (this shader's own literal default) is
   itself internally inconsistent with its other tiling defaults: the
   non-coopmat store path requires `NUM_WARPS == (BM/WM)*(BN/WN)` for
   full tile coverage, which with `BM=BN=64`/`WM=WN=32` needs 4 warps
   (`BLOCK_SIZE=128`), not the 2 warps `BLOCK_SIZE=64` gives — so
   `warp_c` can only ever be 0, and half of every output tile's columns
   are silently never written by any thread (came back as the output
   buffer's untouched zero-initial contents, not a crash). Both bugs
   are fixed together in `PipelineCache::compile_matmul` (src/pipeline.rs),
   which now compiles these 5 shaders with every specialization constant
   pinned explicitly instead of left to (sometimes wrong) embedded
   defaults.

Correctness verified directly against `model::cpu_matmul` (the same
`matrixmultiply::sgemm` wrapper already used for every other CPU-path
matmul in this file) at Gemma4-E2B's real prefill shapes plus several
shapes deliberately not aligned to this shader's BM=BN=64/BK=32 tiles
(`tiled_matmul_dispatch_tests` in src/lib.rs) — max abs error <=
0.000435 across all shapes tested, several orders of magnitude below
the 1e-2 threshold used elsewhere in this file for the same kind of
comparison.

Performance measured (best-of-N trials) at all 3 of Gemma4-E2B's real
large-weight Linear shapes across the prefill T range this changes:

  q_proj (2048x1536):        1.66x-11.79x GPU speedup, T=4..512
  gate/up_proj (6144x1536):  4.09x-15.44x GPU speedup, T=4..512
  down_proj (1536x6144):     1.40x-13.41x GPU speedup, T=4..512

unlike the matvec case, the margin widens with T instead of narrowing,
confirming the tiled matmul's weight-tile reuse is doing its job. For
the small-weight case (k_proj/v_proj, below `_MATVEC_MIN_WEIGHT_ELEMENTS`
— the same size gate already used for the decode matvec dispatch
decision, reused here rather than adding a second, narrower threshold),
GPU only pulls ahead once T is much larger than typical (measured
crossover between T=64 and T=128), so `linear()` deliberately keeps that
shape on CPU at every T.

`linear()` now dispatches `_vulkan_matmul` (new, mirrors `_vulkan_matvec`
and shares its `_get_or_upload_weight` GPU weight cache — both shaders
require the identical row-major `[out_features, in_features]` f32
buffer layout) whenever `weight_elements >= _MATVEC_MIN_WEIGHT_ELEMENTS
and T >= _MATVEC_THRESHOLD`, instead of always falling back to CPU.
Only the plain (non-`_aligned`) shader variant is dispatched, since it
handles any M/T/K shape safely (verified above) without requiring a
per-call alignment check.

Verified: 44/44 Rust tests pass (`cargo test --release`, including the
9 new tests in `tiled_matmul_dispatch_tests`); clippy warnings unchanged
at 44 (identical before/after — confirmed by diffing counts against
this same tree with the change stashed out). 119/125 Python tests pass
(`pytest -m "not slow" tests/python/`, including 4 new tests in
`TestLinearTiledMatmulPrefillDispatch`); the 6 failures are pre-existing
and unrelated — confirmed identical on this same tree with the change
stashed out: 5 are `test_attention_backend.py` failures from a
`torch.ops._C.cpu_attn_reshape_and_cache` `AttributeError` (an installed
vllm/torch native-op mismatch in this environment, nothing to do with
Vulkan dispatch), and 1 is `TestLinearMatvecDispatchThreshold.
test_small_weight_cpu_path_is_faster_than_gpu_dispatch_at_decode_shape`,
a pre-existing timing-based flake unrelated to this change (decode
matvec path, not touched here) that also fails on unmodified `master`.
`ruff check`/`ruff format --check`/`mypy vllm_vulkan` all pass on the
changed Python files.