### PR TITLE
perf: upload matvec/matmul weights as f16 to halve GPU weight bandwidth

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5274,3 +5274,294 @@ mod tiled_matmul_dispatch_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod f16_weight_dispatch_tests {
+    //! First real dispatch of the f16-weight variants of both the
+    //! decode GEMV shader (`mul_mat_vec_f16_f32_f32`) and the prefill
+    //! GEMM shader (`matmul_f16_f32_fp32`) from `vulkan_ops.py`'s
+    //! `_vulkan_matvec`/`_vulkan_matmul` — both compiled by this backend
+    //! since its earliest history (scripts/compile_shaders.sh) and
+    //! already dispatched (and verified correct) from the *separate*
+    //! standalone Rust `VulkanModel` path (`VulkanModel::new`'s "Projection
+    //! weights are uploaded as f16 to halve memory bandwidth"), but never
+    //! wired up on the `VulkanContext`-based path `vulkan_ops.py` actually
+    //! uses to accelerate an arbitrary vLLM model's `nn.Linear` layers —
+    //! the same "compiled but never dispatched" gap #82 found and fixed
+    //! for the plain f32 tiled matmul shader.
+    //!
+    //! Following this codebase's established discipline for any shader
+    //! newly wired up to a real dispatch path (see
+    //! `subgroup_matvec_correctness_tests`'s doc comment on the bug this
+    //! discipline exists to catch, and `tiled_matmul_dispatch_tests` for
+    //! the most recent application of it): correctness against a CPU
+    //! reference comes first. The CPU reference here is computed from
+    //! the weight values ALREADY ROUNDED THROUGH f16 (`half::f16::
+    //! from_f32(v).to_f32()`) rather than the original f32 values — this
+    //! isolates whether the shader's own dispatch/binding/compute math is
+    //! correct from the *expected*, inherent precision loss of storing
+    //! the weight as f16 at all (a separate, already-accepted trade-off
+    //! `vulkan_ops._weight_safe_for_f16`'s overflow guard exists for, not
+    //! a shader correctness question).
+    use super::*;
+
+    fn fake_random(len: usize, seed: u64) -> Vec<f32> {
+        let mut state = seed.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(1);
+        (0..len)
+            .map(|_| {
+                state ^= state >> 12; state ^= state << 25; state ^= state >> 27;
+                let bits = state.wrapping_mul(0x2545F4914F6CDD1D);
+                ((bits >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0
+            })
+            .collect()
+    }
+
+    /// Rounds every element through f16 first, matching the precision
+    /// the f16-weight shaders actually read from their buffer — see
+    /// this module's doc comment for why.
+    fn round_through_f16(data: &[f32]) -> Vec<f32> {
+        data.iter().map(|&v| half::f16::from_f32(v).to_f32()).collect()
+    }
+
+    fn make_engine() -> Option<compute::ComputeEngine> {
+        let dev = match device::ComputeDevice::create(0) {
+            Ok(d) => d,
+            Err(e) => { eprintln!("skip: no Vulkan device available ({e})"); return None; }
+        };
+        let shader_spvs = include_all_shaders();
+        let refs: std::collections::HashMap<&str, &[u8]> = shader_spvs.iter()
+            .map(|(k, v)| (k.as_str(), v.as_slice())).collect();
+        Some(compute::ComputeEngine::new(
+            dev.instance.clone(), dev.physical_device, dev.device.clone(),
+            dev.compute_queue, dev.compute_queue_family, &refs,
+        ).expect("create ComputeEngine"))
+    }
+
+    #[test]
+    fn mul_mat_vec_f16_f32_f32_matches_cpu_reference_at_realistic_k() {
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        let n = 4usize;
+        let t = 1usize;
+        for &k in &[16usize, 64, 256, 512, 1536, 6144] {
+            let weight_f32 = fake_random(n * k, 1);
+            let weight_rounded = round_through_f16(&weight_f32);
+            let x = fake_random(t * k, 2);
+            let mut cpu_ref = vec![0.0f32; t * n];
+            for ni in 0..n {
+                let wr = &weight_rounded[ni * k..(ni + 1) * k];
+                cpu_ref[ni] = wr.iter().zip(x.iter()).map(|(&w, &v)| w * v).sum::<f32>();
+            }
+
+            let weight_f16_bytes = f32_to_f16_bytes(&weight_f32);
+            let wbuf = engine.alloc_host_coherent_storage(weight_f16_bytes.len() as u64).unwrap();
+            wbuf.write(&weight_f16_bytes).unwrap();
+            let xbuf = engine.alloc_host_coherent_storage((x.len() * 4) as u64).unwrap();
+            xbuf.write(bytemuck::cast_slice(&x)).unwrap();
+            let out = engine.alloc_host_coherent_storage((t * n * 4) as u64).unwrap();
+            let pc = mv_pc(k, n, t);
+
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "mul_mat_vec_f16_f32_f32", &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, t as u32, 1)).unwrap();
+            engine.submit_batch(cb).unwrap();
+            let r = read_f32_buf(&out, t * n);
+            let err = r.iter().zip(cpu_ref.iter()).map(|(&a, &b)| (a - b).abs()).fold(0.0f32, f32::max);
+            assert!(err < 1e-2, "k={k}: mul_mat_vec_f16_f32_f32 diverged from f16-rounded CPU reference: {err}");
+        }
+    }
+
+    /// Push constants for `matmul_f16_f32_fp32` — identical layout to
+    /// `tiled_matmul_dispatch_tests::mm_pc` (this shader's push_constant
+    /// block, mul_mm.comp:74-101, carries no dtype-dependent fields: all
+    /// strides are element counts into whichever `A_TYPE`/`B_TYPE` the
+    /// pipeline was compiled with, not byte offsets — see
+    /// `vulkan_ops._matmul_pc`'s doc comment for the same point made on
+    /// the Python side). Duplicated here (rather than sharing
+    /// `tiled_matmul_dispatch_tests::mm_pc`, a private fn in a sibling
+    /// `#[cfg(test)] mod`) to keep this module independently readable.
+    fn mm_pc(m: usize, n: usize, k: usize) -> [u32; 16] {
+        [
+            m as u32, n as u32, k as u32,
+            k as u32, k as u32, m as u32,
+            (m * k) as u32, (k * n) as u32, (m * n) as u32,
+            0, 1, k as u32,
+            1, 1, 1, 1,
+        ]
+    }
+
+    fn mm_workgroups(m: usize, n: usize) -> (u32, u32, u32) {
+        const BM: usize = 64;
+        const BN: usize = 64;
+        (m.div_ceil(BM) as u32, n.div_ceil(BN) as u32, 1)
+    }
+
+    #[test]
+    fn matmul_f16_f32_fp32_matches_cpu_reference_at_realistic_and_boundary_shapes() {
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        // Same shape set as
+        // tiled_matmul_dispatch_tests::matmul_f32_f32_matches_cpu_reference_at_realistic_and_boundary_shapes:
+        // Gemma4-E2B's 3 real prefill shapes plus deliberately
+        // non-tile-aligned shapes exercising this (non-`_aligned`)
+        // variant's boundary-check loads.
+        let shapes = [
+            (2048usize, 128usize, 1536usize),
+            (6144, 128, 1536),
+            (1536, 128, 6144),
+            (65, 63, 33),
+            (16, 7, 5),
+            (127, 129, 96),
+            (64, 64, 64),
+        ];
+        for &(m, t, k) in &shapes {
+            let weight_f32 = fake_random(m * k, 1);
+            let weight_rounded = round_through_f16(&weight_f32);
+            let x = fake_random(t * k, 2);
+            let cpu_ref = model::cpu_matmul(&x, &weight_rounded, t, k, m);
+
+            let weight_f16_bytes = f32_to_f16_bytes(&weight_f32);
+            let wbuf = engine.alloc_host_coherent_storage(weight_f16_bytes.len() as u64).unwrap();
+            wbuf.write(&weight_f16_bytes).unwrap();
+            let xbuf = engine.alloc_host_coherent_storage((x.len() * 4) as u64).unwrap();
+            xbuf.write(bytemuck::cast_slice(&x)).unwrap();
+            let out = engine.alloc_host_coherent_storage((t * m * 4) as u64).unwrap();
+            let pc = mm_pc(m, t, k);
+            let wg = mm_workgroups(m, t);
+
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "matmul_f16_f32_fp32", &[&wbuf, &xbuf, &out], bytemuck::cast_slice(&pc), wg).unwrap();
+            engine.submit_batch(cb).unwrap();
+            let r = read_f32_buf(&out, t * m);
+
+            let err = r.iter().zip(cpu_ref.iter()).map(|(&a, &b)| (a - b).abs()).fold(0.0f32, f32::max);
+            println!("matmul_f16_f32_fp32 M={m} T={t} K={k}: max abs err vs f16-rounded CPU reference = {err:.6}");
+            assert!(
+                err < 1e-2,
+                "matmul_f16_f32_fp32 diverged from CPU reference at M={m} T={t} K={k}: max abs err {err}"
+            );
+        }
+    }
+
+    /// Companion measurement (not a hard assertion): relative GPU-buffer
+    /// dispatch time, f16-weight vs f32-weight, at Gemma4-E2B's real
+    /// q_proj decode/prefill shapes. NOT asserted `f16 < f32` here — the
+    /// bandwidth-reduction rationale (see this module's doc comment and
+    /// `vulkan_ops._get_or_upload_weight`'s) is a real, physical argument
+    /// about VRAM traffic on a discrete GPU, but the only Vulkan device
+    /// available to verify this specific change on is `llvmpipe` (a
+    /// software rasterizer backed by ordinary CPU memory, not a discrete
+    /// GPU's own VRAM/bus), which does not reliably model that argument —
+    /// exactly the same caveat `tiled_matmul_small_weight_crossover_point`
+    /// above already documents for a different measurement. Printed and
+    /// eyeballed so a real regression (e.g. a future change accidentally
+    /// making the f16 path pathologically slow) is still visible, without
+    /// hard-failing CI on a comparison this environment can't faithfully
+    /// make either way.
+    #[test]
+    fn f16_vs_f32_weight_relative_dispatch_time() {
+        let _guard = gpu_test_guard();
+        let Some(mut engine) = make_engine() else { return };
+
+        let (k, n) = (1536usize, 2048usize); // q_proj shape
+        let weight = fake_random(n * k, 1);
+        let x_decode = fake_random(k, 2); // T=1
+
+        let wbuf32 = engine.alloc_host_coherent_storage((weight.len() * 4) as u64).unwrap();
+        wbuf32.write(bytemuck::cast_slice(&weight)).unwrap();
+        let f16_bytes = f32_to_f16_bytes(&weight);
+        let wbuf16 = engine.alloc_host_coherent_storage(f16_bytes.len() as u64).unwrap();
+        wbuf16.write(&f16_bytes).unwrap();
+        let xbuf = engine.alloc_host_coherent_storage((x_decode.len() * 4) as u64).unwrap();
+        xbuf.write(bytemuck::cast_slice(&x_decode)).unwrap();
+        let out = engine.alloc_host_coherent_storage((n * 4) as u64).unwrap();
+        let pc = mv_pc(k, n, 1);
+
+        for _ in 0..3 {
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "mul_mat_vec_f32_f32_f32", &[&wbuf32, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, 1, 1)).unwrap();
+            engine.submit_batch(cb).unwrap();
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "mul_mat_vec_f16_f32_f32", &[&wbuf16, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, 1, 1)).unwrap();
+            engine.submit_batch(cb).unwrap();
+        }
+        let iters = 200;
+        let t0 = std::time::Instant::now();
+        for _ in 0..iters {
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "mul_mat_vec_f32_f32_f32", &[&wbuf32, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, 1, 1)).unwrap();
+            engine.submit_batch(cb).unwrap();
+        }
+        let f32_us = t0.elapsed().as_micros() as f64 / iters as f64;
+        let t0 = std::time::Instant::now();
+        for _ in 0..iters {
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "mul_mat_vec_f16_f32_f32", &[&wbuf16, &xbuf, &out], bytemuck::cast_slice(&pc), (n as u32, 1, 1)).unwrap();
+            engine.submit_batch(cb).unwrap();
+        }
+        let f16_us = t0.elapsed().as_micros() as f64 / iters as f64;
+        println!(
+            "matvec (decode, q_proj 2048x1536) f32-weight {f32_us:.1}us/call  \
+             f16-weight {f16_us:.1}us/call  ratio {:.2}x",
+            f32_us / f16_us
+        );
+
+        let (m, kk, tt) = (2048usize, 1536usize, 128usize); // q_proj prefill shape
+        let weight2 = fake_random(m * kk, 3);
+        let xx = fake_random(tt * kk, 4);
+        let wbuf32b = engine.alloc_host_coherent_storage((weight2.len() * 4) as u64).unwrap();
+        wbuf32b.write(bytemuck::cast_slice(&weight2)).unwrap();
+        let f16b = f32_to_f16_bytes(&weight2);
+        let wbuf16b = engine.alloc_host_coherent_storage(f16b.len() as u64).unwrap();
+        wbuf16b.write(&f16b).unwrap();
+        let xbuf2 = engine.alloc_host_coherent_storage((xx.len() * 4) as u64).unwrap();
+        xbuf2.write(bytemuck::cast_slice(&xx)).unwrap();
+        let out2 = engine.alloc_host_coherent_storage((tt * m * 4) as u64).unwrap();
+        let pc2 = mm_pc(m, tt, kk);
+        let wg = mm_workgroups(m, tt);
+
+        for _ in 0..3 {
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "matmul_f32_f32", &[&wbuf32b, &xbuf2, &out2], bytemuck::cast_slice(&pc2), wg).unwrap();
+            engine.submit_batch(cb).unwrap();
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "matmul_f16_f32_fp32", &[&wbuf16b, &xbuf2, &out2], bytemuck::cast_slice(&pc2), wg).unwrap();
+            engine.submit_batch(cb).unwrap();
+        }
+        let iters2 = 30;
+        let t0 = std::time::Instant::now();
+        for _ in 0..iters2 {
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "matmul_f32_f32", &[&wbuf32b, &xbuf2, &out2], bytemuck::cast_slice(&pc2), wg).unwrap();
+            engine.submit_batch(cb).unwrap();
+        }
+        let mm_f32_us = t0.elapsed().as_micros() as f64 / iters2 as f64;
+        let t0 = std::time::Instant::now();
+        for _ in 0..iters2 {
+            let cb = engine.begin_batch().unwrap();
+            engine.record_to(cb, "matmul_f16_f32_fp32", &[&wbuf16b, &xbuf2, &out2], bytemuck::cast_slice(&pc2), wg).unwrap();
+            engine.submit_batch(cb).unwrap();
+        }
+        let mm_f16_us = t0.elapsed().as_micros() as f64 / iters2 as f64;
+        println!(
+            "matmul (prefill T=128, q_proj 2048x1536) f32-weight {mm_f32_us:.1}us/call  \
+             f16-weight {mm_f16_us:.1}us/call  ratio {:.2}x",
+            mm_f32_us / mm_f16_us
+        );
+    }
+
+    /// Direct, hardware-independent verification of the actual, tangible
+    /// win: the f16-weight buffer really is half the bytes of the
+    /// f32-weight buffer for the exact same logical weight — unlike the
+    /// timing comparison above, this doesn't depend on the Vulkan
+    /// device's memory subsystem at all, so it's exactly as meaningful on
+    /// `llvmpipe` as on a discrete GPU.
+    #[test]
+    fn f16_weight_buffer_is_half_the_bytes_of_f32() {
+        let weight = fake_random(2048 * 1536, 1);
+        let f32_bytes = weight.len() * 4;
+        let f16_bytes = f32_to_f16_bytes(&weight).len();
+        assert_eq!(f16_bytes * 2, f32_bytes);
+    }
+}

