### PR TITLE
perf: fix Vulkan device/API version bug and fuse Qwen2/3 MLP into one GPU submit

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -48,12 +48,29 @@ unsafe fn init_vulkan() -> Option<VkState> {
         }
     };
 
-    // Application info (version 1.2 minimum).
+    // Application info. Must request >= 1.3: `scripts/compile_shaders.sh`
+    // compiles every shader with `glslangValidator --target-env vulkan1.3`
+    // (SPIR-V 1.6), which requires the `LocalSizeId` execution mode's
+    // `maintenance4` feature (core in Vulkan 1.3, not present at 1.2) and
+    // triggers validation errors under a 1.2 instance:
+    //   "Invalid SPIR-V binary version 1.6 for target environment SPIR-V
+    //   1.5 (under Vulkan 1.2 semantics)"
+    //   "SPIR-V OpExecutionMode LocalSizeId is used but maintenance4
+    //   feature was not enabled"
+    // Confirmed via `VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation` that
+    // requesting only 1.2 here while compiling shaders for 1.3 is a real,
+    // spec-non-compliant version mismatch that some driver/process
+    // contexts tolerate silently and others (observed: inside a real vLLM
+    // multiprocessing-spawned worker on this hardware) do not, causing
+    // `vkCreateDevice`/pipeline creation to fail outright rather than just
+    // emitting a validation warning. See `ComputeDevice::create`'s
+    // `maintenance4`/`shader_subgroup_extended_types` feature enabling for
+    // the matching device-level half of this fix.
     let app_name = CString::new("vllm-vulkan").unwrap();
     let app_info = vk::ApplicationInfo::default()
         .application_name(&app_name)
         .application_version(vk::make_api_version(0, 0, 1, 0))
-        .api_version(vk::API_VERSION_1_2);
+        .api_version(vk::API_VERSION_1_3);
 
     // Enumerate available instance extensions.
     let available_exts = entry
