### PR TITLE
fix: resolve vLLM CPU-platform startup crashes and test tolerances

### DIFF
--- a/tests/python/test_vulkan_ops.py
+++ b/tests/python/test_vulkan_ops.py
@@ -73,14 +73,33 @@ def vulkan_ctx():
 
 @pytest.fixture
 def upload_counter(monkeypatch):
-    """Count real GPU uploads (_WeightCache.put calls) deterministically,
-    independent of the weak-ref cache's final size (see module docstring
-    for why the latter can be misleading)."""
+    """Count real GPU-weight/CPU-float32-cache-populating `_WeightCache.put`
+    calls deterministically, independent of the weak-ref cache's final size
+    (see module docstring for why the latter can be misleading).
+
+    Used by callers that assert on either `_weight_cache` (a real GPU
+    upload) or `_cpu_float32_cache` (a real host-side float32 conversion)
+    being populated exactly once — historically the same thing, since
+    counting *any* `_WeightCache.put` call was equivalent to counting
+    "real, potentially-expensive conversion/upload work done" when those
+    were the only two `_WeightCache` instances in this module.
+
+    Excludes `_weight_f16_decision_cache` specifically (added in #83):
+    `_weight_uses_f16` caches its own per-weight decision there — a cheap
+    cached bool, not a GPU upload or CPU conversion — so counting its
+    `put` calls alongside the other two would double-count "1 real
+    upload" as 2 (one decision-cache `put`, one actual weight-cache
+    `put`) for any weight that goes through
+    `_get_or_upload_weight(..., prefer_f16=True)`, exactly the weights
+    several of this fixture's callers (>= _MATVEC_MIN_WEIGHT_ELEMENTS)
+    use.
+    """
     counts = {"n": 0}
     orig_put = vulkan_ops._WeightCache.put
 
     def counting_put(self, w, gpu):
-        counts["n"] += 1
+        if self is not vulkan_ops._weight_f16_decision_cache:
+            counts["n"] += 1
         return orig_put(self, w, gpu)
 
     monkeypatch.setattr(vulkan_ops._WeightCache, "put", counting_put)
@@ -118,7 +137,23 @@ def test_linear_matches_torch_reference_at_realistic_hidden_size(vulkan_ctx):
 
     result = vulkan_ops.linear(x, weight, None)
     expected = torch.nn.functional.linear(x, weight, None)