--- a/tests/python/test_vulkan_ops.py
+++ b/tests/python/test_vulkan_ops.py
@@ -54,6 +54,12 @@ def vulkan_ctx():
         pytest.skip("Vulkan device is a software renderer; GPU dispatch disabled")
     prev_cache = vulkan_ops._weight_cache
     prev_cpu_cache = vulkan_ops._cpu_float32_cache
+    # `set_context` above already resets `_weight_f16_decision_cache` to a
+    # fresh `_WeightCache()` (see its doc comment) since `ctx` is a newly
+    # constructed `VulkanContext` every call — saved/restored here anyway,
+    # for the same explicit symmetry with `_weight_cache`/
+    # `_cpu_float32_cache` this fixture already keeps.
+    prev_f16_decision_cache = vulkan_ops._weight_f16_decision_cache
     vulkan_ops._weight_cache = vulkan_ops._WeightCache()
     vulkan_ops._cpu_float32_cache = vulkan_ops._WeightCache()
     try:
@@ -62,6 +68,7 @@ def vulkan_ctx():
         vulkan_ops._ctx = prev_ctx
         vulkan_ops._weight_cache = prev_cache
         vulkan_ops._cpu_float32_cache = prev_cpu_cache
+        vulkan_ops._weight_f16_decision_cache = prev_f16_decision_cache
 
 
 @pytest.fixture