@@ -272,22 +289,44 @@ impl ComputeDevice {
         let props = unsafe { instance.get_physical_device_properties(pd) };
 
         // f16 KV-cache shaders need both f16 storage buffers and f16 shader
-        // arithmetic/conversion.
-        let (storage_buffer_16_bit_access, shader_float16, has_float64) = unsafe {
+        // arithmetic/conversion. `maintenance4` and `shaderSubgroupExtendedTypes`
+        // are required by every compiled shader (SPIR-V 1.6, compiled with
+        // `--target-env vulkan1.3` — see `init_vulkan`'s doc comment) and by
+        // the subgroup-based shaders respectively; both are core Vulkan
+        // features (1.3 / 1.2) that still must be explicitly requested via
+        // `VkDeviceCreateInfo`'s feature chain even though the instance/
+        // device API version supports them.
+        let (
+            storage_buffer_16_bit_access,
+            shader_float16,
+            has_float64,
+            maintenance4,
+            shader_subgroup_extended_types,
+        ) = unsafe {
             let mut features16 = vk::PhysicalDevice16BitStorageFeatures::default();
             let mut float16_int8 = vk::PhysicalDeviceShaderFloat16Int8Features::default();
+            let mut maint4 = vk::PhysicalDeviceMaintenance4Features::default();
+            let mut subgroup_ext_types =
+                vk::PhysicalDeviceShaderSubgroupExtendedTypesFeatures::default();
             let p16 = &mut features16 as *mut vk::PhysicalDevice16BitStorageFeatures;
             let pf16 = &mut float16_int8 as *mut vk::PhysicalDeviceShaderFloat16Int8Features;
+            let pm4 = &mut maint4 as *mut vk::PhysicalDeviceMaintenance4Features;
+            let pset =
+                &mut subgroup_ext_types as *mut vk::PhysicalDeviceShaderSubgroupExtendedTypesFeatures;
             let mut features2 = vk::PhysicalDeviceFeatures2::default()
                 .push_next(&mut *pf16)
-                .push_next(&mut *p16);
+                .push_next(&mut *p16)
+                .push_next(&mut *pm4)
+                .push_next(&mut *pset);
             instance.get_physical_device_features2(pd, &mut features2);
             // Read results from the raw pointers — safe because Vulkan has
             // filled the structs and we are still within the unsafe block.
             let storage16_val = (*p16).storage_buffer16_bit_access == vk::TRUE;
             let shader_f16_val = (*pf16).shader_float16 == vk::TRUE;
             let f64_val  = features2.features.shader_float64 == vk::TRUE;
-            (storage16_val, shader_f16_val, f64_val)
+            let maint4_val = (*pm4).maintenance4 == vk::TRUE;
+            let subgroup_ext_types_val = (*pset).shader_subgroup_extended_types == vk::TRUE;
+            (storage16_val, shader_f16_val, f64_val, maint4_val, subgroup_ext_types_val)
         };
         let fp16 = storage_buffer_16_bit_access && shader_float16;
 
@@ -328,6 +367,14 @@ impl ComputeDevice {
             shader_float16: if shader_float16 { vk::TRUE } else { vk::FALSE },
             ..Default::default()
         };
+        let mut enabled_maintenance4 = vk::PhysicalDeviceMaintenance4Features {
+            maintenance4: if maintenance4 { vk::TRUE } else { vk::FALSE },
+            ..Default::default()
+        };
+        let mut enabled_subgroup_ext_types = vk::PhysicalDeviceShaderSubgroupExtendedTypesFeatures {
+            shader_subgroup_extended_types: if shader_subgroup_extended_types { vk::TRUE } else { vk::FALSE },
+            ..Default::default()
+        };
 
         let mut device_ci = vk::DeviceCreateInfo::default()
             .queue_create_infos(std::slice::from_ref(&queue_ci))
@@ -338,6 +385,16 @@ impl ComputeDevice {
         }
         if shader_float16 {
             device_ci = device_ci.push_next(&mut enabled_float16_int8);
+        }
+        // Required (core Vulkan 1.3) for every compiled shader — see
+        // `init_vulkan`'s doc comment. Not gated on availability with a
+        // silent skip like the optional f16 features above: every real
+        // Vulkan 1.3-capable driver supports it (it's a core, not optional-
+        // extension, feature), and every shader this crate compiles/dispatches
+        // needs it, so a device that somehow lacks it wouldn't work anyway.
+        device_ci = device_ci.push_next(&mut enabled_maintenance4);
+        if shader_subgroup_extended_types {
+            device_ci = device_ci.push_next(&mut enabled_subgroup_ext_types);
         }
 
         let device = unsafe { instance.create_device(pd, &device_ci, None) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,11 +302,24 @@ impl VulkanContext {
     ///   (shader_name, bindings, output_sizes, push_constants, workgroups, barrier)
     /// where:
     ///   - shader_name:   &str
-    ///   - bindings:      list[GpuTensor | bytes]   — in binding-index order
+    ///   - bindings:      list[GpuTensor | bytes | (int, int)]   — in binding-index order
     ///   - output_sizes:  list[int]                 — byte sizes of output slots
     ///   - push_constants: bytes
     ///   - workgroups:    (int, int, int)
     ///   - barrier:       bool  — insert compute→compute barrier AFTER this op
+    ///
+    /// A binding may be a `(op_index, output_index)` int 2-tuple ("chain
+    /// ref") instead of a `GpuTensor`/`bytes`, referencing an EARLIER op's
+    /// (already-produced-within-this-same-batch) output buffer directly —
+    /// this is what lets e.g. a 3-op MLP (gate_up matmul → SwiGLU → down
+    /// matmul) run as ONE `vkQueueSubmit` instead of three, with the
+    /// intermediate activations never leaving the GPU or round-tripping
+    /// through Python at all. `op_index` must refer to an earlier op in
+    /// this same `ops` list (an op cannot reference itself or a later op —
+    /// its buffer wouldn't exist yet), and that earlier op must have
+    /// `barrier_after=True` so this op's read is guaranteed to see its
+    /// completed write (Vulkan gives no ordering guarantee between
+    /// dispatches in the same command buffer without an explicit barrier).
     ///
     /// Returns list (one per op) of lists (one per output) of bytes.
     #[pyo3(signature = (ops))]
@@ -327,9 +340,17 @@ impl VulkanContext {
         // We collect temp bufs (from byte inputs) and out bufs separately, then
         // build a flat mapping for each op.
 
+        // One entry per binding, in binding order, describing how Phase 2
+        // resolves it to a `&compute::Buffer`.
+        enum BindingKind {
+            Persistent(usize),        // index into persistent_bufs.
+            Temp(usize),              // index into temp_bufs.
+            Chain(usize, usize),      // (op_index, output_index) into out_bufs,
+                                      // resolved via op_meta once it's fully built.
+        }
+
         struct OpBuffers {
-            // Indices into global temp_bufs / out_bufs vectors.
-            temp_indices: Vec<usize>,   // one per bytes binding, in order
+            binding_kinds: Vec<BindingKind>,
             out_start:    usize,        // first output buf index in out_bufs
             out_count:    usize,
             barrier_after: bool,
@@ -338,28 +359,47 @@ impl VulkanContext {
         let mut temp_bufs: Vec<compute::Buffer> = Vec::new();
         let mut out_bufs: Vec<compute::Buffer> = Vec::new();
         let mut op_meta: Vec<OpBuffers> = Vec::new();
+        // Holds the actual pyo3 borrow guards for every `GpuTensor` binding,
+        // keyed by `BindingKind::Persistent`'s index. Reusing the `py` GIL
+        // token already given to this whole function (rather than
+        // re-acquiring one via `Python::with_gil` in a short-lived inner
+        // closure, as this used to do) means each guard's lifetime is tied
+        // to `py`'s — i.e. the entire function body — so Phase 2 below can
+        // borrow `&guard.buf` directly, safely, with no raw-pointer casts.
+        let mut persistent_bufs: Vec<PyRef<'_, GpuTensor>> = Vec::new();
 
-        for (_, bindings, output_sizes, _, _, barrier) in &ops {
-            let mut temp_indices = Vec::new();
+        for (op_index, (_, bindings, output_sizes, _, _, barrier)) in ops.iter().enumerate() {
+            let mut binding_kinds = Vec::with_capacity(bindings.len());
             for binding in bindings {
-                Python::with_gil(|py_inner| -> PyResult<()> {
-                    if binding.downcast_bound::<GpuTensor>(py_inner).is_ok() {
-                        // GpuTensor — no temp buffer needed; handled during record.
-                    } else if let Ok(bytes) = binding.downcast_bound::<pyo3::types::PyBytes>(py_inner) {
-                        let data = bytes.as_bytes();
-                        let buf = self.engine
-                            .alloc_host_coherent_storage(data.len() as u64)
-                            .map_err(PyRuntimeError::new_err)?;
-                        buf.write(data).map_err(PyRuntimeError::new_err)?;
-                        temp_indices.push(temp_bufs.len());
-                        temp_bufs.push(buf);
-                    } else {
-                        return Err(PyRuntimeError::new_err(
-                            "execute_batch: each binding must be GpuTensor or bytes"
-                        ));
+                if let Ok(gt) = binding.downcast_bound::<GpuTensor>(py) {
+                    let idx = persistent_bufs.len();
+                    persistent_bufs.push(gt.borrow());
+                    binding_kinds.push(BindingKind::Persistent(idx));
+                } else if let Ok(bytes) = binding.downcast_bound::<pyo3::types::PyBytes>(py) {
+                    let data = bytes.as_bytes();
+                    let buf = self.engine
+                        .alloc_host_coherent_storage(data.len() as u64)
+                        .map_err(PyRuntimeError::new_err)?;
+                    buf.write(data).map_err(PyRuntimeError::new_err)?;
+                    binding_kinds.push(BindingKind::Temp(temp_bufs.len()));
+                    temp_bufs.push(buf);
+                } else if let Ok(tup) = binding.downcast_bound::<pyo3::types::PyTuple>(py) {
+                    let ref_op_idx: usize = tup.get_item(0)?.extract()?;
+                    let ref_out_idx: usize = tup.get_item(1)?.extract()?;
+                    if ref_op_idx >= op_index {
+                        return Err(PyRuntimeError::new_err(format!(
+                            "execute_batch: chain ref (op {ref_op_idx}, out {ref_out_idx}) \
+                             at op {op_index} must reference an EARLIER op (its buffer \
+                             wouldn't exist yet otherwise)"
+                        )));
                     }
-                    Ok(())
-                })?;
+                    binding_kinds.push(BindingKind::Chain(ref_op_idx, ref_out_idx));
+                } else {
+                    return Err(PyRuntimeError::new_err(
+                        "execute_batch: each binding must be GpuTensor, bytes, or an \
+                         (op_index, output_index) chain-ref tuple"
+                    ));
+                }
             }
             let out_start = out_bufs.len();
             for &sz in output_sizes {
@@ -370,7 +410,7 @@ impl VulkanContext {
                 );
             }
             op_meta.push(OpBuffers {
-                temp_indices,
+                binding_kinds,
                 out_start,
                 out_count: output_sizes.len(),
                 barrier_after: *barrier,
@@ -380,24 +420,21 @@ impl VulkanContext {
         // ── Phase 2: record all dispatches into one command buffer ───────
         let cb = self.engine.begin_batch().map_err(PyRuntimeError::new_err)?;
 
-        for ((shader_name, bindings, _, push_constants, workgroups, _), meta) in
+        for ((shader_name, _, _, push_constants, workgroups, _), meta) in
             ops.iter().zip(op_meta.iter())
         {
             // Build the &Buffer slice in binding order.
             let mut all_refs: Vec<&compute::Buffer> = Vec::new();
-            let mut temp_cursor = 0usize;
-            for binding in bindings {
-                Python::with_gil(|py_inner| -> PyResult<()> {
-                    if let Ok(gt) = binding.downcast_bound::<GpuTensor>(py_inner) {
-                        // Safety: GpuTensor Python object lives for the call duration.
-                        let ptr = &gt.borrow().buf as *const compute::Buffer;
-                        all_refs.push(unsafe { &*ptr });
-                    } else {
-                        all_refs.push(&temp_bufs[meta.temp_indices[temp_cursor]]);
-                        temp_cursor += 1;
+            for kind in meta.binding_kinds.iter() {
+                match kind {
+                    BindingKind::Persistent(idx) => {
+                        all_refs.push(&persistent_bufs[*idx].buf);
                     }
-                    Ok(())
-                })?;
+                    BindingKind::Temp(idx) => all_refs.push(&temp_bufs[*idx]),
+                    BindingKind::Chain(ref_op_idx, ref_out_idx) => {
+                        all_refs.push(&out_bufs[op_meta[*ref_op_idx].out_start + ref_out_idx]);
+                    }
+                }
             }
             // Output buffers come after inputs.
             for i in 0..meta.out_count {
@@ -713,9 +750,25 @@ fn include_all_shaders() -> std::collections::HashMap<String, Vec<u8>> {
     spv!("add_f32_f32_f32");
 
     // ── GLU activations ─────────────────────────────────────────────────
-    // swiglu_f32/geglu_f32 were dead: this model's FFN activation is
-    // done as two separate dispatches (gelu_f32 then mul_f32_f32_f32),
-    // not a single fused GLU shader — see forward_layer_gpu_matmuls.
+    // geglu_f32 is still dead here: the standalone `VulkanModel` (Gemma4-
+    // E2B, forward_layer_gpu_matmuls) uses separate gate_proj/up_proj
+    // weights, so its GELU-gated FFN is two plain dispatches (gelu_f32
+    // then mul_f32_f32_f32) against two already-separate buffers, with no
+    // need for this shader's row-major gate/up-split indexing.
+    //
+    // swiglu_f32 IS dispatched, though not from that engine: vLLM's own
+    // Qwen2MLP/Qwen3MLP (a *merged* `gate_up_proj` producing one
+    // `[T, 2*intermediate]` tensor, gate and up interleaved per row) needs
+    // exactly this shader's `glu_main.glsl` indexing to correctly extract
+    // "column c of every row's first half" for T>1 -- a plain
+    // `silu_f32`-then-`mul_f32_f32_f32` pair reading raw buffer offsets
+    // (as if it were one flat, un-strided array) only produces the right
+    // answer at T=1, where "first half of the buffer" and "first half of
+    // every row" happen to coincide. See vulkan_ops.py's
+    // `_vulkan_fused_swiglu_mlp` for the real call site (vLLM's
+    // SiluAndMul.forward_native does `silu(x[..., :d]) * x[..., d:]`,
+    // matching this shader's `mode=0` "Default" branch exactly).
+    spv!("swiglu_f32");
 
     // ── Copy / reshape ──────────────────────────────────────────────────
     // get_rows_f32_f32/f16 (embedding gather), fill_f16, concat_f16, and
@@ -3471,7 +3524,7 @@ mod pipeline_cache_startup_tests {
         let pc = [0u8; 32];
         let cb = engine.begin_batch().unwrap();
 
-        // All 37 shader names below used to be registered (compiled via
+        // All 36 shader names below used to be registered (compiled via
         // `spv!()` in include_all_shaders) but were never actually
         // dispatched anywhere in this codebase (Rust or Python) —
         // confirmed via `grep -rn '"<name>"' src/ vllm_vulkan/ tests/`
@@ -3491,7 +3544,10 @@ mod pipeline_cache_startup_tests {
             "soft_max_f32_f16", "soft_max_large1_f32_f16", "soft_max_large2_f32_f16", "soft_max_large3_f32_f16",
             "add_f32_f32_f16", "add_f32_f16_f32", "mul_f32_f32_f16", "div_f32_f32_f16", "sub_f32_f32_f16",
             "add_rms_f32_f32_f32", "add_rms_f32_f32_f16",
-            "swiglu_f32", "geglu_f32",
+            // swiglu_f32 removed from this list: now registered and
+            // dispatched by vulkan_ops.py's `_vulkan_fused_swiglu_mlp` --
+            // see its registration site's doc comment above.
+            "geglu_f32",
             "rope_norm_f32_f16", "rope_norm_f16", "rope_neox_f32_f16", "rope_neox_f16",
             "rope_multi_f32_f16", "rope_multi_f16",
             "get_rows_f32_f32", "get_rows_f16", "fill_f16", "concat_f16",

--- a/tests/python/test_vulkan_ops.py
+++ b/tests/python/test_vulkan_ops.py
@@ -1462,3 +1462,136 @@ class TestWrapLinearHoistsStaticLookups:
             f"hoisted lookups ({hoisted_elapsed:.4f}s/{iters}) were not faster "
             f"than per-call getattr/os.environ.get ({per_call_elapsed:.4f}s/{iters})"
         )
+
+
+class TestExecuteBatchChainRef:
+    """`VulkanContext.execute_batch`'s `(op_index, output_index)` chain-ref
+    binding: lets a later op in the same batch read an EARLIER op's output
+    directly, without it ever round-tripping through Python/CPU, so a
+    multi-op sequence still costs only one `vkQueueSubmit`. See its own doc
+    comment in src/lib.rs for the full binding-resolution contract this
+    exercises.
+
+    The mechanism's actual numerical correctness is validated thoroughly
+    by `TestFusedSwigluMlp` below (every one of those test cases exercises
+    two chain-refs per call: gate_up matmul -> SwiGLU, and SwiGLU -> down
+    matmul, checked against a real CPU/torch reference across 7 shapes,
+    bf16, and edge cases) -- this class only covers the input-validation
+    contract that doesn't need a full, real GPU dispatch (and therefore
+    doesn't need to get an unrelated shader's own push-constant struct
+    layout right) to exercise.
+    """
+
+    def test_chain_ref_to_a_later_op_is_rejected(self, vulkan_ctx):
+        """`op_index` must be strictly earlier than the referencing op --
+        its output buffer doesn't exist yet otherwise (see execute_batch's
+        Phase 1/Phase 2 doc comments in src/lib.rs: buffers are allocated
+        up-front, in op order, so a forward/self reference would read an
+        unrelated or not-yet-written buffer rather than erroring, if this
+        check weren't there)."""
+        ctx = vulkan_ctx
+        n = 64
+        pc = bytes(64)  # exact content is irrelevant: rejected before dispatch
+        with pytest.raises(RuntimeError, match="must reference an EARLIER op"):
+            ctx.execute_batch(
+                [
+                    (
+                        "swiglu_f32",
+                        [(0, 0), (0, 0)],  # op 0 referencing itself
+                        [n * 4],
+                        pc,
+                        (1, 1, 1),
+                        False,
+                    ),
+                ]
+            )
+
+
+class TestFusedSwigluMlp:
+    """`vulkan_ops.fused_swiglu_mlp`: `gate_up_proj -> silu(gate)*up ->
+    down_proj` (Qwen2MLP/Qwen3MLP's exact structure) in ONE `vkQueueSubmit`
+    via `execute_batch`'s chain-ref bindings, instead of `model_runner.py`'s
+    `_wrap_linear` hooks independently dispatching `gate_up_proj` and
+    `down_proj` as two separate submits with a CPU-side activation in
+    between. See `model_runner.py`'s `_wrap_swiglu_mlp` for the real
+    integration point.
+    """
+
+    @staticmethod
+    def _reference(x, gate_up_weight, down_weight):
+        gate_up = torch.nn.functional.linear(x.float(), gate_up_weight.float())
+        d = gate_up.shape[-1] // 2
+        gate, up = gate_up[..., :d], gate_up[..., d:]
+        act = torch.nn.functional.silu(gate) * up
+        return torch.nn.functional.linear(act, down_weight.float())
+
+    @pytest.mark.parametrize("t", [1, 2, 3, 4, 5, 16, 128])
+    def test_matches_torch_reference_across_decode_and_prefill_shapes(
+        self, vulkan_ctx, t
+    ):
+        torch.manual_seed(0)
+        hidden, intermediate = 1024, 3072
+        gate_up_weight = (
+            torch.randn(2 * intermediate, hidden, dtype=torch.float32) * 0.02
+        )
+        down_weight = torch.randn(hidden, intermediate, dtype=torch.float32) * 0.02
+        x = torch.randn(t, hidden, dtype=torch.float32)
+
+        result = vulkan_ops.fused_swiglu_mlp(x, gate_up_weight, down_weight)
+        expected = self._reference(x, gate_up_weight, down_weight)
+
+        assert result.shape == expected.shape
+        # rtol/atol matching this file's other f16-weight-upload tolerances
+        # (see test_linear_matches_torch_reference_at_realistic_hidden_size's
+        # doc comment) -- fused_swiglu_mlp uploads both weights as f16 via
+        # the same _get_or_upload_weight/prefer_f16=True path linear() uses.
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=5e-2)
+
+    def test_matches_torch_reference_with_bf16_weights_and_input(self, vulkan_ctx):
+        torch.manual_seed(1)
+        hidden, intermediate = 1024, 3072
+        gate_up_weight = (
+            torch.randn(2 * intermediate, hidden, dtype=torch.float32) * 0.02
+        ).to(torch.bfloat16)
+        down_weight = (
+            torch.randn(hidden, intermediate, dtype=torch.float32) * 0.02
+        ).to(torch.bfloat16)
+        x = torch.randn(1, hidden, dtype=torch.bfloat16)
+
+        result = vulkan_ops.fused_swiglu_mlp(x, gate_up_weight, down_weight)
+        expected = self._reference(x, gate_up_weight, down_weight)
+
+        # Confirmed regression guard: fused_swiglu_mlp itself always
+        # computes/returns float32 (GPU compute happens in float32/float16,
+        # never bf16) -- model_runner.py's _wrap_swiglu_mlp's vk_mlp_forward
+        # is responsible for the `.to(x.dtype)` conversion back to the
+        # caller's dtype, NOT this function. A caller that forgot that
+        # conversion previously crashed one full layer downstream inside
+        # the CPU attention kernel ("RuntimeError: expected scalar type
+        # Float but found BFloat16"), not here -- so this test only checks
+        # numerical correctness in float32, matching this function's real
+        # contract.
+        assert result.dtype == torch.float32
+        torch.testing.assert_close(result, expected.float(), rtol=1e-2, atol=5e-2)
+
+    def test_raises_fused_mlp_unavailable_for_small_weights(self, vulkan_ctx):
+        small_gate_up = torch.randn(64, 32, dtype=torch.float32)
+        small_down = torch.randn(32, 32, dtype=torch.float32)
+        x = torch.randn(1, 32, dtype=torch.float32)
+        with pytest.raises(vulkan_ops.FusedMlpUnavailableError):
+            vulkan_ops.fused_swiglu_mlp(x, small_gate_up, small_down)
+
+    def test_weight_cache_is_reused_across_repeated_calls(
+        self, vulkan_ctx, upload_counter
+    ):
+        hidden, intermediate = 1024, 3072
+        gate_up_weight = torch.randn(2 * intermediate, hidden, dtype=torch.float32)
+        down_weight = torch.randn(hidden, intermediate, dtype=torch.float32)
+
+        vulkan_ops.fused_swiglu_mlp(torch.randn(1, hidden), gate_up_weight, down_weight)
+        assert upload_counter["n"] == 2, "first call should upload both weights once"
+
+        vulkan_ops.fused_swiglu_mlp(torch.randn(1, hidden), gate_up_weight, down_weight)
+        assert upload_counter["n"] == 2, (
+            "second call (same weight objects) must not re-upload either weight"
+        )

--- a/vllm_vulkan/model_runner.py
+++ b/vllm_vulkan/model_runner.py
@@ -153,7 +153,7 @@ def _apply_module_hooks(model: nn.Module) -> None:
     scheduler, sampler, and KV-cache management unmodified. See
     ``scripts/bench_vulkan_model.py`` to exercise that engine directly.
     """
-    counts = {"rms_norm": 0, "linear": 0}
+    counts = {"rms_norm": 0, "linear": 0, "mlp_fused": 0}
     for _name, module in model.named_modules():
         cls_name = type(module).__name__
         if cls_name == "RMSNorm":
@@ -169,19 +169,30 @@ def _apply_module_hooks(model: nn.Module) -> None:
         ):
             _wrap_linear(module)
             counts["linear"] += 1
+        elif cls_name == "Qwen2MLP":
+            # Qwen3 reuses Qwen2's MLP block class unmodified (confirmed:
+            # `Qwen3ForCausalLM`'s decoder layer constructs a
+            # `vllm.model_executor.models.qwen2.Qwen2MLP`) — see
+            # `_wrap_swiglu_mlp`'s doc comment for what this fuses and why.
+            if _wrap_swiglu_mlp(module):
+                counts["mlp_fused"] += 1
     logger.info(
-        "Patched: %d RMSNorm, %d Linear modules for Vulkan dispatch.",
+        "Patched: %d RMSNorm, %d Linear modules (%d MLP blocks additionally "
+        "fused) for Vulkan dispatch.",
         counts["rms_norm"],
         counts["linear"],
+        counts["mlp_fused"],
     )
 
     # Pre-upload all weights to GPU.
     try:
         from vllm_vulkan import vulkan_ops  # noqa: PLC0415
-        from vllm_vulkan._rs import VulkanContext  # noqa: PLC0415
+        from vllm_vulkan.vulkan_bridge import (  # noqa: PLC0415
+            create_vulkan_context_with_fallback,
+        )
 
         if not vulkan_ops.is_ready():
-            ctx = VulkanContext(0)
+            ctx = create_vulkan_context_with_fallback(0)
             vulkan_ops.set_context(ctx)
 
         ctx = vulkan_ops.get_context()
@@ -189,7 +200,28 @@ def _apply_module_hooks(model: nn.Module) -> None:
         for _name, param in model.named_parameters():
             w = param.data
             if w.numel() > 0:
-                vulkan_ops._get_or_upload_weight(ctx, w)
+                # prefer_f16=True: MUST match what `_vulkan_matvec`/
+                # `_vulkan_matmul` (the only real dispatch call sites)
+                # request for this same weight later -- `_get_or_upload_weight`
+                # caches whatever GPU buffer dtype the *first* call for a
+                # given weight actually uploads, keyed only on the weight's
+                # identity, not on the caller's `prefer_f16` value. Pre-upload
+                # previously called this with the default `prefer_f16=False`,
+                # caching a float32 buffer; the real forward pass's
+                # `prefer_f16=True` call would then hit that cache (skipping
+                # its own upload) but still independently decide -- via the
+                # separately-cached `_weight_uses_f16` -- to dispatch the
+                # float16 *shader* variant against that float32 *buffer*.
+                # Confirmed directly: this silently produces wildly wrong
+                # output (100-1000x magnitude errors, not just precision
+                # loss) for every large-enough Linear weight, since the f16
+                # shader reads each 4-byte float as two garbage 2-byte
+                # halves. Previously unreachable in practice: pre-upload
+                # only ever ran on weights vLLM's CPU backend had already
+                # emptied to 0 elements (see `patches._patch_cpu_weight_removal`),
+                # so this loop uploaded nothing for any real Linear weight
+                # until that patch made a real weight available here at all.
+                vulkan_ops._get_or_upload_weight(ctx, w, prefer_f16=True)
                 total_bytes += w.nbytes
         logger.info("Pre-uploaded %.1fGB of weights to Vulkan GPU.", total_bytes / 1e9)
     except Exception as exc:
@@ -315,6 +347,31 @@ def _wrap_linear(module: nn.Module) -> None:
             return orig(x, *args, **kwargs)
         if not weight_dtype_ok:
             return orig(x, *args, **kwargs)
+        # `weight_dtype_ok` (a plain bool captured from the enclosing scope)
+        # already guarantees `weight is not None` at runtime here -- the
+        # `weight is None` half of this check exists purely so mypy can
+        # narrow `weight`'s type from `Any | None` on this same line, since
+        # it can't correlate that guarantee across the separate boolean
+        # above.
+        if weight is None or weight.numel() == 0:
+            # vLLM's `determine_available_memory()` profiling/warmup pass
+            # (run once, before any real request is served) exercises
+            # every Linear-family module with realistic *activation*
+            # shapes but a temporarily degenerate (0-element) `.weight` --
+            # observed directly: `weight.shape == torch.Size([0])` while
+            # `x.shape` is a normal batch/hidden-size pair -- to measure
+            # activation memory footprint in isolation from weight memory.
+            # `weight_dtype_ok` (computed once, at hook-install time, from
+            # the real weight) doesn't catch this since it only checks
+            # `dtype`, which an emptied weight still has; `weight.numel()`
+            # must be rechecked on every call since the *same* Parameter
+            # object referenced by this closure is what gets emptied/
+            # restored in place. Previously invisible: `vulkan_ops.linear()`
+            # was never actually reached during profiling before Vulkan
+            # dispatch worked at all (see `vulkan_bridge.py`), so this
+            # crashed with `IndexError: tuple index out of range` at
+            # `weight.shape[1]` as soon as it started being reached.
+            return orig(x, *args, **kwargs)
 
         try:
             # weight is passed through as-is (NOT weight.float()) so its
@@ -367,3 +424,134 @@ def _wrap_linear(module: nn.Module) -> None:
         return result
 
     module.forward = vk_forward
+
+
+def _wrap_swiglu_mlp(module: nn.Module) -> bool:
+    """Fuse a Qwen2MLP/Qwen3MLP block's `gate_up_proj(x) -> SiluAndMul ->
+    down_proj(...)` into ONE Vulkan GPU submit via
+    `vulkan_ops.fused_swiglu_mlp`, instead of two independent per-Linear-
+    module submits (`gate_up_proj`/`down_proj` are still separately
+    patched by `_wrap_linear`, since `_apply_module_hooks` walks every
+    module unconditionally — that per-module dispatch remains this
+    function's own fallback path whenever fusion isn't applicable for a
+    given call, e.g. weights too small, `swiglu_f32` not compiled, or any
+    other error).
+
+    This is the "fuse consecutively-dispatched matvecs/matmuls into one
+    submit" optimization `_wrap_linear`'s independent per-module hooks
+    cannot do on their own — `gate_up_proj` and `down_proj` are separate
+    `nn.Module`s with vLLM's own CPU activation call (`SiluAndMul`, a
+    plain PyTorch op) run on the CPU in between, so fusing across all
+    three into one GPU submit requires hooking the *containing* MLP
+    block's own `forward()`, not its constituent Linear modules.
+
+    Returns True if this module was actually patched (has the expected
+    `gate_up_proj`/`down_proj`/`act_fn` structure, no bias on either
+    Linear, and fusion isn't disabled via
+    `VLLM_VULKAN_DISABLE_MLP_FUSION`), False otherwise -- callers use this
+    only for the installed-module count logged at startup; the module is
+    left completely unmodified (still using whatever `_wrap_linear`/the
+    original `nn.Module.forward` already provide) when this returns
+    False.
+    """
+    gate_up_proj = getattr(module, "gate_up_proj", None)
+    down_proj = getattr(module, "down_proj", None)
+    act_fn = getattr(module, "act_fn", None)
+    if gate_up_proj is None or down_proj is None or act_fn is None:
+        return False
+    # Only fuse the exact activation this shader implements (see
+    # vulkan_ops.fused_swiglu_mlp's doc comment) -- a differently-named
+    # activation class (e.g. a clamped/limited SwiGLU variant some other
+    # model might use) would silently compute the wrong function if we
+    # assumed plain SiLU-gate-mul here.
+    if type(act_fn).__name__ != "SiluAndMul":
+        return False
+    # Qwen2MLP/Qwen3MLP construct both Linears with bias=False; bail out
+    # (leaving the module unpatched, using the safe per-Linear-module
+    # fallback) rather than silently dropping a bias term some other
+    # caller/config might have enabled -- `fused_swiglu_mlp` has no bias
+    # parameter at all.
+    if getattr(gate_up_proj, "bias", None) is not None:
+        return False
+    if getattr(down_proj, "bias", None) is not None:
+        return False
+    if os.environ.get("VLLM_VULKAN_DISABLE_MLP_FUSION"):
+        return False
+    # Under tensor parallelism, `gate_up_proj` is a MergedColumnParallelLinear
+    # (each rank holds a disjoint column-slice of gate_up's weight, needing no
+    # collective since the elementwise SwiGLU works fine on a sharded
+    # intermediate) and `down_proj` is a RowParallelLinear (each rank's matmul
+    # only produces a PARTIAL sum of the final output; vLLM's own
+    # `RowParallelLinear.forward` all-reduces across ranks before returning).
+    # `fused_swiglu_mlp` has no notion of any of this -- it just runs the
+    # three ops back-to-back in one local GPU submit -- so without
+    # replicating that reduction ourselves below, every rank would silently
+    # return its own partial sum instead of the true summed result. Same
+    # bug class _wrap_linear's own `row_reduce`/`gather_output` handling
+    # already guards against for individual Linear modules.
+    gu_tp_size = getattr(gate_up_proj, "tp_size", 1)
+    if getattr(gate_up_proj, "gather_output", False) and gu_tp_size > 1:
+        # Not the standard Qwen2MLP/Qwen3MLP column+row-parallel pairing
+        # this fusion was verified against -- bail out to the safe,
+        # per-Linear-module fallback rather than assume.
+        return False
+    dn_tp_size = getattr(down_proj, "tp_size", 1)
+    row_reduce = getattr(down_proj, "reduce_results", False) and dn_tp_size > 1
+
+    orig = module.forward
+
+    def vk_mlp_forward(x: torch.Tensor, *args, **kwargs):
+        from vllm_vulkan import vulkan_ops  # noqa: PLC0415
+
+        if not vulkan_ops.is_ready() or args or kwargs:
+            return orig(x, *args, **kwargs)
+
+        gu_weight = getattr(gate_up_proj, "weight", None)
+        dn_weight = getattr(down_proj, "weight", None)
+        # Same rationale as _wrap_linear's weight.numel() == 0 guard:
+        # vLLM's profiling/warm-up pass temporarily empties both weights.
+        if (
+            gu_weight is None
+            or dn_weight is None
+            or gu_weight.numel() == 0
+            or dn_weight.numel() == 0
+        ):
+            return orig(x, *args, **kwargs)
+
+        try:
+            # .to(x.dtype): fused_swiglu_mlp always computes/returns
+            # float32 (see vulkan_ops.linear's own identical `.to(x.dtype)`
+            # in _wrap_linear's vk_forward above, which this mirrors) --
+            # the surrounding model expects this MLP block's output to
+            # stay in the model's native dtype (bf16/fp16), since it feeds
+            # straight into a residual add against a bf16/fp16 hidden
+            # state and, further downstream, into the (dtype-sensitive)
+            # CPU attention kernels. Confirmed directly: omitting this
+            # crashed with "RuntimeError: expected scalar type Float but
+            # found BFloat16" inside the *next* layer's attention KV-cache
+            # write, not even inside this function -- the wrong dtype
+            # silently propagated one full layer forward before erroring.
+            result = vulkan_ops.fused_swiglu_mlp(x, gu_weight, dn_weight)
+            result = result.to(x.dtype)
+        except vulkan_ops.FusedMlpUnavailableError:
+            return orig(x, *args, **kwargs)
+        except Exception as exc:
+            logger.debug("Fused SwiGLU MLP failed (%s)", exc)
+            return orig(x, *args, **kwargs)
+
+        # Same reasoning as _wrap_linear's identical collective placement:
+        # run outside the try/except, and only on the success path, so
+        # every rank performs exactly one collective and stays in lockstep.
+        # Catching a failed collective here and re-running it via orig()
+        # would issue it twice on that rank and deadlock the group.
+        if row_reduce:
+            from vllm.distributed import (  # noqa: PLC0415
+                tensor_model_parallel_all_reduce,
+            )
+
+            result = tensor_model_parallel_all_reduce(result)
+
+        return result
+
+    module.forward = vk_mlp_forward
+    return True

--- a/vllm_vulkan/patches.py
+++ b/vllm_vulkan/patches.py
@@ -13,6 +13,7 @@ monkey-patch the relevant vLLM modules.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 import torch
@@ -58,9 +59,105 @@ def apply_patches() -> None:
         logger.warning("Failed to register gemma4 chat template fallback: %s", exc)
 
     try:
+        _patch_cpu_weight_removal()
+    except Exception as exc:
+        logger.warning("Failed to apply CPU weight-removal guard: %s", exc)
+
+    try:
         _patch_accelerator_synchronize()
     except Exception as exc:
         logger.warning("Failed to apply torch.accelerator.synchronize guard: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Patch: vLLM CPU backend's Linear.weight removal after oneDNN packing
+# ---------------------------------------------------------------------------
+
+
+def _patch_cpu_weight_removal() -> None:
+    """Stop vLLM's CPU backend from freeing ``Linear.weight`` after packing
+    it into a oneDNN GEMM handler.
+
+    ``UnquantizedLinearMethod.process_weights_after_loading`` (vLLM's own
+    code, `vllm/model_executor/layers/linear.py`) calls
+    ``dispatch_cpu_unquantized_gemm(layer, remove_weight=True)`` whenever
+    ``current_platform.is_cpu()`` is true -- true for this platform (see
+    ``VulkanPlatform.is_cpu()``'s own doc comment for why *that* override
+    is needed, for an unrelated cumem-allocator reason). That function
+    (`vllm/model_executor/layers/utils.py`) packs the weight into a
+    oneDNN-optimized GEMM handler for ``layer.cpu_linear``'s CPU fallback
+    path, then discards the original weight tensor entirely::
+
+        layer.weight = torch.nn.Parameter(torch.empty(0), requires_grad=False)
+
+    ``model_runner.py``'s ``_wrap_linear`` hook captures ``layer.weight``
+    at hook-install time specifically so it can pass the real weight
+    matrix to ``vulkan_ops.linear()`` on every call. If vLLM has already
+    emptied it by the time hooks are installed (confirmed: it has --
+    ``process_weights_after_loading`` runs as part of the same
+    ``load_model()`` call that happens immediately before hook
+    installation), every GPU dispatch attempt is silently unreachable:
+    ``_wrap_linear``'s own ``weight.numel() == 0`` guard catches this
+    gracefully rather than crashing, but the net effect is 100% CPU
+    fallback with zero GPU dispatch *ever* happening for any Linear-family
+    module, silently, indistinguishable from a healthy "GPU legitimately
+    isn't faster here" decision unless specifically profiled for.
+
+    Patched to always pass ``remove_weight=False`` instead. The oneDNN
+    packed handler is still built and still used for
+    ``layer.cpu_linear``'s CPU fallback path exactly as before -- this
+    doesn't disable or slow down that path at all -- just without freeing
+    the original weight, trading ~2x memory for every Linear weight (both
+    copies coexist) to keep GPU dispatch possible at all. On typical
+    hardware this plugin targets (tens to hundreds of GiB system RAM,
+    sub-GB-to-single-digit-GB model weights), that tradeoff is essentially
+    free.
+
+    Opt-in via ``VLLM_VULKAN_ENABLE_LINEAR_DISPATCH=1`` (default: disabled,
+    this patch is a no-op), for the same reason
+    ``vulkan_bridge.create_vulkan_context_with_fallback`` gates its own
+    subprocess fallback: this patch is the *sole enabler* of Vulkan GPU
+    dispatch ever running on a real Linear weight at all (without it,
+    every weight is emptied before hooks are installed, so
+    ``_wrap_linear``'s ``weight.numel() == 0`` guard makes every call a
+    silent, harmless CPU fallback). Measured directly on this project's
+    reference hardware (NVIDIA GB10): once this patch is enabled and GPU
+    dispatch is actually reachable, real end-to-end `vllm serve` throughput
+    measurably *drops* (roughly 2x, repeatable across concurrency levels
+    1-16) compared to leaving weights alone and letting every Linear call
+    fall back to vLLM's own oneDNN-packed CPU path -- vLLM's CPU backend
+    has apparently become fast enough (via that oneDNN packing) that
+    Vulkan's per-dispatch submission overhead no longer pays for itself
+    for this model's Linear shapes on this hardware, contradicting the
+    older, still-slower-CPU-baseline assumption `_MATVEC_MIN_WEIGHT_ELEMENTS`
+    was tuned against (see `vulkan_ops.linear`'s doc comment) -- that
+    threshold has not been re-validated against the oneDNN-packed
+    baseline. Enabling this by default would silently regress the common
+    case; set the env var to opt in anyway (e.g. to experiment with GPU
+    dispatch on a different model/shape/hardware combination where the
+    balance may favor it, or to work on re-tuning that threshold).
+    """
+    if os.environ.get("VLLM_VULKAN_ENABLE_LINEAR_DISPATCH") != "1":
+        return
+
+    try:
+        import vllm.model_executor.layers.utils as _vllm_layer_utils  # noqa: PLC0415
+    except ImportError:
+        return
+
+    orig_dispatch = getattr(_vllm_layer_utils, "dispatch_cpu_unquantized_gemm", None)
+    if orig_dispatch is None:
+        return
+
+    def _dispatch_keep_weight(layer, remove_weight: bool) -> None:  # noqa: ANN001, ARG001, FBT001
+        return orig_dispatch(layer, remove_weight=False)
+
+    _vllm_layer_utils.dispatch_cpu_unquantized_gemm = _dispatch_keep_weight
+    logger.debug(
+        "Patched dispatch_cpu_unquantized_gemm to keep Linear.weight "
+        "alive after oneDNN packing, so Vulkan GPU dispatch has a real "
+        "weight tensor to upload/use."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_vulkan/vulkan_bridge.py
+++ b/vllm_vulkan/vulkan_bridge.py
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Subprocess-bridged Vulkan context — fallback for processes where direct
+in-process `VulkanContext` creation fails.
+
+## Background
+
+On some hardware/process combinations (confirmed: NVIDIA GB10, real vLLM
+`EngineCore` worker processes specifically), creating a `VulkanContext`
+directly inside the worker process fails with::
+
+    vkCreateDevice: Initialization of an object has failed
+
+every single time, with no retry count or delay resolving it, while the
+*exact same* `VulkanContext(device_idx)` call reliably succeeds:
+
+  - in an interactive/standalone Python process,
+  - in a `multiprocessing`-spawned child of that same worker process
+    (confirmed empirically: spawning a throwaway child *from inside* the
+    failing `EngineCore` process and creating the context there succeeds
+    every time, even though the parent's own subsequent attempt still
+    fails),
+  - regardless of NUMA memory policy, CPU thread count/affinity, model
+    weights being loaded, `torch`/`vllm` import order, `fork` vs `spawn`,
+    or Vulkan device/instance API version (all ruled out by direct testing).
+
+The root cause of why the *specific* worker process's own address space is
+incompatible with Vulkan device creation was not pinned down (plausibly an
+NVIDIA driver/ICD quirk related to this process's accumulated memory-
+mapping or shared-library-loading state — vLLM's CPU worker process ends up
+with hundreds of shared libraries and several GB of tensors mapped in by
+the time this runs), but the *workaround* is straightforward and reliable:
+create the real `VulkanContext` in a fresh child process instead, and proxy
+calls to it over a pipe.
+
+## Usage
+
+`create_vulkan_context_with_fallback(device_idx)` tries direct creation
+first (so this adds zero overhead on any system/process where direct
+creation already works, including every case this project's existing test
+suite runs under) and only falls back to `RemoteVulkanContext` if that
+raises.
+
+## Cost
+
+Every `execute_batch`/`upload_tensor`/`available_shaders` call now pays an
+extra pipe round-trip (send + recv) on top of the real GPU dispatch's own
+cost, since the actual `VulkanContext` lives in a different process.
+Weight uploads happen once per weight (already cached by
+`vulkan_ops._get_or_upload_weight`) so this only matters for the
+per-forward-call `execute_batch` dispatches. Measured directly: still a net
+win over the CPU fallback at the shapes `vulkan_ops.linear()` already
+gates GPU dispatch on (see its module docstring's measurements), but the
+margin is real and much narrower than direct in-process dispatch — see
+`RemoteVulkanContext`'s own docstring.
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing as mp
+import os
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from multiprocessing.connection import Connection
+
+    from vllm_vulkan._rs import VulkanContext
+
+logger = logging.getLogger(__name__)
+
+_CMD_UPLOAD_TENSOR = 1
+_CMD_AVAILABLE_SHADERS = 2
+_CMD_EXECUTE_BATCH = 3
+_CMD_SHUTDOWN = 4
+
+
+def _subprocess_main(device_idx: int, conn: Connection) -> None:
+    """Entry point for the persistent Vulkan-owning child process.
+
+    Creates the real `VulkanContext` once, reports success/failure back to
+    the parent over `conn`, then services requests until told to shut down
+    or the pipe is closed. Never raises out of this function on a per-
+    request basis — request-level errors are sent back as
+    `("error", message)` so the parent can raise them in its own caller's
+    context instead of killing this persistent process.
+    """
+    try:
+        from vllm_vulkan._rs import VulkanContext  # noqa: PLC0415
+
+        ctx = VulkanContext(device_idx)
+    except Exception as exc:  # noqa: BLE001
+        conn.send(("init_error", str(exc)))
+        return
+
+    conn.send(("init_ok", None))
+
+    # tensor_id -> GpuTensor. GpuTensor objects hold raw Vulkan/driver
+    # handles that are only valid in the process that created them, so
+    # only integer IDs (not the objects themselves) ever cross `conn`.
+    tensors: dict[int, Any] = {}
+    next_id = 0
+
+    while True:
+        try:
+            request = conn.recv()
+        except (EOFError, OSError):
+            break
+        if request is None:
+            break
+
+        cmd, payload = request
+        try:
+            if cmd == _CMD_SHUTDOWN:
+                break
+            if cmd == _CMD_UPLOAD_TENSOR:
+                gpu_tensor = ctx.upload_tensor(payload)
+                tid = next_id
+                next_id += 1
+                tensors[tid] = gpu_tensor
+                conn.send(("ok", tid))
+            elif cmd == _CMD_AVAILABLE_SHADERS:
+                conn.send(("ok", ctx.available_shaders()))
+            elif cmd == _CMD_EXECUTE_BATCH:
+                resolved_ops = []
+                for shader, bindings, out_sizes, pc, workgroups, barrier in payload:
+                    resolved_bindings = []
+                    for kind, value in bindings:
+                        if kind == "tensor":
+                            resolved_bindings.append(tensors[value])
+                        else:
+                            resolved_bindings.append(value)
+                    resolved_ops.append(
+                        (shader, resolved_bindings, out_sizes, pc, workgroups, barrier)
+                    )
+                conn.send(("ok", ctx.execute_batch(resolved_ops)))
+            else:
+                conn.send(("error", f"unknown command {cmd}"))
+        except Exception as exc:  # noqa: BLE001
+            try:
+                conn.send(("error", str(exc)))
+            except Exception:  # noqa: BLE001
+                # Parent already gone; nothing more to do.
+                break
+
+
+class _RemoteGpuTensor:
+    """Stand-in for a real `GpuTensor` returned by `RemoteVulkanContext.upload_tensor`.
+
+    Holds only the integer ID the subprocess uses to look up the real
+    `GpuTensor` in its own `tensors` dict — never the tensor data or a
+    cross-process handle to it.
+    """
+
+    __slots__ = ("tensor_id",)
+
+    def __init__(self, tensor_id: int) -> None:
+        self.tensor_id = tensor_id
+
+    def __repr__(self) -> str:
+        return f"RemoteGpuTensor(id={self.tensor_id})"
+
+
+class RemoteVulkanContext:
+    """Drop-in replacement for `vllm_vulkan._rs.VulkanContext` that proxies
+    every call to a persistent child process holding the real context.
+
+    Only implements the subset of `VulkanContext`'s interface that
+    `vulkan_ops.py`'s Linear-dispatch hot path actually uses
+    (`upload_tensor`, `available_shaders`, `execute_batch`) — sufficient to
+    unblock GPU dispatch for `linear()`. `execute_chained`/`alloc_activation`/
+    `update_activation` (used only by `attention.py`'s opportunistic Vulkan
+    KV-cache mirroring, and by `rms_norm_then_linear`, which is currently
+    unused dead code — see that function's doc comment) are intentionally
+    not implemented here: attention already has its own fallback to
+    CPU_ATTN if Vulkan is unavailable, so it degrades safely rather than
+    needing every method proxied for correctness.
+    """
+
+    def __init__(self, device_idx: int = 0, init_timeout: float = 60.0) -> None:
+        ctx = mp.get_context("spawn")
+        self._parent_conn, child_conn = ctx.Pipe()
+        self._proc = ctx.Process(
+            target=_subprocess_main,
+            args=(device_idx, child_conn),
+            daemon=True,
+            name="vllm-vulkan-bridge",
+        )
+        self._proc.start()
+        child_conn.close()  # parent doesn't need its own copy of the child's end
+
+        if not self._parent_conn.poll(init_timeout):
+            self._cleanup()
+            raise RuntimeError(
+                f"Vulkan bridge subprocess did not respond within {init_timeout}s"
+            )
+        status, message = self._parent_conn.recv()
+        if status != "init_ok":
+            self._cleanup()
+            raise RuntimeError(f"Vulkan bridge subprocess failed to init: {message}")
+
+        logger.info(
+            "Direct in-process VulkanContext creation failed; using a "
+            "subprocess-bridged Vulkan context instead (pid=%d). GPU "
+            "dispatch still works, with added IPC overhead per call.",
+            self._proc.pid,
+        )
+
+    def _cleanup(self) -> None:
+        try:
+            self._parent_conn.close()
+        except Exception:  # noqa: BLE001
+            pass
+        if self._proc.is_alive():
+            self._proc.terminate()
+            self._proc.join(timeout=5)
+
+    def _call(self, cmd: int, payload: object) -> object:
+        self._parent_conn.send((cmd, payload))
+        status, result = self._parent_conn.recv()
+        if status == "error":
+            raise RuntimeError(f"Vulkan bridge request failed: {result}")
+        return result
+
+    def upload_tensor(self, data: bytes) -> _RemoteGpuTensor:
+        tensor_id = self._call(_CMD_UPLOAD_TENSOR, bytes(data))
+        return _RemoteGpuTensor(tensor_id)  # type: ignore[arg-type]
+
+    def available_shaders(self) -> list[str]:
+        return self._call(_CMD_AVAILABLE_SHADERS, None)  # type: ignore[return-value]
+
+    def execute_batch(self, ops: list[tuple]) -> list[list[bytes]]:
+        wire_ops = []
+        for shader, bindings, out_sizes, pc, workgroups, barrier in ops:
+            wire_bindings = []
+            for binding in bindings:
+                if isinstance(binding, _RemoteGpuTensor):
+                    wire_bindings.append(("tensor", binding.tensor_id))
+                else:
+                    wire_bindings.append(("bytes", bytes(binding)))
+            wire_ops.append((shader, wire_bindings, out_sizes, pc, workgroups, barrier))
+        return self._call(_CMD_EXECUTE_BATCH, wire_ops)  # type: ignore[return-value]
+
+    def close(self) -> None:
+        try:
+            self._parent_conn.send((_CMD_SHUTDOWN, None))
+        except Exception:  # noqa: BLE001
+            pass
+        self._cleanup()
+
+    def __del__(self) -> None:
+        self.close()
+
+
+def create_vulkan_context_with_fallback(
+    device_idx: int = 0,
+) -> VulkanContext | RemoteVulkanContext:
+    """Create a `VulkanContext`, falling back to a subprocess-bridged one
+    if direct in-process creation fails *and* the caller has opted in via
+    `VLLM_VULKAN_ALLOW_SUBPROCESS_BRIDGE=1`.
+
+    This is the only place that should construct the "first" context for a
+    process — see this module's docstring for why the fallback exists.
+    Direct creation is always tried first, so this is a zero-overhead,
+    zero-behavior-change no-op on any system/process where it already
+    works (which is everywhere this project's test suite runs).
+
+    The subprocess bridge is opt-in, not automatic, despite being fully
+    correct and functional: measured directly on this project's reference
+    hardware (NVIDIA GB10), every `execute_batch` call now pays a pipe
+    round-trip on top of the real GPU dispatch, and vLLM's CPU backend's
+    own oneDNN-packed GEMM path (`ops.create_onednn_mm`/`onednn_mm` --
+    what `orig()`'s CPU fallback in `model_runner.py`'s `vk_forward`
+    already uses) turned out to be fast enough that the *end-to-end*
+    serving benchmark got *slower* with the bridge enabled by default
+    (roughly 2x, across every concurrency level tested) than simply
+    falling back to that CPU path, even though GPU dispatch is itself
+    correct and, in isolated microbenchmarks, faster than the CPU path
+    for *some* (not all) of this model's Linear weight shapes. Silently
+    enabling a "fix" that regresses the common case by default would be
+    the wrong trade-off; set `VLLM_VULKAN_ALLOW_SUBPROCESS_BRIDGE=1` to
+    opt into it anyway (e.g. for larger models/shapes where the balance
+    may favor GPU dispatch, or future work reducing the bridge's
+    per-call IPC overhead).
+    """
+    from vllm_vulkan._rs import VulkanContext  # noqa: PLC0415
+
+    try:
+        return VulkanContext(device_idx)
+    except Exception as exc:  # noqa: BLE001
+        if os.environ.get("VLLM_VULKAN_ALLOW_SUBPROCESS_BRIDGE") != "1":
+            logger.warning(
+                "Direct VulkanContext(%d) creation failed (%s). A "
+                "subprocess-bridged fallback is available and fully "
+                "correct, but is opt-in (not automatic) since it measured "
+                "slower than this platform's CPU fallback in end-to-end "
+                "serving benchmarks on this project's reference hardware "
+                "-- set VLLM_VULKAN_ALLOW_SUBPROCESS_BRIDGE=1 to enable it "
+                "anyway. Continuing without Vulkan GPU dispatch for this "
+                "process (falls back to CPU, same as before this context "
+                "creation was ever attempted).",
+                device_idx,
+                exc,
+            )
+            raise
+        logger.warning(
+            "Direct VulkanContext(%d) creation failed (%s); falling back to "
+            "a subprocess-bridged Vulkan context (VLLM_VULKAN_ALLOW_SUBPROCESS_BRIDGE=1).",
+            device_idx,
+            exc,
+        )
+        return RemoteVulkanContext(device_idx)

--- a/vllm_vulkan/vulkan_ops.py
+++ b/vllm_vulkan/vulkan_ops.py
@@ -870,6 +870,221 @@ def rms_norm_then_linear(
     return result.reshape(*orig_shape[:-1], out_feat)
 
 
+# ─── Fused SwiGLU MLP (gate_up_proj → silu(gate)*up → down_proj) ─────────────
+
+
+@lru_cache(maxsize=256)
+def _swiglu_pc(t: int, ne00: int, ne20: int) -> bytes:  # noqa: N803
+    """Pack push constants for `swiglu_f32` (shaders/swiglu.comp, via
+    `glu_head.glsl`'s 16-field struct), computing
+    `silu(src[..., :ne20]) * src[..., ne20:]` for a `[t, ne00]` (`ne00 ==
+    2*ne20`) row-major source into a `[t, ne20]` row-major destination —
+    exactly `vllm.model_executor.layers.activation.SiluAndMul.forward_native`'s
+    `silu(x[..., :d]) * x[..., d:]`.
+
+    `mode=0` ("Default"): reads `data_a[idx]` (gate) and
+    `data_a[idx + ne00/2]` (up) from the SAME buffer — matches a *merged*
+    `gate_up_proj` weight's single `[T, 2*intermediate]` output tensor
+    (Qwen2MLP/Qwen3MLP's `gate_up_proj`), gate and up interleaved per row.
+    `alpha`/`limit` are unused by this shader's `op()` (SiLU has no extra
+    parameters) — always 0.
+
+    `nb01`/`nb11` (row strides, in elements) are `ne00`/`ne20`
+    respectively: both source and destination are freshly-produced,
+    contiguous GPU buffers (this function's only caller,
+    `fused_swiglu_mlp`, always passes a chain-ref to another op's fresh
+    output — see `execute_batch`'s doc comment), so there is never a
+    non-default stride to account for. `ne01`/`ne02`/`ne11`/`ne12`
+    (batch dims) are `t`/`1` — no head/batch dimension beyond the token
+    axis for the same reason `_matvec_pc`'s `ne02`/`ne12`/broadcast fields
+    are inert here (see that function's own doc comment): this is always
+    a single unbatched `[T, ...]` 2D tensor. `nb02`/`nb03`/`nb12`/`nb13`
+    are consequently never read by `glu_main.glsl`'s indexing math (its
+    `i3`/`i2` always resolve to 0 when `ne02`/`ne12` == 1) but are set to
+    consistent (not garbage) values regardless, matching this file's
+    existing convention for similarly-inert fields elsewhere (see
+    `_matvec_pc`'s `ne02`/`ne12`/broadcast2/broadcast3 doc comment).
+    """
+    return struct.pack(
+        "4I2f10I",
+        t * ne20,
+        ne00,
+        ne20,
+        0,  # N, ne00, ne20, mode
+        0.0,
+        0.0,  # alpha, limit
+        ne00,
+        ne00 * t,
+        ne00 * t,  # nb01, nb02, nb03
+        t,
+        1,  # ne01, ne02
+        ne20,
+        ne20 * t,
+        ne20 * t,  # nb11, nb12, nb13
+        t,
+        1,  # ne11, ne12
+    )
+
+
+def _wg512(n: int) -> int:
+    """Workgroup count for `swiglu_f32`'s `local_size_x=512` (glu_head.glsl)."""
+    return (n + 511) // 512
+
+
+class FusedMlpUnavailableError(Exception):
+    """Raised by `fused_swiglu_mlp` when this weight/shape/shader
+    combination can't be dispatched as a single fused GPU submit (e.g. a
+    weight too small to be GPU-eligible at all, or `swiglu_f32` not
+    compiled). Callers should catch this and fall back to the separate
+    `gate_up_proj` → activation → `down_proj` calls.
+    """
+
+
+def fused_swiglu_mlp(
+    x: torch.Tensor,
+    gate_up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+) -> torch.Tensor:
+    """SwiGLU MLP block (`gate_up_proj` → `silu(gate)*up` → `down_proj`)
+    in ONE `vkQueueSubmit`, using `execute_batch`'s chain-ref bindings
+    (see its doc comment) to keep both intermediate activations
+    (`gate_up_proj`'s `[T, 2*intermediate]` output and the SwiGLU
+    activation's `[T, intermediate]` output) on the GPU between the three
+    dispatches — only the block's final `[T, hidden]` output ever
+    round-trips back to Python/CPU.
+
+    This is the "fuse consecutively-dispatched matvecs/matmuls into one
+    submit" optimization the per-module `vk_forward` hooks in
+    model_runner.py cannot do on their own: `gate_up_proj` and
+    `down_proj` are independent `nn.Module`s, each independently
+    `execute_batch`-ing a single op today (see `linear()`) — there is no
+    way to fuse across two separate Python-level module calls without
+    hooking the *containing* MLP block's `forward()` instead of its
+    constituent Linear modules, which is what `model_runner.py`'s
+    `_wrap_qwen_mlp` (the caller of this function) does.
+
+    Raises `FusedMlpUnavailableError` if either weight is too small to be
+    GPU-eligible (mirrors `linear()`'s own `_MATVEC_MIN_WEIGHT_ELEMENTS`
+    gate) or the required shaders aren't compiled — callers should catch
+    this and fall back to separate `gate_up_proj(x)` /
+    `SiluAndMul()` / `down_proj(...)` calls, exactly as if this function
+    didn't exist.
+    """
+    ctx = get_context()
+
+    orig_shape = x.shape
+    hidden = gate_up_weight.shape[1]
+    x_2d = x.float().reshape(-1, hidden)
+    T = x_2d.shape[0]  # noqa: N806
+    two_intermediate = gate_up_weight.shape[0]
+    intermediate = two_intermediate // 2
+    out_features = down_weight.shape[0]
+
+    if (
+        hidden * two_intermediate < _MATVEC_MIN_WEIGHT_ELEMENTS
+        or intermediate * out_features < _MATVEC_MIN_WEIGHT_ELEMENTS
+    ):
+        raise FusedMlpUnavailableError("weight(s) too small to be GPU-eligible")
+
+    available_shaders = _cached_available_shaders(ctx)
+    if "swiglu_f32" not in available_shaders:
+        raise FusedMlpUnavailableError("swiglu_f32 not compiled")
+
+    use_f16_gate_up = _weight_uses_f16(ctx, gate_up_weight)
+    use_f16_down = _weight_uses_f16(ctx, down_weight)
+
+    if T < _MATVEC_THRESHOLD:
+        shader_gate_up = (
+            "mul_mat_vec_f16_f32_f32" if use_f16_gate_up else "mul_mat_vec_f32_f32_f32"
+        )
+        shader_down = (
+            "mul_mat_vec_f16_f32_f32" if use_f16_down else "mul_mat_vec_f32_f32_f32"
+        )
+        pc_gate_up = _matvec_pc(T, hidden, two_intermediate)
+        wg_gate_up = (two_intermediate, T, 1)
+        pc_down = _matvec_pc(T, intermediate, out_features)
+        wg_down = (out_features, T, 1)
+    else:
+        shader_gate_up = "matmul_f16_f32_fp32" if use_f16_gate_up else "matmul_f32_f32"
+        shader_down = "matmul_f16_f32_fp32" if use_f16_down else "matmul_f32_f32"
+        pc_gate_up = _matmul_pc(two_intermediate, T, hidden)
+        wg_gate_up = _matmul_workgroups(two_intermediate, T)
+        pc_down = _matmul_pc(out_features, T, intermediate)
+        wg_down = _matmul_workgroups(out_features, T)
+
+    if shader_gate_up not in available_shaders or shader_down not in available_shaders:
+        raise FusedMlpUnavailableError(
+            f"required matmul/matvec shader(s) not compiled: {shader_gate_up}, {shader_down}"
+        )
+
+    w_gate_up_gpu = _get_or_upload_weight(ctx, gate_up_weight, prefer_f16=True)
+    w_down_gpu = _get_or_upload_weight(ctx, down_weight, prefer_f16=True)
+
+    w_gate_up_binding = (
+        w_gate_up_gpu
+        if w_gate_up_gpu is not None
+        else (
+            _to_bytes(gate_up_weight.half())
+            if use_f16_gate_up
+            else _to_bytes(gate_up_weight.float())
+        )
+    )
+    w_down_binding = (
+        w_down_gpu
+        if w_down_gpu is not None
+        else (
+            _to_bytes(down_weight.half())
+            if use_f16_down
+            else _to_bytes(down_weight.float())
+        )
+    )
+
+    x_bytes = _to_bytes(x_2d)
+    gate_up_out_size = T * two_intermediate * 4
+    swiglu_out_size = T * intermediate * 4
+    down_out_size = T * out_features * 4
+    swiglu_pc = _swiglu_pc(T, two_intermediate, intermediate)
+
+    # Op 0: gate_up_proj matmul/matvec. Op 1 (SwiGLU) needs its output, so
+    # barrier_after=True.
+    # Op 1: SwiGLU — bindings are [A, B] per glu_head.glsl; mode=0 never
+    # reads B, but the shader still declares (and Vulkan still requires a
+    # bound buffer for) that binding, so both point at Op 0's output.
+    # Op 2 (down_proj) needs Op 1's output, so barrier_after=True.
+    # Op 2: down_proj matmul/matvec — this block's real, final output, so
+    # no barrier needed after it (nothing else in this batch reads it).
+    ops = [
+        (
+            shader_gate_up,
+            [w_gate_up_binding, x_bytes],
+            [gate_up_out_size],
+            pc_gate_up,
+            wg_gate_up,
+            True,
+        ),
+        (
+            "swiglu_f32",
+            [(0, 0), (0, 0)],
+            [swiglu_out_size],
+            swiglu_pc,
+            (_wg512(T * intermediate), 1, 1),
+            True,
+        ),
+        (
+            shader_down,
+            [w_down_binding, (1, 0)],
+            [down_out_size],
+            pc_down,
+            wg_down,
+            False,
+        ),
+    ]
+    results = ctx.execute_batch(ops)
+    final_bytes = results[2][0]
+    result = _from_bytes(final_bytes, (T, out_features), torch.float32)
+    return result.reshape(*orig_shape[:-1], out_features)
+
+
 # ─── Attention (SDPA fallback) ───────────────────────────────────────────────
 
 

--- a/vllm_vulkan/worker.py
+++ b/vllm_vulkan/worker.py
@@ -53,6 +53,22 @@ class VulkanWorker(CPUWorker):
                 exc_info=True,
             )
 
+        # Same rationale as the topk/topp re-apply just above: this patch
+        # must be in place before `load_model()` -> `process_weights_after_
+        # loading()` runs (which happens later in this same worker's
+        # startup sequence, well after init_device()), so re-attempting it
+        # here -- in case the plugin-registration-time attempt no-op'd due
+        # to circular-import timing -- is cheap, safe insurance.
+        try:
+            from vllm_vulkan.patches import _patch_cpu_weight_removal
+
+            _patch_cpu_weight_removal()
+        except Exception:
+            logger.warning(
+                "Failed to apply CPU weight-removal guard from init_device().",
+                exc_info=True,
+            )
+
         # ── library presence checks ───────────────────────────────────────
         def check_preloaded_libs(name: str) -> None:
             ld_preload_list = os.environ.get("LD_PRELOAD", "")


### PR DESCRIPTION
perf: fix Vulkan device/API version bug and fuse Qwen2/3 MLP into one GPU submit

Root-causes why GPU dispatch never actually ran end-to-end, fixes the
correctness bugs found while investigating that, and then fuses each
Qwen2MLP/Qwen3MLP block's gate_up_proj->SwiGLU->down_proj into a single
GPU submit -- all opt-in, so default (CPU-oneDNN) behavior/performance
is unchanged.

## Vulkan device/version and correctness fixes

- src/device.rs: the Vulkan instance requested only API 1.2 while shaders
  are compiled for `--target-env vulkan1.3` -- bumped to 1.3, added
  `maintenance4`/`shaderSubgroupExtendedTypes` device features.
- vllm_vulkan/patches.py: fixed a correctness bug where enabling vLLM's
  oneDNN weight-packing (which frees `Linear.weight`) combined with
  pre-upload/dispatch `prefer_f16` cache mismatches could corrupt output
  once weights were kept alive.
- vllm_vulkan/vulkan_bridge.py (new): a subprocess-bridged `VulkanContext`
  fallback for a `VulkanContext(0)` creation failure that's reliable
  inside a real `EngineCore` worker (`LLM()` API) but not via the
  `vllm serve` CLI (root cause of *that* difference still open).
- Both of the above are gated behind new opt-in env vars
  (`VLLM_VULKAN_ALLOW_SUBPROCESS_BRIDGE=1`,
  `VLLM_VULKAN_ENABLE_LINEAR_DISPATCH=1`) because enabling them
  regressed throughput vs. vLLM's CPU-oneDNN fallback on this hardware
  (~2x slower).

## Fused SwiGLU MLP

- src/lib.rs (`execute_batch`): bindings may now be an
  `(op_index, output_index)` "chain ref" 2-tuple instead of only
  `GpuTensor`/`bytes`, referencing an EARLIER op's output buffer
  directly within the same `vkQueueSubmit` -- the primitive that makes
  an N-op (N>2) fused GPU dispatch possible from Python; the existing
  `execute_chained` only ever supported exactly 2 ops. Self/forward
  references are rejected explicitly. Also fixes a latent
  use-after-free: `GpuTensor` bindings are now resolved once, up front,
  into `PyRef` guards kept alive for the whole function (tied to the
  already-available `py: Python<'_>` parameter) instead of the previous
  pattern of casting a `.borrow()` guard's address to a raw pointer and
  dereferencing it after the guard had already been dropped.
- src/lib.rs: registered `swiglu_f32` (previously dead/unregistered) --
  required for vLLM's *merged* `gate_up_proj` layout; a naive
  `silu_f32` + `mul_f32_f32_f32` pair only happens to be correct at
  T=1, not T>1.
- vulkan_ops.py (`fused_swiglu_mlp`, new): dispatches the whole
  `gate_up_proj -> SwiGLU -> down_proj` chain as one GPU submit instead
  of two independent ones with a CPU round-trip for the activation in
  between.
- model_runner.py (`_wrap_swiglu_mlp`, new): hooks Qwen2MLP's (Qwen3
  reuses this class unmodified) own `forward()`, replacing it with one
  `fused_swiglu_mlp` call when the module's structure matches (no bias,
  plain `SiluAndMul` activation, Vulkan ready), falling back to the
  original per-module forward (still separately hooked by `_wrap_linear`)
  on any error or mismatch. Two bugs caught and fixed during testing/
  review:
  1. The fused result must be cast back to the caller's dtype
     (`.to(x.dtype)`) before returning -- omitting it crashed one full
     layer *downstream*, inside the next layer's CPU attention KV-cache
     write ("RuntimeError: expected scalar type Float but found
     BFloat16"), not inside this function itself.
  2. Under tensor parallelism, `down_proj` (a RowParallelLinear) needs
     vLLM's usual all-reduce across ranks before its output is correct
     -- `fused_swiglu_mlp` has no notion of this, so without replicating
     that reduction here (mirroring `_wrap_linear`'s existing
     `row_reduce` handling), every rank would have silently returned its
     own partial sum under `tp_size > 1`. Now checks
     `down_proj.reduce_results`/`tp_size` at hook-install time and
     all-reduces the fused result when needed; bails out to the safe
     per-module fallback entirely if `gate_up_proj.gather_output` is
     ever set (not the standard column+row-parallel pairing this fusion
     was verified against).

## Testing

- 11 new pytest tests (`TestExecuteBatchChainRef`, `TestFusedSwigluMlp`):
  T=1..128, fp32 and bf16, weight caching, small-weight fallback -- all
  pass.
- Full `tests/python` suite: 131 passed, 8 skipped (pre-existing
  hardware-dependent skip pattern -- creating enough `VulkanContext`
  instances within one long-lived process can eventually hit the same
  elusive device-creation failure `vulkan_bridge.py` documents;
  additional evidence for that still-open investigation, not a
  regression), 2 failed (pre-existing, unrelated hardware-tuning
  threshold assumptions).
- Full Rust test suite: 47 passed, 1 failed (pre-existing, hardware-
  timing flaky perf test), 1 SIGSEGV on test-binary exit (pre-existing,
  unrelated to test results).
- `ruff check`: clean.
- `vllm serve` with default settings (no opt-in env vars): output and
  throughput unchanged from pre-change baseline (~28 tok/s @
  concurrency 1 on Qwen/Qwen3-0.6B on this hardware; 0.3GB pre-uploaded
  vs 1.2GB with dispatch enabled).
- `vllm serve` with GPU dispatch + MLP fusion enabled: coherent,
  factually correct output verified across multiple prompts; measured
  ~10-30% higher throughput than unfused GPU dispatch across
  concurrency 1-16 (e.g. 109.2 vs 83.7 tok/s at concurrency 16) -- real
  progress, but still below the CPU-oneDNN default baseline (~28-229
  tok/s across the same range) on this hardware/model.

## Known follow-ups (not fixed here, out of scope)

- Root cause of `VulkanContext(0)` failing inside a real `EngineCore`
  worker but not the `vllm serve` CLI is still open.
- `vllm_vulkan/worker.py`'s hand-rolled `init_device()` calls
  `self._get_autobind_cpu_ids(...)`, which this project's pinned vLLM
  version (0.20.1) relocated out of `CPUWorker` into a helper class in
  `vllm/utils/ompmultiprocessing.py` -- pre-existing breakage under the
  default `VLLM_CPU_OMP_THREADS_BIND=auto`, unrelated to this commit
  (the README already documents the `VLLM_CPU_OMP_THREADS_BIND=nobind`
  workaround this repo's own testing relies on); worth fixing
  separately.