-    torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
+    # rtol=1e-2/atol=5e-2 (not 1e-3/1e-3): since #83, `linear()`'s GPU decode
+    # path uploads/dispatches this (>= _MATVEC_MIN_WEIGHT_ELEMENTS) weight as
+    # float16 whenever `_weight_uses_f16` says it's safe to (see
+    # `_get_or_upload_weight`'s doc comment) — a deliberate, expected
+    # precision/bandwidth tradeoff, not a correctness bug: the result matches
+    # a CPU reference computed from the *same* f16-rounded weight values to
+    # within ~2e-4 (well inside f16's own ~1e-3 relative precision), while
+    # diverging from this fp32-weight `torch.nn.functional.linear` reference
+    # by up to ~0.032 at this shape/dtype across repeated runs on real
+    # (non-mock) Vulkan hardware — the two are simply no longer expected to
+    # agree at 1e-3/1e-3 now that the weight itself is stored more coarsely
+    # on the GPU. rtol=1e-2/atol=5e-2 comfortably covers the observed ~0.03
+    # max abs error (including near-zero-`expected` elements, where relative
+    # error alone spikes) with margin, without being so loose it'd miss an
+    # actual dispatch/binding/stride bug reintroducing errors an order of
+    # magnitude larger than f16 rounding alone explains.
+    torch.testing.assert_close(result, expected, rtol=1e-2, atol=5e-2)
 
 
 def test_get_or_upload_weight_hits_cache_for_same_tensor_object(
@@ -847,7 +882,14 @@ class TestLinearTiledMatmulPrefillDispatch:
             x = torch.randn(t, in_features, dtype=torch.float32)
             result = vulkan_ops.linear(x, weight, None)
             expected = torch.nn.functional.linear(x, weight, None)
-            torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-2)
+            # rtol=1e-2/atol=5e-2 (not 1e-3/1e-2): same rationale as
+            # `test_linear_matches_torch_reference_at_realistic_hidden_size`
+            # above — since #83, this weight (>= _MATVEC_MIN_WEIGHT_ELEMENTS)
+            # is uploaded/dispatched as float16 by `_vulkan_matmul` too, so
+            # this fp32-weight `torch.nn.functional.linear` reference is no
+            # longer expected to match at 1e-2 absolute; observed max abs
+            # error across these T values on real Vulkan hardware is ~0.045.
+            torch.testing.assert_close(result, expected, rtol=1e-2, atol=5e-2)
 
     def test_large_weight_prefill_uses_gpu_weight_cache_not_cpu_path(
         self, vulkan_ctx, upload_counter

--- a/vllm_vulkan/patches.py
+++ b/vllm_vulkan/patches.py
@@ -23,6 +23,12 @@ _patches_applied = False
 
 _TEMPLATES_DIR = Path(__file__).parent
 
+# Keeps torch.library.Library fragments alive for the process lifetime; a
+# Library object unregisters all of its ops when garbage-collected, so a
+# module-level reference is required for _patch_cpu_memory_env's fallback op
+# to remain callable.
+_KEEPALIVE_LIBS: list[torch.library.Library] = []
+
 
 def apply_patches() -> None:
     """Apply all patches.  Safe to call multiple times (idempotent)."""
@@ -32,14 +38,134 @@ def apply_patches() -> None:
     _patches_applied = True
 
     try:
+        _patch_cpu_memory_env()
+    except Exception as exc:
+        logger.warning("Failed to apply vllm._C.init_cpu_memory_env patch: %s", exc)
+
+    try:
         _patch_cpu_triton_utils()
     except Exception as exc:
         logger.warning("Failed to apply vllm._C patches: %s", exc)
 
     try:
+        _patch_topk_topp_triton()
+    except Exception as exc:
+        logger.warning("Failed to apply top-k/top-p Triton-CUDA guard: %s", exc)
+
+    try:
         _register_gemma4_chat_template()
     except Exception as exc:
         logger.warning("Failed to register gemma4 chat template fallback: %s", exc)
+
+    try:
+        _patch_accelerator_synchronize()
+    except Exception as exc:
+        logger.warning("Failed to apply torch.accelerator.synchronize guard: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Patch: torch.accelerator.synchronize() on platforms with no torch accelerator
+# ---------------------------------------------------------------------------
+
+
+def _patch_accelerator_synchronize() -> None:
+    """Make ``torch.accelerator.synchronize()``/``empty_cache()`` no-ops when
+    no torch accelerator (CUDA/XPU/etc.) is registered.
+
+    ``vllm.v1.worker.gpu_model_runner.GPUModelRunner._cleanup_profiling_kv_cache``
+    (reused by ``_VulkanCPUModelRunner`` via ``CPUModelRunner``) unconditionally
+    calls both during worker shutdown. Their docstrings say they're a no-op
+    if the current accelerator is not initialized, but the implementation
+    doesn't actually honor that for a device_type="cpu" platform like this
+    one (no torch accelerator is ever registered): each raises
+        RuntimeError: Cannot access accelerator device when none is available.
+    This doesn't corrupt or lose any already-generated output (it only fires
+    during worker teardown, after results have been returned), but it turns
+    every clean shutdown -- including a normal ``LLM()`` object being garbage
+    collected, or ``vllm serve`` receiving Ctrl-C -- into a scary, confusing
+    traceback in the logs. Guard both so shutdown is quiet when there truly
+    is no accelerator.
+    """
+    if not hasattr(torch, "accelerator"):
+        return
+
+    for name in ("synchronize", "empty_cache"):
+        orig_func = getattr(torch.accelerator, name, None)
+        if orig_func is None:
+            continue
+
+        def _make_safe(orig):  # noqa: ANN001
+            def _safe(*args, **kwargs):
+                if not torch.accelerator.is_available():
+                    return None
+                return orig(*args, **kwargs)
+
+            return _safe
+
+        setattr(torch.accelerator, name, _make_safe(orig_func))
+
+    logger.debug(
+        "Guarded torch.accelerator.synchronize()/empty_cache() to no-op "
+        "when no torch accelerator is registered (Vulkan/CPU platform)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Patch: vllm.v1.sample.ops.topk_topp_sampler's Triton fast path
+# ---------------------------------------------------------------------------
+
+
+def _patch_topk_topp_triton() -> None:
+    """Force the PyTorch top-k/top-p sampling fallback on this platform.
+
+    ``vllm.v1.sample.ops.topk_topp_sampler.apply_top_k_top_p`` unconditionally
+    dispatches to ``apply_top_k_top_p_triton`` whenever ``vllm.triton_utils
+    .HAS_TRITON`` is true and the batch size is >= 8 -- with no platform
+    check. That Triton kernel is CUDA-only (it launches through
+    ``triton.backends.nvidia.driver``), so it crashes as soon as
+    ``triton`` happens to be importable in the environment, which is common:
+    it is a normal transitive dependency of vLLM (e.g. via structured-output
+    backends) even for CPU-only installs, so a Vulkan-plugin user need not
+    have installed it deliberately. Since this platform's tensors always sit
+    on ``torch.device("cpu")`` (compute is offloaded to the GPU only inside
+    the model's own forward pass, not vLLM's post-hoc sampler), the kernel's
+    ``ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu
+    tensor?)`` fires on essentially every request with a batch size >= 8.
+
+    We patch ``HAS_TRITON`` to ``False`` inside the already-imported
+    ``topk_topp_sampler`` module only (not globally), so the module's
+    ``apply_top_k_top_p`` falls back to ``apply_top_k_top_p_pytorch``, which
+    is a plain, device-agnostic PyTorch sort-based implementation.
+    """
+    # NOTE: this is deliberately *not* only called from apply_patches() at
+    # plugin-registration time. That runs extremely early (from inside
+    # vLLM's own lazy ``current_platform`` resolution, itself triggered
+    # while ``vllm.config`` and friends may still be mid-import), so
+    # importing ``vllm.v1.sample.ops.topk_topp_sampler`` at that point
+    # reliably raises:
+    #   ImportError: cannot import name 'CUDAGraphMode' from partially
+    #   initialized module 'vllm.config' (most likely due to a circular
+    #   import)
+    # which is swallowed here and by apply_patches()'s caller, silently
+    # making the patch a no-op. ``VulkanWorker.init_device()`` also calls
+    # this function directly, at a point where vLLM's module graph is
+    # already fully imported, which is where this patch actually takes
+    # effect in practice.
+    try:
+        import vllm.v1.sample.ops.topk_topp_sampler as _sampler_mod  # noqa: PLC0415
+    except ImportError:
+        return
+
+    if not getattr(_sampler_mod, "HAS_TRITON", False):
+        return  # Already false; e.g. triton genuinely not installed.
+
+    _sampler_mod.HAS_TRITON = False
+    logger.info(
+        "Disabled vLLM's CUDA-only Triton top-k/top-p sampling kernel for "
+        "the Vulkan/CPU platform; falling back to the PyTorch "
+        "implementation (vllm.v1.sample.ops.topk_topp_sampler."
+        "apply_top_k_top_p_pytorch)."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -131,13 +257,88 @@ class _FuncWrapper:
         return self.func
 
 
+# ---------------------------------------------------------------------------
+# Patch: vllm._C.init_cpu_memory_env
+# ---------------------------------------------------------------------------
+
+
+def _patch_cpu_memory_env() -> None:
+    """Register a no-op fallback for ``vllm._C.init_cpu_memory_env``.
+
+    ``CPUWorker.__init__`` (vLLM's base class for our ``VulkanWorker``) calls
+    ``torch.ops._C.init_cpu_memory_env(...)`` unconditionally, before
+    ``VulkanWorker.init_device()`` even runs, to bind the process to a NUMA
+    memory node for the CPU backend's AVX-optimized kernels.
+
+    Some vLLM CPU wheels (observed on aarch64 builds, where the heavy
+    AVX-512 CPU kernel sources are not compiled) ship a ``vllm._C`` module
+    that imports successfully but registers *zero* ops under the ``_C``
+    torch.library namespace. ``_patch_cpu_triton_utils`` below already
+    handles the case where ``import vllm._C`` fails outright, but it cannot
+    detect this "importable but empty" case, so ``torch.ops._C.init_cpu_memory_env``
+    raises an uncaught ``AttributeError`` and engine startup crashes:
+
+        AttributeError: '_OpNamespace' '_C' object has no attribute
+        'init_cpu_memory_env'
+
+    The Vulkan plugin runs on ``device_type=cpu`` purely as a host/scheduling
+    shim -- all matmul/norm/attention compute is dispatched to the GPU via
+    Vulkan -- so NUMA-local memory binding is irrelevant here and safe to
+    skip entirely, exactly like the existing ``init_cpu_threads_env``
+    try/except in ``VulkanWorker.init_device``.
+    """
+    try:
+        import vllm._C  # noqa: PLC0415, F401
+    except (ImportError, ModuleNotFoundError):
+        # vllm._C missing entirely; CPUWorker.__init__ will still fail the
+        # same way, but that is a separate, pre-existing limitation (running
+        # vLLM without any compiled extension at all) outside this patch's
+        # scope.
+        return
+
+    if hasattr(torch.ops._C, "init_cpu_memory_env"):
+        return  # Real op is present and registered; nothing to do.
+
+    lib = torch.library.Library("_C", "FRAGMENT")
+    lib.define("init_cpu_memory_env(SymInt[] node_ids) -> ()")
+    lib.impl(
+        "init_cpu_memory_env",
+        lambda node_ids: None,
+        "CompositeExplicitAutograd",
+    )
+    # Prevent the Library (and therefore the op registration) from being
+    # garbage-collected once this function returns.
+    _KEEPALIVE_LIBS.append(lib)
+
+    logger.info(
+        "Registered no-op fallback for vllm._C.init_cpu_memory_env "
+        "(op not present in this vLLM CPU build); NUMA-local memory "
+        "binding is skipped. Compute is dispatched to the GPU via Vulkan "
+        "regardless, so this has no effect on functionality."
+    )
+
+
 def _patch_cpu_triton_utils() -> None:
-    """Monkey-patch ``vllm.utils.cpu_triton_utils`` if ``vllm._C`` is absent."""
+    """Monkey-patch ``vllm.utils.cpu_triton_utils`` if ``vllm._C`` is absent.
+
+    Checking only ``import vllm._C`` succeeding is not sufficient: some vLLM
+    CPU wheels (observed on aarch64 builds) ship a ``vllm._C`` module that
+    imports fine but registers *zero* ops under the ``_C`` torch.library
+    namespace (see ``_patch_cpu_memory_env`` above for the same situation
+    with a different op). ``vllm.utils.cpu_triton_utils.compute_slot_mapping_kernel``
+    unconditionally calls ``torch.ops._C.compute_slot_mapping_kernel_impl``
+    with no fallback of its own, so in that "importable but empty" case this
+    crashes on every forward pass with:
+        AttributeError: '_OpNamespace' '_C' object has no attribute
+        'compute_slot_mapping_kernel_impl'
+    Check for the specific op instead of just the module's importability.
+    """
     try:
         import vllm._C  # noqa: PLC0415, F401
 
-        # If we reach here, the C extension IS available — no patch needed.
-        return
+        if hasattr(torch.ops._C, "compute_slot_mapping_kernel_impl"):
+            # The real op IS available — no patch needed.
+            return
     except (ImportError, ModuleNotFoundError):
         pass  # Extension absent; apply the pure-Python fallback.
 

--- a/vllm_vulkan/platform.py
+++ b/vllm_vulkan/platform.py
@@ -140,6 +140,27 @@ class VulkanPlatform(Platform):
         except (ImportError, OSError):
             return 0
 
+    @classmethod
+    def num_compute_units(cls, device_id: int = 0) -> int:
+        """Parallelism hint for vLLM's Triton CPU top-k/top-p sampler
+        (``vllm.v1.sample.ops.topk_topp_triton``), which launches its grid
+        sized to ``min(num_compute_units(), batch_size)``.
+
+        That kernel operates on the sampler's logits tensor, which lives on
+        ``torch.device("cpu")`` (this platform's ``device_type``) regardless
+        of Vulkan GPU offload elsewhere in the model's forward pass, so CPU
+        core count -- not a Vulkan-specific notion of "compute units" -- is
+        the right answer here.
+
+        The base ``Platform.num_compute_units`` raises ``NotImplementedError``
+        (only CUDA/ROCm/XPU override it); previously this crashed engine
+        warm-up as soon as ``triton`` happened to be importable in the
+        environment and the profiling batch size reached 8, which happens
+        whenever anything else in the environment (e.g. torch itself, on
+        some platforms) pulls in `triton` as a transitive dependency.
+        """
+        return os.cpu_count() or 1
+
     # ─── Device management ───────────────────────────────────────────────────
 
     @classmethod
@@ -163,6 +184,41 @@ class VulkanPlatform(Platform):
     @classmethod
     def get_torch_device(cls, device_id: int = 0) -> torch.device:
         return torch.device("cpu")
+
+    @classmethod
+    def is_cpu(cls) -> bool:
+        """Report this platform as CPU-like to vLLM's generic capability
+        checks.
+
+        The base ``Platform.is_cpu()`` returns ``self._enum ==
+        PlatformEnum.CPU``, which is ``False`` here since out-of-tree
+        plugins use ``PlatformEnum.OOT`` -- even though this platform's
+        ``device_type`` is ``"cpu"`` and it reuses vLLM's ``CPUWorker``/
+        ``CPUModelRunner`` throughout. Several call sites gate CUDA/XPU-only
+        features (e.g. ``Worker._maybe_get_memory_pool_context``'s sleep-mode
+        cumem allocator) behind ``current_platform.is_cpu()`` to skip them
+        with a plain ``nullcontext()``; without this override those checks
+        fall through to ``get_mem_allocator_instance()``, which raises::
+
+            RuntimeError: Sleep mode allocator is not available on platform
+            VulkanPlatform (device_type=cpu).
+
+        on every model load, since this platform is (correctly) absent from
+        that allocator's supported-platform list.
+        """
+        return True
+
+    @classmethod
+    def manual_seed_all(cls, seed: int) -> None:
+        """No-op: the torch device is "cpu" (torch.manual_seed already covers
+        it), and Vulkan compute buffers don't participate in torch's RNG
+        state. The base ``Platform.manual_seed_all`` raises
+        ``NotImplementedError`` by default, which previously crashed
+        ``VulkanWorker.init_device`` -> ``set_random_seed`` on every startup.
+        vLLM's own CPU platform (`CpuPlatform.manual_seed_all`) is likewise a
+        no-op for the same reason.
+        """
+        pass
 
     # ─── vLLM config integration ─────────────────────────────────────────────
 

--- a/vllm_vulkan/worker.py
+++ b/vllm_vulkan/worker.py
@@ -35,6 +35,24 @@ class VulkanWorker(CPUWorker):
         from vllm.utils.torch_utils import set_random_seed
         from vllm.v1.worker.gpu_worker import init_worker_distributed_environment
 
+        # Re-apply the top-k/top-p Triton-CUDA guard here. It is also
+        # attempted from vllm_vulkan's plugin-registration entrypoint
+        # (vllm_vulkan.patches.apply_patches, called extremely early via
+        # vLLM's lazy `current_platform` resolution), but that is too early
+        # for `import vllm.v1.sample.ops.topk_topp_sampler` to succeed
+        # (vllm.config is still mid-import at that point), so it silently
+        # no-ops there. By the time init_device() runs, vLLM's module graph
+        # is fully loaded, so this is where the patch actually takes effect.
+        try:
+            from vllm_vulkan.patches import _patch_topk_topp_triton
+
+            _patch_topk_topp_triton()
+        except Exception:
+            logger.warning(
+                "Failed to apply top-k/top-p Triton-CUDA guard from init_device().",
+                exc_info=True,
+            )
+
         # ── library presence checks ───────────────────────────────────────
         def check_preloaded_libs(name: str) -> None:
             ld_preload_list = os.environ.get("LD_PRELOAD", "")


### PR DESCRIPTION
## Summary

`vllm serve <model>` (the README's own quickstart) crashed through a chain of
distinct bugs before ever generating a token, tested on real (non-mock, non-CI)
hardware: an NVIDIA GB10 (DGX Spark) with a genuinely working Vulkan ICD. All
of these turned out to be triggered by a vLLM CPU wheel whose `vllm._C`
extension *imports successfully* but doesn't register every op this plugin's
code paths assume is present — a case the existing `try: import vllm._C /
except ImportError` fallback pattern in `patches.py` didn't cover.

None of these are Vulkan-specific bugs — they're vLLM-CPU-platform
integration gaps that any out-of-tree CPU-device plugin would hit.

## Fixes, in the order they were hit during startup

1. **`torch.ops._C.init_cpu_memory_env`** — `CPUWorker.__init__` calls this
   unconditionally (before `VulkanWorker.init_device()` even runs) to bind
   the process to a NUMA node. Registers a no-op fallback via
   `torch.library` when the op isn't present.
2. **`VulkanPlatform.manual_seed_all()`** — the base `Platform` class raises
   `NotImplementedError`; `set_random_seed()` calls it unconditionally
   during `init_device()`. Implemented as a no-op, matching vLLM's own CPU
   platform.
3. **`VulkanPlatform.num_compute_units()`** — only CUDA/ROCm/XPU implement
   this upstream. The CPU-Triton top-k/top-p sampler calls it once batch
   size >= 8, and `triton` being merely *importable* (a normal transitive
   vLLM dependency) is enough to trigger that path. Returns `os.cpu_count()`,
   since the tensor this specific kernel touches lives on
   `torch.device("cpu")` regardless of Vulkan offload elsewhere.
4. **The Triton top-k/top-p kernel itself is CUDA-only** — even with (3)
   fixed, it launches through `triton.backends.nvidia.driver` and crashes on
   a CPU tensor (`ValueError: Pointer argument (at 0) cannot be accessed
   from Triton`). Forces the pure-PyTorch fallback by patching `HAS_TRITON`
   to `False` inside the already-imported sampler module — applied from
   `VulkanWorker.init_device()` rather than only at plugin-registration
   time, since the latter runs early enough to hit vLLM's own
   circular-import guard (`vllm.config` mid-import) and silently no-op.
5. **`compute_slot_mapping_kernel_impl`** — same root cause as (1), a
   different op. The existing `_patch_cpu_triton_utils` fallback only
   triggered when `import vllm._C` failed outright; now checks for the
   specific op via `hasattr()`.
6. **`VulkanPlatform.is_cpu()`** — the base implementation checks
   `self._enum == PlatformEnum.CPU`, which is `False` for out-of-tree
   plugins (`PlatformEnum.OOT`) even though this platform's `device_type` is
   `"cpu"`. Several vLLM call sites (e.g. the cumem sleep-mode allocator
   setup) gate CUDA/XPU-only features behind `is_cpu()` and, without this
   override, fall through to a real-allocator lookup that doesn't know
   about this platform. Implemented to return `True`.
7. **Noisy (harmless) shutdown crash** — `torch.accelerator.synchronize()`/
   `empty_cache()` are documented as no-ops when no accelerator is
   registered, but the implementation doesn't honor that for a CPU-only
   platform. Guarded both so a clean `LLM()` teardown or `vllm serve`
   Ctrl-C doesn't print a scary traceback after results have already been
   returned.

## Test suite

Also fixes 6 of 8 `test_vulkan_ops.py` failures observed when running the
suite against this real Vulkan device (the other 2 are pre-existing
CPU-vs-GPU performance-threshold assumptions tuned on different hardware,
unrelated to this PR, left as-is):

- `#83` (upload matvec/matmul weights as f16) legitimately loosens numerical
  precision. Verified directly: GPU output matches a CPU reference computed
  from the *same* f16-rounded weights to ~2e-4 — two orders of magnitude
  tighter than its gap from the fp32 reference used in the two affected
  tests' assertions. Loosened those two tolerances to match the observed
  f16 error bounds (still tight enough to catch a real dispatch/stride bug
  an order of magnitude larger).
- `#83` also added a second `_WeightCache` instance (caching the f16-safety
  decision per weight). The existing `upload_counter` test fixture patches
  `_WeightCache.put` at the class level, so it was counting both the real
  upload and this decision-cache's `put()`, turning "1 real upload" into a
  reported "2" for 4 other tests. Excluded the decision-cache from the
  count.

`python -m pytest tests/python -q` now passes 128/130 (the remaining 2 are
the pre-existing, unrelated hardware-tuning assumptions noted above).

## Testing

- Ran `vllm serve Qwen/Qwen3-0.6B --enforce-eager` end-to-end on an NVIDIA
  GB10 (DGX Spark) and confirmed correct, coherent completions via the
  OpenAI-compatible API, before and after these fixes (before: crash; after:
  correct output matching the CUDA backend's completions for the same
  prompt/seed).
- `python -m pytest tests/python -q`: 128 passed, 2 failed (pre-existing,
  unrelated -- see above).