@@ -333,6 +340,33 @@ def test_set_context_invalidates_the_shader_cache():
     finally:
         vulkan_ops._ctx = prev_ctx
         vulkan_ops._available_shaders_cache = prev_cache
+
+
+def test_set_context_invalidates_the_f16_decision_cache():
+    """Same regression this file already guards for
+    `_available_shaders_cache` (`test_set_context_invalidates_the_shader_cache`
+    above), for `_weight_f16_decision_cache`: `_weight_uses_f16`'s per-weight
+    decision depends on the *context* too (via `available_shaders()`), not
+    just the weight's own values, so a fresh `set_context` call must
+    invalidate it — otherwise a weight tensor queried against two
+    different `VulkanContext` instances with different compiled shader
+    sets (a real risk this project's review process caught before merge)
+    could silently keep reading a decision computed for the *previous*
+    context. Pure Python/state behaviour on the module-level cache
+    directly — doesn't need a real Vulkan device."""
+    prev_ctx = vulkan_ops._ctx
+    prev_cache = vulkan_ops._weight_f16_decision_cache
+    try:
+        stale_cache = vulkan_ops._WeightCache()
+        vulkan_ops._weight_f16_decision_cache = stale_cache
+        vulkan_ops.set_context(object())  # type: ignore[arg-type]
+        assert vulkan_ops._weight_f16_decision_cache is not stale_cache, (
+            "set_context must invalidate (replace with a fresh _WeightCache) "
+            "any previously cached _weight_uses_f16 decisions"
+        )
+    finally:
+        vulkan_ops._ctx = prev_ctx
+        vulkan_ops._weight_f16_decision_cache = prev_cache
 
 
 def test_cached_available_shaders_is_faster_than_uncached_repeated_calls(
@@ -910,6 +944,160 @@ class TestLinearTiledMatmulPrefillDispatch:
             f"CPU ({cpu_elapsed:.4f}s/{iters}) at prefill-scale T={t_prefill} - "
             f"see _MATVEC_THRESHOLD's doc comment before changing this dispatch "
             f"decision based on this alone."
+        )
+
+
+class TestVulkanF16WeightUpload:
+    """`_get_or_upload_weight(..., prefer_f16=True)` (now used by both
+    `_vulkan_matvec` and `_vulkan_matmul`) uploads a large weight as
+    float16 instead of float32 whenever `_weight_uses_f16` judges it safe
+    to — halving both the one-time upload cost and, more importantly
+    since the same persistent buffer is re-read from GPU memory on every
+    matvec/matmul dispatch against it, the bytes every one of those calls
+    has to move. This mirrors the standalone Rust `VulkanModel` path's
+    own weight upload (src/lib.rs's `VulkanModel::new`, "Projection
+    weights are uploaded as f16 to halve memory bandwidth") — this
+    (separate) `VulkanContext`-based path never had that applied even
+    though the matching f16 shaders (`mul_mat_vec_f16_f32_f32`,
+    `matmul_f16_f32_fp32`) were already compiled and available for it,
+    per this project's established "compiled but never dispatched"
+    pattern (see e.g. #82).
+
+    These tests use `_require_vulkan_context()` directly rather than the
+    `vulkan_ctx` fixture: the fixture deliberately disables GPU dispatch
+    entirely on a software Vulkan renderer (see `set_context`'s doc
+    comment) as a safety net for the *real* serving path, but that would
+    also skip these tests everywhere a discrete GPU isn't available for
+    CI/local testing — while the underlying dispatch/byte-layout
+    correctness this file verifies is exactly as meaningful on a
+    software renderer as a discrete GPU (same Vulkan pipeline, same
+    SPIR-V, same push-constant contract), unlike a timing comparison.
+    """
+
+    def test_weight_safe_for_f16_true_for_realistic_model_weights(self):
+        """Real transformer weights (bf16-loaded, roughly unit-scale after
+        training normalization) must be judged safe for f16 — the
+        overwhelmingly common case this optimization exists for."""
+        weight = torch.randn(2048, 1536, dtype=torch.bfloat16) * 0.1
+        assert vulkan_ops._weight_safe_for_f16(weight) is True
+
+    def test_weight_safe_for_f16_false_for_values_exceeding_f16_range(self):
+        """float16's exponent range (5 bits, max ~6.5e4) is much smaller
+        than bf16/float32's (8 bits, max ~3.4e38 — see
+        `_weight_safe_for_f16`'s doc comment): a weight containing even
+        one value beyond that range must be rejected, not silently cast
+        to +/-inf."""
+        weight = torch.randn(16, 8, dtype=torch.float32)
+        weight[3, 2] = 1e6  # finite in float32, overflows float16's range
+        assert vulkan_ops._weight_safe_for_f16(weight) is False
+
+    def test_weight_safe_for_f16_false_for_existing_nan_or_inf(self):
+        """Not this function's job to fix (a NaN/inf weight is already
+        broken before it reaches here), but it must not crash and must
+        not claim such a weight is "safe" — `torch.isfinite` is already
+        False for either."""
+        weight = torch.randn(16, 8, dtype=torch.float32)
+        weight[0, 0] = float("inf")
+        assert vulkan_ops._weight_safe_for_f16(weight) is False
+
+    def test_get_or_upload_weight_prefer_f16_halves_buffer_size_for_safe_weight(self):
+        """Direct, hardware-independent verification that this actually
+        reduces GPU memory footprint: a safe-for-f16 weight's persistent
+        buffer must be exactly half the bytes of the same-shaped weight
+        uploaded as float32 — not a timing measurement (this project's
+        own history shows those can be misleading on a software Vulkan
+        renderer, see e.g. `tiled_matmul_beats_cpu_at_prefill_scale_for_large_weights`'s
+        doc comment in src/lib.rs), but a deterministic byte-count
+        comparison that holds identically on any Vulkan device.
+        """
+        ctx = _require_vulkan_context()
+        if "mul_mat_vec_f16_f32_f32" not in ctx.available_shaders():
+            pytest.skip("mul_mat_vec_f16_f32_f32 shader unavailable")
+
+        out_features, in_features = 2048, 1536
+        weight_f16 = torch.randn(out_features, in_features, dtype=torch.bfloat16)
+        weight_f32 = torch.randn(out_features, in_features, dtype=torch.bfloat16)
+
+        gpu_f16 = vulkan_ops._get_or_upload_weight(ctx, weight_f16, prefer_f16=True)
+        gpu_f32 = vulkan_ops._get_or_upload_weight(ctx, weight_f32, prefer_f16=False)
+
+        assert gpu_f16 is not None
+        assert gpu_f32 is not None
+        assert vulkan_ops._weight_uses_f16(ctx, weight_f16) is True
+        assert gpu_f16.nbytes == out_features * in_features * 2
+        assert gpu_f32.nbytes == out_features * in_features * 4
+        assert gpu_f16.nbytes == gpu_f32.nbytes // 2
+
+    def test_get_or_upload_weight_falls_back_to_f32_for_overflowing_weight(self):
+        """A weight containing an out-of-f16-range value must still
+        upload as float32 even when `prefer_f16=True` is passed — the
+        safety fallback, not a crash or silent wrong data."""
+        ctx = _require_vulkan_context()
+        if "mul_mat_vec_f16_f32_f32" not in ctx.available_shaders():
+            pytest.skip("mul_mat_vec_f16_f32_f32 shader unavailable")
+
+        out_features, in_features = 16, 8
+        weight = torch.randn(out_features, in_features, dtype=torch.float32)
+        weight[0, 0] = 1e6
+
+        gpu = vulkan_ops._get_or_upload_weight(ctx, weight, prefer_f16=True)
+        assert gpu is not None
+        assert vulkan_ops._weight_uses_f16(ctx, weight) is False
+        assert gpu.nbytes == out_features * in_features * 4
+
+    def test_vulkan_matvec_f16_weight_matches_cpu_reference(self):
+        """End-to-end correctness: `_vulkan_matvec` dispatching the
+        f16-weight shader (`mul_mat_vec_f16_f32_f32`) must match
+        `torch.nn.functional.linear`'s float32 reference within the
+        precision loss f16 weight storage alone accounts for."""
+        ctx = _require_vulkan_context()
+        if "mul_mat_vec_f16_f32_f32" not in ctx.available_shaders():
+            pytest.skip("mul_mat_vec_f16_f32_f32 shader unavailable")
+
+        out_features, in_features = 2048, 1536
+        weight = torch.randn(out_features, in_features, dtype=torch.float32) * 0.1
+        x = torch.randn(1, in_features, dtype=torch.float32)
+
+        result = vulkan_ops._vulkan_matvec(ctx, x, weight)
+        expected = torch.nn.functional.linear(x, weight, None)
+        torch.testing.assert_close(result, expected, rtol=2e-2, atol=2e-2)
+
+    def test_vulkan_matmul_f16_weight_matches_cpu_reference(self):
+        """Same correctness check, for the prefill tiled-matmul path
+        (`_vulkan_matmul` dispatching `matmul_f16_f32_fp32`)."""
+        ctx = _require_vulkan_context()
+        if "matmul_f16_f32_fp32" not in ctx.available_shaders():
+            pytest.skip("matmul_f16_f32_fp32 shader unavailable")
+
+        out_features, in_features = 2048, 1536
+        weight = torch.randn(out_features, in_features, dtype=torch.float32) * 0.1
+        x = torch.randn(128, in_features, dtype=torch.float32)
+
+        result = vulkan_ops._vulkan_matmul(ctx, x, weight)
+        expected = torch.nn.functional.linear(x, weight, None)
+        torch.testing.assert_close(result, expected, rtol=2e-2, atol=2e-2)
+
+    def test_rms_norm_then_linear_still_uses_f32_weight_unchanged(
+        self, vulkan_ctx, upload_counter
+    ):
+        """`rms_norm_then_linear` (the fused decode-only RMSNorm+Linear
+        path, unlike the plain `_vulkan_matvec`/`_vulkan_matmul` above)
+        deliberately keeps calling `_get_or_upload_weight` without
+        `prefer_f16=True` — it hardcodes dispatching
+        `mul_mat_vec_f32_f32_f32`, not the f16-weight variant, so its
+        weight upload must keep matching that shader's expected byte
+        layout exactly, unchanged by this optimization."""
+        norm_weight = torch.randn(8, dtype=torch.float32)
+        linear_weight = torch.randn(16, 8, dtype=torch.float32)
+        x = torch.randn(1, 8, dtype=torch.float32)
+
+        vulkan_ops.rms_norm_then_linear(x, norm_weight, 1e-6, linear_weight, None)
+        gpu = vulkan_ops._weight_cache.get(linear_weight)
+        assert gpu is not None
+        assert gpu.nbytes == 16 * 8 * 4, (
+            "rms_norm_then_linear's linear_weight must still upload as "
+            "float32 (matching the mul_mat_vec_f32_f32_f32 it hardcodes), "
+            "not float16"
         )
 
 

--- a/vllm_vulkan/vulkan_ops.py
+++ b/vllm_vulkan/vulkan_ops.py
@@ -40,9 +40,19 @@ _available_shaders_cache: frozenset[str] | None = None
 
 
 def set_context(ctx: VulkanContext) -> None:
-    global _ctx, _available_shaders_cache
+    global _ctx, _available_shaders_cache, _weight_f16_decision_cache
     _ctx = ctx
     _available_shaders_cache = None
+    # `_weight_f16_decision_cache` (see `_weight_uses_f16`'s doc comment)
+    # caches a per-weight decision that depends on the *context* too (via
+    # `_cached_available_shaders(ctx)`), not just the weight's own values
+    # — reset it here for exactly the same reason `_available_shaders_cache`
+    # is reset above: without this, a weight tensor object queried against
+    # two different `VulkanContext` instances with different compiled
+    # shader sets (e.g. sequential tests, or a real caller that swaps
+    # devices) could silently keep reading a decision computed for the
+    # *previous* context instead of the current one.
+    _weight_f16_decision_cache = _WeightCache()
 
     # Detect software renderer and disable GPU dispatch.
     try:
@@ -165,16 +175,107 @@ class _WeightCache:
 
 _weight_cache = _WeightCache()
 _cpu_float32_cache = _WeightCache()
+# Per-weight decision cache for `_weight_uses_f16` — see its doc comment.
+_weight_f16_decision_cache = _WeightCache()
 
 
-def _get_or_upload_weight(ctx: VulkanContext, weight: torch.Tensor) -> object | None:
-    """Return a persistent GpuTensor for weight, uploading once on first use."""
+def _weight_safe_for_f16(weight: torch.Tensor) -> bool:
+    """True if every element of `weight` round-trips through float16
+    without overflowing to +/-inf.
+
+    bf16 (the dtype real checkpoints load projection weights as — see
+    module docstring) has the same 8-bit exponent as float32, so its
+    representable range is ~3.4e38; float16 has only a 5-bit exponent,
+    range ~6.5e4. A value that's perfectly finite in bf16/float32 can
+    therefore silently become +/-inf in float16 — not an error, just a
+    wrong number quietly propagating through every downstream matvec/
+    matmul that reads it, exactly the kind of silent-wrong-output failure
+    `mul_mat_vec_f32_f32_f32_subgroup`'s postmortem (src/lib.rs's
+    `subgroup_matvec_correctness_tests`) established this codebase must
+    check for directly rather than assume away. Real transformer weights
+    are essentially always small (normalized to roughly unit scale by
+    training), so this is expected to return True in practice — but
+    "expected" is exactly the assumption that shader's bug hid behind.
+    """
+    return bool(torch.isfinite(weight.half()).all())
+
+
+def _weight_uses_f16(ctx: VulkanContext, weight: torch.Tensor) -> bool:
+    """Whether `weight`'s persistent GPU buffer should be (and, once
+    `_get_or_upload_weight` has run for it, was) uploaded as float16
+    instead of float32.
+
+    A pure, cached function of `weight`'s identity + values (same
+    weak-ref-keyed convention as `_weight_cache` itself — see
+    `_WeightCache`'s docstring): both `_vulkan_matvec` and `_vulkan_matmul`
+    need this exact same decision twice (once to pick which shader
+    variant to dispatch, once inside `_get_or_upload_weight` to pick which
+    dtype to upload), and `_weight_safe_for_f16` costs a full weight-sized
+    `.half()` conversion + `isfinite` scan — real, avoidable, repeated
+    work if redone on every single decode-step/prefill-chunk call instead
+    of once per distinct weight tensor, same rationale as `_weight_cache`
+    avoiding a re-upload on every call.
+
+    Gated on both f16-weight shader variants
+    (`mul_mat_vec_f16_f32_f32`/`matmul_f16_f32_fp32`) actually being
+    compiled — unconditionally true for this backend's fixed shader set
+    today (see scripts/compile_shaders.sh), but checked the same
+    defensive way every other shader dispatch in this file gates on
+    `_cached_available_shaders`, rather than assuming a future build
+    always has them.
+    """
+    cached = _weight_f16_decision_cache.get(weight)
+    if cached is not None:
+        return cast("bool", cached)
+    available_shaders = _cached_available_shaders(ctx)
+    decision = (
+        "mul_mat_vec_f16_f32_f32" in available_shaders
+        and "matmul_f16_f32_fp32" in available_shaders
+        and _weight_safe_for_f16(weight)
+    )
+    _weight_f16_decision_cache.put(weight, decision)
+    return decision
+
+
+def _get_or_upload_weight(
+    ctx: VulkanContext, weight: torch.Tensor, prefer_f16: bool = False
+) -> object | None:
+    """Return a persistent GpuTensor for weight, uploading once on first use.
+
+    `prefer_f16`: if True AND `_weight_uses_f16` agrees (safe range, f16
+    shaders available), upload/cache a float16 buffer — HALF the bytes
+    of the usual float32 upload, and (more importantly, since this same
+    buffer is re-read from GPU memory on every matvec/matmul dispatch
+    against it, not just once here) half the bytes every dispatch has to
+    move for this weight. This mirrors the standalone Rust `VulkanModel`
+    path's own weight upload (src/lib.rs's `VulkanModel::new`, "Projection
+    weights are uploaded as f16 to halve memory bandwidth") — this
+    (separate, `VulkanContext`-based) code path never had that applied
+    even though the matching f16 shaders were compiled and available for
+    it too, per this project's established "compiled but never
+    dispatched" pattern (see e.g. #82's `matmul_f32_f32`/#77's fused
+    decode dispatch).
+
+    Only `_vulkan_matvec`/`_vulkan_matmul` pass `prefer_f16=True` — every
+    other caller (RMSNorm's `norm_weight` via `rms_norm_then_linear`,
+    which has no matching f16-weight shader wired up here) keeps this at
+    its default and gets the exact same float32-always behaviour as
+    before this change.
+
+    Callers needing to know whether f16 was actually used (to pick a
+    matching shader variant) must call `_weight_uses_f16` themselves —
+    the same cached decision this function uses internally, so the two
+    can never disagree for a given weight.
+    """
     try:
         cached = _weight_cache.get(weight)
         if cached is not None:
             return cached
-        w_f32 = weight.float() if weight.dtype != torch.float32 else weight
-        gpu = ctx.upload_tensor(_to_bytes(w_f32))
+        if prefer_f16 and _weight_uses_f16(ctx, weight):
+            gpu = ctx.upload_tensor(_to_bytes(weight.half()))
+        else:
+            w_f32 = weight.float() if weight.dtype != torch.float32 else weight
+            gpu = ctx.upload_tensor(_to_bytes(w_f32))
         _weight_cache.put(weight, gpu)
         return gpu
     except Exception as exc:
@@ -568,7 +669,7 @@ def _vulkan_matvec(
     x: torch.Tensor,  # [T, K] float32
     weight: torch.Tensor,  # [N, K] any dtype
 ) -> torch.Tensor:
-    """Dispatch mul_mat_vec_f32_f32_f32 for decode (T<4).
+    """Dispatch mul_mat_vec_{f16,f32}_f32_f32 for decode (T<4).
 
     NOT mul_mat_vec_f32_f32_f32_subgroup: that variant was found to
     silently diverge from the correct result for ncols>=~256 (i.e.
@@ -578,14 +679,26 @@ def _vulkan_matvec(
     plain, non-subgroup variant) has an identical binding/push-constant/
     workgroup-dispatch convention and was confirmed correct at every
     size tested.
+
+    Uploads (and dispatches against) `weight` as float16 instead of
+    float32 whenever `_weight_uses_f16` says it's safe to — halving the
+    bytes this (large, per-call, re-read-from-GPU-memory) weight buffer
+    costs to move. `mul_mat_vec_f16_f32_f32` shares `mul_mat_vec_base.glsl`
+    with the f32 variant and only differs in `A_TYPE`
+    (scripts/compile_shaders.sh), converting each element to float on
+    load before the identical dot-product math either variant runs — see
+    `f16_weight_dispatch_tests::mul_mat_vec_f16_f32_f32_matches_cpu_reference_at_realistic_k`
+    (src/lib.rs) for the direct correctness verification against a CPU
+    reference computed from the same f16-rounded weight values.
     """
-    # Cache key on original weight (before .float()) - and the .float()
+    # Cache key on original weight (before .float()/.half()) - and that
     # conversion itself only happens lazily, in the `w_gpu is None`
     # fallback branch below, since on the (overwhelmingly common) cache-hit
     # path the GPU-resident buffer already holds the converted weight and
-    # recomputing weight.float() here would just be a wasted full
-    # weight-matrix copy, every single call, for a value nothing else uses.
-    w_gpu = _get_or_upload_weight(ctx, weight)
+    # recomputing it here would just be a wasted full weight-matrix copy,
+    # every single call, for a value nothing else uses.
+    use_f16 = _weight_uses_f16(ctx, weight)
+    w_gpu = _get_or_upload_weight(ctx, weight, prefer_f16=True)
 
     T, K = x.shape  # noqa: N806
     N = weight.shape[0]  # noqa: N806
@@ -593,12 +706,16 @@ def _vulkan_matvec(
     x_bytes = _to_bytes(x)
     out_size = T * N * 4
 
-    w_binding = w_gpu if w_gpu is not None else _to_bytes(weight.float())
+    if w_gpu is not None:
+        w_binding = w_gpu
+    else:
+        w_binding = _to_bytes(weight.half()) if use_f16 else _to_bytes(weight.float())
 
+    shader = "mul_mat_vec_f16_f32_f32" if use_f16 else "mul_mat_vec_f32_f32_f32"
     results = ctx.execute_batch(
         [
             (
-                "mul_mat_vec_f32_f32_f32",
+                shader,
                 [w_binding, x_bytes],
                 [out_size],
                 pc,
@@ -615,26 +732,30 @@ def _vulkan_matmul(
     x: torch.Tensor,  # [T, K] float32
     weight: torch.Tensor,  # [M, K] any dtype
 ) -> torch.Tensor:
-    """Dispatch `matmul_f32_f32` (the tiled matmul shader, mul_mm.comp)
-    for prefill (T >= _MATVEC_THRESHOLD, large-enough weight — see
-    `linear`'s dispatch decision).
+    """Dispatch `matmul_{f16,f32}_f32` (the tiled matmul shader,
+    mul_mm.comp) for prefill (T >= _MATVEC_THRESHOLD, large-enough
+    weight — see `linear`'s dispatch decision).
 
-    Only the plain (non-`_aligned`) variant is dispatched: the
+    Only the plain (non-`_aligned`) variants are dispatched: the
     `_aligned` variants assume `K` is already a multiple of the tile
     size and skip bounds-checking loads, silently producing wrong
-    results otherwise. `matmul_f32_f32` handles any `M`/`T`/`K` shape
-    safely — verified directly, including shapes deliberately NOT
-    aligned to this shader's BM=BN=64/BK=32 tile sizes, against a CPU
-    reference (see `tiled_matmul_dispatch_tests` in src/lib.rs) — so no
-    alignment check is needed here.
+    results otherwise. `matmul_f32_f32`/`matmul_f16_f32_fp32` handle any
+    `M`/`T`/`K` shape safely — verified directly, including shapes
+    deliberately NOT aligned to this shader's BM=BN=64/BK=32 tile sizes,
+    against a CPU reference (see `tiled_matmul_dispatch_tests` and
+    `f16_weight_dispatch_tests` in src/lib.rs) — so no alignment check is
+    needed here.
 
     Shares `_get_or_upload_weight`'s GPU weight cache with
     `_vulkan_matvec`: both shaders require the exact same buffer layout
-    (row-major `[out_features, in_features]`, `f32`), so the same
-    persistent upload serves either dispatch path for a given weight,
-    whichever T a given call happens to use.
+    (row-major `[out_features, in_features]`, same dtype as
+    `_weight_uses_f16` decided for this weight), so the same persistent
+    upload serves either dispatch path for a given weight, whichever T a
+    given call happens to use — `_weight_uses_f16`'s own cache guarantees
+    both call sites agree on that dtype for the same weight tensor.
     """
-    w_gpu = _get_or_upload_weight(ctx, weight)
+    use_f16 = _weight_uses_f16(ctx, weight)
+    w_gpu = _get_or_upload_weight(ctx, weight, prefer_f16=True)
 
     T, K = x.shape  # noqa: N806
     M = weight.shape[0]  # noqa: N806
@@ -642,12 +763,16 @@ def _vulkan_matmul(
     x_bytes = _to_bytes(x)
     out_size = T * M * 4
 
-    w_binding = w_gpu if w_gpu is not None else _to_bytes(weight.float())
+    if w_gpu is not None:
+        w_binding = w_gpu
+    else:
+        w_binding = _to_bytes(weight.half()) if use_f16 else _to_bytes(weight.float())
 
+    shader = "matmul_f16_f32_fp32" if use_f16 else "matmul_f32_f32"
     results = ctx.execute_batch(
         [
             (
-                "matmul_f32_f32",
+                shader,
                 [w_binding, x_bytes],
                 [out_size],
                 pc,


### PR DESCRIPTION
## Summary

`_get_or_upload_weight` (the persistent GPU weight cache shared by
`_vulkan_matvec`'s decode path and `_vulkan_matmul`'s prefill path, #82)
always uploaded weights as `float32`, even though this backend has
compiled f16-weight variants of both shaders
(`mul_mat_vec_f16_f32_f32`, `matmul_f16_f32_fp32`) since its earliest
history and already dispatches them from the separate, standalone Rust
`VulkanModel` path. This wires the same f16 upload up for the
`VulkanContext`-based path `vulkan_ops.py` actually uses to accelerate
an arbitrary vLLM model's `nn.Linear` layers — halving both the
one-time upload cost and the bytes every matvec/prefill-matmul
dispatch has to move for every large-enough Linear weight.

## Safety

bf16 (checkpoints' native dtype) has the same exponent range as
float32; float16's is much smaller. A new `_weight_safe_for_f16` guard
(`torch.isfinite(weight.half()).all()`, cached per-weight) falls back
to the exact previous float32-always behavior for any weight that
doesn't safely fit — silently and correctly, never producing wrong
output.

## Verification

- **Correctness**: new `f16_weight_dispatch_tests` (src/lib.rs) compare
  both shaders directly against a CPU reference (weight values rounded
  through f16 first, isolating shader-dispatch bugs from expected
  quantization noise) across Gemma4-E2B's real shapes plus tile-boundary
  edge cases. Max abs error <= 0.000351.
- **7 new Python tests** (`TestVulkanF16WeightUpload`) cover the
  overflow-safety fallback, end-to-end output correctness, and a
  hardware-independent, deterministic check that the f16 buffer is
  exactly half the bytes of the float32 one (`GpuTensor.nbytes`).
- **Performance**: this sandbox only has `llvmpipe` (software Vulkan)
  available — no discrete GPU/VRAM is reachable here. Bandwidth effects
  are a wash on `llvmpipe` as expected (matvec 0.98x, prefill matmul
  1.00x — printed, not asserted, same precedent as
  `tiled_matmul_small_weight_crossover_point`), i.e. measurably no
  regression on the only hardware available to verify this change
  against. The bandwidth-halving argument itself is the same one already
  applied for the standalone `VulkanModel` path in this repo. **Real
  discrete-GPU re-validation (RX 7900 XTX / RX 6900 XT / GB10) is
  recommended** to confirm the expected win materializes there.
- `cargo test --release`: 46/48 pass — same 2 pre-existing,
  discrete-GPU-only failures as master, unrelated to this change.
- `pytest -m "not slow" tests/python/`: 73/73 pass (up from 66).
- Clippy warnings unchanged at 46. `scripts/lint.sh` passes clean.

See the commit message for full detail.
