### PR TITLE
feat(shaders): quantized matvec + subgroup-attention shader library (upstream PR2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,59 @@ jobs:
         # The test binary embeds the interpreter; point it at the system Python.
         export PYTHONHOME="$(python3.12 -c 'import sys; print(sys.base_prefix)')"
         cargo test --no-default-features --features "multiple-pymethods" --lib
+
+    # lavapipe is Mesa's CPU Vulkan driver. With it selected the kernel
+    # conformance tests stop no-op'ing and actually dispatch the compiled
+    # SPIR-V, checking each quantized matvec against a CPU reference. The
+    # device-less run above stays as-is: it is what proves the graceful-skip
+    # path still works.
+    - name: Install Mesa lavapipe (software Vulkan device)
+      run: |
+        sudo apt-get install -y mesa-vulkan-drivers vulkan-tools
+        # The lavapipe ICD filename varies with Mesa packaging -- noble ships
+        # lvp_icd.x86_64.json while noble-updates ships lvp_icd.json -- and the
+        # directory differs across distros too. Discover it instead of pinning
+        # one spelling, and fail loudly (listing what IS installed) if absent,
+        # so this never degrades into a silently device-less run.
+        icd=$(find /usr/share/vulkan/icd.d /usr/lib/x86_64-linux-gnu/vulkan/icd.d \
+                -name 'lvp_icd*.json' 2>/dev/null | head -1)
+        if [ -z "$icd" ]; then
+          echo "::error::lavapipe ICD not found. Installed Vulkan ICDs:"
+          find /usr -name '*_icd*.json' 2>/dev/null | sed 's/^/  /'
+          exit 1
+        fi
+        echo "lavapipe ICD: $icd"
+        echo "VK_ICD_FILENAMES=$icd" >> "$GITHUB_ENV"
+        VK_ICD_FILENAMES="$icd" vulkaninfo --summary | head -40
+
+    - name: Run Rust tests against the software Vulkan device
+      env:
+        RUST_BACKTRACE: '1'
+      run: |
+        # VK_ICD_FILENAMES comes from the discovery step above via GITHUB_ENV.
+        export PYTHONHOME="$(python3.12 -c 'import sys; print(sys.base_prefix)')"
+        cargo test --no-default-features --features "multiple-pymethods" --lib -- --nocapture
+
+    # Structural validation of every compiled module. Complements the Rust
+    # reflection gates: spirv-val checks the module against the SPIR-V spec,
+    # while the reflection tests check it against the Rust dispatch contract
+    # (bindings, push-constant sizes) -- which spirv-val does not look at.
+    # The target-env must track scripts/compile_shaders.sh's --target-env.
+    - name: Validate compiled SPIR-V modules
+      run: |
+        set -euo pipefail
+        sudo apt-get install -y spirv-tools
+        mapfile -t mods < <(find target -type d -name spirv -path '*/vllm-vulkan-*/out/*' -exec find {} -name '*.spv' \;)
+        if [ "${#mods[@]}" -eq 0 ]; then
+          echo "::error::no compiled .spv modules found - did the build step run?"
+          exit 1
+        fi
+        fail=0
+        for m in "${mods[@]}"; do
+          if ! out=$(spirv-val --target-env vulkan1.3 "$m" 2>&1); then
+            echo "::error file=$m::spirv-val failed: $out"
+            fail=$((fail + 1))
+          fi
+        done
+        echo "spirv-val: ${#mods[@]} module(s) checked, $fail failure(s)"
+        [ "$fail" -eq 0 ]

--- a/scripts/compile_shaders.sh
+++ b/scripts/compile_shaders.sh
@@ -66,12 +66,24 @@ rm -f "${_probe}"
 
 FAILED=0
 TOTAL=0
+SKIPPED=0
 
 compile() {
   local out_stem="$1"; shift
   local src="$1";      shift
   local out="${OUT_DIR}/${out_stem}.spv"
   local actual_src="${SHADER_DIR}/${src}"
+
+  # Skip cleanly when the source shader isn't present. The crate is built as
+  # per-feature slices (foundation + one model at a time): each slice ships only
+  # the shaders it uses, so this one script can drive any slice — it compiles
+  # what's present and skips the rest (build.rs derives the registry from the
+  # compiled output, so a skipped shader is simply absent from the registry).
+  if [ ! -f "${actual_src}" ]; then
+    echo "skip (source absent): ${src}"
+    SKIPPED=$(( SKIPPED + 1 ))
+    return 0
+  fi
 
   TOTAL=$(( TOTAL + 1 ))
 
@@ -168,7 +180,7 @@ echo "=== Elementwise unary (f32→f32) ==="
 # silu/gelu etc. use generic_head.glsl — A_TYPE is defined by types.glsl which
 # is included after, so it resolves correctly without explicit A_TYPE. But pass
 # it anyway for safety on strict parsers.
-for op in silu gelu gelu_quick relu tanh exp sigmoid abs neg ceil; do
+for op in silu gelu gelu_quick relu relu2 tanh exp sigmoid abs neg ceil; do
   compile "${op}_f32" "${op}.comp" ${U_F32}
 done
 compile "gelu_inplace_f32" "gelu.comp" ${U_F32} INPLACE=1
@@ -176,14 +188,21 @@ compile "gelu_inplace_f32" "gelu.comp" ${U_F32} INPLACE=1
 # ── Elementwise binary ─────────────────────────────────────────────────────────
 echo ""
 echo "=== Elementwise binary ==="
-compile "add_f32_f32_f32" "add.comp"  DATA_A_F32=1 A_TYPE=float DATA_B_F32=1 B_TYPE=float D_TYPE=float FLOAT_TYPE=float RMS_NORM_ROPE_FUSION=0
+# NB: the _f32_f32_f32 binary variants are referenced by src/shaders.rs (spv!)
+# but were previously not compiled here — a full shader rebuild would then fail
+# the include_bytes! for the missing .spv. They are compiled below. add_f32_f32_f32
+# is also the residual-add kernel used by the fused GPU-resident Qwen layer.
+# (${BIN_F32} expands to the same flags upstream spelled out explicitly.)
+compile "add_f32_f32_f32" "add.comp"  ${BIN_F32}
 compile "add_f32_f32_f16" "add.comp"  DATA_A_F32=1 A_TYPE=float DATA_B_F32=1 B_TYPE=float D_TYPE=float16_t FLOAT_TYPE=float RMS_NORM_ROPE_FUSION=0
 compile "add_f32_f16_f32" "add.comp"  DATA_A_F32=1 A_TYPE=float DATA_B_F16=1 B_TYPE=float16_t D_TYPE=float FLOAT_TYPE=float RMS_NORM_ROPE_FUSION=0
 compile "add_rms_f32_f32_f32" "multi_add.comp" ${BIN_F32}
 compile "add_rms_f32_f32_f16" "multi_add.comp" DATA_A_F32=1 A_TYPE=float DATA_B_F32=1 B_TYPE=float D_TYPE=float16_t FLOAT_TYPE=float RMS_NORM_ROPE_FUSION=0
 compile "mul_f32_f32_f32" "mul.comp" ${BIN_F32}
 compile "mul_f32_f32_f16" "mul.comp" DATA_A_F32=1 A_TYPE=float DATA_B_F32=1 B_TYPE=float D_TYPE=float16_t FLOAT_TYPE=float RMS_NORM_ROPE_FUSION=0
+compile "div_f32_f32_f32" "div.comp" ${BIN_F32}
 compile "div_f32_f32_f16" "div.comp" DATA_A_F32=1 A_TYPE=float DATA_B_F32=1 B_TYPE=float D_TYPE=float16_t FLOAT_TYPE=float RMS_NORM_ROPE_FUSION=0
+compile "sub_f32_f32_f32" "sub.comp" ${BIN_F32}
 compile "sub_f32_f32_f16" "sub.comp" DATA_A_F32=1 A_TYPE=float DATA_B_F32=1 B_TYPE=float D_TYPE=float16_t FLOAT_TYPE=float RMS_NORM_ROPE_FUSION=0
 
 # ── Normalization ──────────────────────────────────────────────────────────────
@@ -210,6 +229,28 @@ echo "=== GLU activations ==="
 # glu_head.glsl uses A_TYPE for both inputs; D_TYPE for output. No B_TYPE.
 compile "swiglu_f32" "swiglu.comp" DATA_A_F32=1 A_TYPE=float D_TYPE=float FLOAT_TYPE=float RMS_NORM_ROPE_FUSION=0
 compile "geglu_f32"  "geglu.comp"  DATA_A_F32=1 A_TYPE=float D_TYPE=float FLOAT_TYPE=float RMS_NORM_ROPE_FUSION=0
+# DSV4 routed-expert SwiGLU with swiglu_limit clamp (silu(min(g,lim))*clamp(u,±lim),
+# no GPT-OSS +1). Class Plain; Split mode 2 (separate gate/up buffers).
+compile "dsv4_swiglu_clamp" "dsv4_swiglu_clamp.comp" DATA_A_F32=1 A_TYPE=float D_TYPE=float FLOAT_TYPE=float RMS_NORM_ROPE_FUSION=0
+# DSV4 manifold hyper-connection residual mix (self-contained; class Plain):
+# out[k] = post[k]*sublayer + Σ_j comb[j,k]*streams[j].
+compile "dsv4_hc_residual_mix" "dsv4_hc_residual_mix.comp"
+# DSV4 M2b resident single-token MLA eager-attention softmax (sink + sliding
+# window + compressed-KV block_bias + output-rope conjugate). Class Plain; one
+# wave64 workgroup per head. Oracle dsv4_gpu::attention_layer_decode softmax core.
+compile "dsv4_mla_softmax" "dsv4_mla_softmax.comp"
+
+# Laguna per-head softplus attention gate (self-contained; class Plain).
+compile "laguna_softplus_gate" "laguna_softplus_gate.comp"
+
+# Laguna GPU decode-SDPA over the resident K/V planes (subgroup, wave64-only;
+# skipped on non-64 devices in pipeline.rs, like paged_attn_decode_f32_sg).
+compile "laguna_gpu_sdpa" "laguna_gpu_sdpa.comp"
+
+# Laguna MoE router scoring + top-k on GPU (sigmoid + e_score_correction_bias +
+# gate matvec + serial top-k); reads back only the top-k idx+weights. Self-
+# contained; class Plain.
+compile "laguna_router" "laguna_router.comp"
 
 # ── RoPE ───────────────────────────────────────────────────────────────────────
 echo ""
@@ -217,6 +258,7 @@ echo "=== RoPE ==="
 compile "rope_norm_f32_f16" "rope_norm.comp" DATA_A_F32=1 A_TYPE=float  ROPE_D_TYPE=float16_t D_TYPE=float      FLOAT_TYPE=float      RMS_NORM_ROPE_FUSION=0
 compile "rope_norm_f16"     "rope_norm.comp" DATA_A_F16=1 A_TYPE=float16_t ROPE_D_TYPE=float16_t D_TYPE=float16_t FLOAT_TYPE=float16_t RMS_NORM_ROPE_FUSION=0
 compile "rope_neox_f32_f16" "rope_neox.comp" DATA_A_F32=1 A_TYPE=float  ROPE_D_TYPE=float16_t D_TYPE=float      FLOAT_TYPE=float      RMS_NORM_ROPE_FUSION=0
+compile "rope_neox_f32_f32" "rope_neox.comp" DATA_A_F32=1 A_TYPE=float  ROPE_D_TYPE=float      D_TYPE=float      FLOAT_TYPE=float      RMS_NORM_ROPE_FUSION=0
 compile "rope_neox_f16"     "rope_neox.comp" DATA_A_F16=1 A_TYPE=float16_t ROPE_D_TYPE=float16_t D_TYPE=float16_t FLOAT_TYPE=float16_t RMS_NORM_ROPE_FUSION=0
 compile "rope_multi_f32_f16" "rope_multi.comp" DATA_A_F32=1 A_TYPE=float  ROPE_D_TYPE=float16_t D_TYPE=float      FLOAT_TYPE=float      RMS_NORM_ROPE_FUSION=0
 compile "rope_multi_f16"     "rope_multi.comp" DATA_A_F16=1 A_TYPE=float16_t ROPE_D_TYPE=float16_t D_TYPE=float16_t FLOAT_TYPE=float16_t RMS_NORM_ROPE_FUSION=0
@@ -253,6 +295,10 @@ compile "mul_mat_vec_f32_f32_f32_subgroup" "mul_mat_vec.comp" \
   DATA_A_F32=1 A_TYPE=float DATA_B_F32=1 B_TYPE=float ${MMVEC_BASE} USE_SUBGROUP_ADD_NO_SHMEM=1
 compile "mul_mat_vec_f16_f32_f32" "mul_mat_vec.comp" \
   DATA_A_F16=1 A_TYPE=float16_t DATA_B_F32=1 B_TYPE=float ${MMVEC_BASE}
+# bf16 weight matvec (VLLM_VULKAN_QUANT=bf16): weights loaded raw bf16 (native
+# precision, no f32→f16 conversion churn on load). 2 bytes/weight like f16.
+compile "mul_mat_vec_bf16_f32_f32" "mul_mat_vec.comp" \
+  DATA_A_BF16=1 A_TYPE=uint16_t DATA_B_F32=1 B_TYPE=float ${MMVEC_BASE}
 compile "mul_mat_vec_f16_f32_f32_subgroup" "mul_mat_vec.comp" \
   DATA_A_F16=1 A_TYPE=float16_t DATA_B_F32=1 B_TYPE=float ${MMVEC_BASE} USE_SUBGROUP_ADD_NO_SHMEM=1
 
@@ -270,6 +316,279 @@ compile "mul_mat_vec_q8_0_f32_f32_subgroup"  "mul_mat_vecq.comp" DATA_A_Q8_0=1  
 compile "mul_mat_vec_iq4_nl_f32_f32" "mul_mat_vec.comp" DATA_A_IQ4_NL=1 \
   DATA_B_F32=1 B_TYPE=float B_TYPEV4=vec4 \
   D_TYPE=float FLOAT_TYPE=float FLOAT_TYPEV2=vec2 RMS_NORM_ROPE_FUSION=0
+# q8_0 DEQUANTIZE path (mul_mat_vec.comp, not the MMQ mul_mat_vecq.comp). The MMQ
+# variant above expects the activation vector pre-quantized to q8_1 (block_q8_1_x4)
+# on binding 1; our matvec dispatch uploads raw f32 activations, so we use the
+# dequantize kernel instead (reads f32 B directly, dequantizes the q8_0 weight via
+# get_dm/dequantize4). Needs B_TYPEV4 for the K_PER_ITER==8 vec4 B loads.
+compile "mul_mat_vec_q8_0deq_f32_f32" "mul_mat_vec.comp" DATA_A_Q8_0=1 \
+  DATA_B_F32=1 B_TYPE=float B_TYPEV4=vec4 \
+  D_TYPE=float FLOAT_TYPE=float FLOAT_TYPEV2=vec2 RMS_NORM_ROPE_FUSION=0
+
+# q4_0 dequantize kernel (VLLM_VULKAN_QUANT=q4_0): 4-bit weights, f32 activations.
+# ~4x less weight bandwidth/memory vs f16. Same dequant-kernel approach as q8_0deq.
+compile "mul_mat_vec_q4_0deq_f32_f32" "mul_mat_vec.comp" DATA_A_Q4_0=1 \
+  DATA_B_F32=1 B_TYPE=float B_TYPEV4=vec4 \
+  D_TYPE=float FLOAT_TYPE=float FLOAT_TYPEV2=vec2 RMS_NORM_ROPE_FUSION=0
+
+# q4_K dequantize kernel (VLLM_VULKAN_QUANT=q4_k): per-sub-block 6-bit scale+min
+# K-quant, much higher quality than q4_0 at the same ~4 bits. Uses the DEQUANT
+# kernel from mul_mat_vec.comp (reads f32 B, dequantizes the q4_K weight via the
+# DATA_A_Q4_K block in dequant_funcs.glsl: w = d*sc*q - dmin*m). NOT the
+# mul_mat_vec_q4_k.comp MMQ kernel (that wants quantized activations → all-zero).
+compile "mul_mat_vec_q4_kdeq_f32_f32" "mul_mat_vec.comp" DATA_A_Q4_K=1 \
+  DATA_B_F32=1 B_TYPE=float B_TYPEV4=vec4 \
+  D_TYPE=float FLOAT_TYPE=float FLOAT_TYPEV2=vec2 RMS_NORM_ROPE_FUSION=0
+
+# MLX-affine 4-bit dequantize matvec (VLLM_VULKAN_MLX_GPU=1). Dedicated shader
+# (mul_mat_vec_mlx4.comp), NOT mul_mat_vec.comp: MLX stores scales+biases in two
+# separate buffers (not GGUF blocks), so it can't express the affine layout. The
+# packed 4-bit weight (~1/8 of f32) stays resident on the GPU and is dequantized
+# per-matvec, letting the 27B fit one 16GB UMA node. Mirrors
+# model::dequantize_mlx_affine exactly. Uses the BLOCK_SIZE/NUM_ROWS spec
+# constants (compile_matvec), so no -D type defines are needed.
+compile "mul_mat_vec_mlx4_f32_f32" "mul_mat_vec_mlx4.comp"
+
+# f16-resident affine scales/biases variant (VLLM_VULKAN_MOE_F16_SCALES, default
+# OFF): identical kernel, but scales+biases are read as float16_t from a HALF-size
+# resident MoE buffer. This is the 122B-A10B PP-6 fit-enabler (−~1.2GB/stage of
+# expert-scale GTT) and a general MoE load-footprint win. f16 holds every in-range
+# bf16-sourced affine scale EXACTLY (10 vs 7 mantissa bits) -> bit-identical to the
+# f32 oracle; the host upload's exact round-trip guard rejects any out-of-range
+# tensor (keeps f32). Gets the same _r2/_r4/_r8 spec-constant siblings as the base.
+compile "mul_mat_vec_mlx4_f16scale_f32_f32" "mul_mat_vec_mlx4.comp" SCALE_F16=1
+
+# mlx4 word-granular affine-factored siblings (perf/matvec-batch-dispatch):
+# each thread owns whole 4-bit-packed word(s) instead of striding nibble-by-
+# nibble, cutting VMEM issue 8x/16x and factoring the affine (q*s+b)*x sum into
+# s*dot(q,x) + b*sum(x) so scale/bias load once per word(-pair) not per nibble.
+# See shaders/mul_mat_vec_mlx4_w8.comp / _w16.comp for the math writeup.
+compile "mul_mat_vec_mlx4w8_f32_f32"  "mul_mat_vec_mlx4_w8.comp"
+compile "mul_mat_vec_mlx4w16_f32_f32" "mul_mat_vec_mlx4_w16.comp"
+
+# w8sg: word-granular w8 load/dequant + subgroupAdd reduction (no LDS tree) for
+# single-subgroup workgroups (BLOCK_SIZE<=64 on wave64 GFX1013). 1850MHz-clock
+# re-sweep probe (registered but wired only where it clears the 25% decision
+# bar vs the wired v1 winner per dispatch shape — see IMPROVEMENTS.md history).
+compile "mul_mat_vec_mlx4w8sg_f32_f32" "mul_mat_vec_mlx4w8sg_f32_f32.comp"
+
+# repack: VALU-bound repack refactor (VLLM_VULKAN_MLX4_REPACK, default OFF) for
+# the DENSE decode mlx4 path (k%32==0). dwordx4 (uvec4) word-granular load = 32
+# nibbles/load, scale/bias ONCE per 32-elem chunk, fma-factored affine +
+# subgroupAdd reduction. Cuts the ~190-addr-VALU/16-unpack address-gen the
+# gfx1013 ISA probe found in v1 (mul_mat_vec_mlx4.comp bs512/r8). Packed layout
+# unchanged (contiguous-4-word-per-thread => coalescing order == existing order).
+compile "mul_mat_vec_mlx4repack_f32_f32" "mul_mat_vec_mlx4repack_f32_f32.comp"
+
+# repack + f16-RESIDENT scale (VLLM_VULKAN_MLX4_REPACK=1 AND VLLM_VULKAN_MOE_F16_SCALES=1).
+# The SCALE_F16 sibling of the repack twin above: same dwordx4/subgroupAdd repack
+# body, but the affine scales/biases are read float16_t (half the resident GTT —
+# the 122B-A10B PP-8 fit-enabler). Routes the MoE routed-expert f16scale branch of
+# matvec_mlx4_moe_variant_k OFF the address-gen-bound v1 f16scale kernel
+# (mul_mat_vec_mlx4_f16scale_f32_f32, bs512) onto the repack roofline for the
+# k>=1024/n>=1024 experts (122B gate/up k=3072 n=1024, down k=1024 n=3072). f16
+# holds bf16 scales EXACTLY in range -> argmax-exact vs the f32 twin + v1 oracle.
+compile "mul_mat_vec_mlx4repack_f16scale_f32_f32" "mul_mat_vec_mlx4repack_f32_f32.comp" SCALE_F16=1
+
+# repack EXPERT-BATCHED (VLLM_VULKAN_LING_MOE_BATCH, default OFF): the Ling MoE
+# decode dispatch-collapse lever. Same per-byte repack body, plus a per-expert
+# base lookup from a meta[] buffer (binding 5) + a 2D dispatch (gl_WorkGroupID.y
+# = expert). Collapses the 8-experts x {gate,up,down} = 24 tiny per-expert matvec
+# dispatches into 3 batched dispatches while keeping per-expert throughput at the
+# BW floor (the guardrail: batch THROUGH the repack kernel, not the v1 tree).
+compile "mul_mat_vec_mlx4repack_batched_f32_f32" "mul_mat_vec_mlx4repack_batched_f32_f32.comp"
+
+# DeepSeek-V4-Flash Phase 2a — 2-bit affine repack (routed experts, gs128, 84% of
+# model). The 2-bit twin of mlx4repack: dwordx4 (uvec4) = 64 codes/load, 16 codes
+# per u32 (word-aligned, byte-identical to model::dequantize_mlx_affine per_word=16),
+# scale/bias ONCE per 64-elem chunk (2 chunks/gs128 group), fma-affine + subgroupAdd.
+# k%64==0, packed base 16B-aligned (wpr=k/16 mult 4). Gate ARGMAX-EXACT vs the oracle.
+compile "mul_mat_vec_mlx2repack_f32_f32" "mul_mat_vec_mlx2repack_f32_f32.comp"
+
+# 2-bit EXPERT-BATCHED (Ling MoE dispatch-collapse primitive at 2-bit width): same
+# repack body + per-expert meta[] base lookup + 2D dispatch (WorkGroupID.y=expert).
+compile "mul_mat_vec_mlx2repack_batched_f32_f32" "mul_mat_vec_mlx2repack_batched_f32_f32.comp"
+
+# DeepSeek-V4-Flash Phase 2a — 6-bit CONTIGUOUS affine matvec (attn/MLA/DSA
+# indexer+compressor, gs128). 6-bit codes are a contiguous little-endian bitstream
+# crossing u32 boundaries (packed_cols = in*6/32). "3 words per 16 codes" scheme:
+# each thread unpacks 16 codes from 3 consecutive words with COMPILE-TIME-CONSTANT
+# shifts (only codes 5/10 straddle) => register-resident, no scratch. Ports the
+# model::dequantize_mlx_affine_bits 6-bit path to GLSL; gate ARGMAX-EXACT vs it.
+compile "mul_mat_vec_mlx6_f32_f32" "mul_mat_vec_mlx6_f32_f32.comp"
+
+# DeepSeek-V4-Flash Phase 2b — 8-bit gs64 affine matvec (shared_experts /
+# embed_tokens / lm_head). Aligned 4 codes/u32 (8 divides 32, no boundary cross);
+# dwordx4 = 16 codes/load, fma-factored affine, gs64 => chunks_per_group=4. First
+# REAL 8-bit MLX-affine matvec (mul_mat_vec_mlx4_w8 is a misnamed 4-bit). Gate
+# ARGMAX-EXACT vs model::dequantize_mlx_affine_bits (bits=8).
+compile "mul_mat_vec_mlx8_f32_f32" "mul_mat_vec_mlx8_f32_f32.comp"
+
+# DeepSeek-V4-Flash Phase 2b — Manifold Hyper-Connection (mHC) with the fp32
+# stability treatment the reference lacks (sanitize + max-factored RMSNorm + logit
+# clamp; exact linear Sinkhorn). One workgroup/token; proven in
+# scripts/dsv4/hc_stability.py (equivalence cos=1.0 + depth-finiteness).
+compile "dsv4_hyper_connection" "dsv4_hyper_connection.comp"
+
+# DeepSeek-V4-Flash Phase 2b — DSA Lightning-Indexer SCORE kernel (ReLU
+# head-weighted q·compressed_kv -> index_scores; the sparse-attention gate).
+# Ports the reference indexer score math; validated vs hc_dsa_oracle.py.
+compile "dsv4_dsa_index_score" "dsv4_dsa_index_score.comp"
+
+# DeepSeek-V4-Flash Phase 2d — DSA compressor-POOL + dual-RoPE(yarn θ=160000).
+# Ca/Cb two-series windowed lookback -> per-channel softmax-gate pool over the 2m
+# axis -> kv_norm RMSNorm -> interleaved dual-RoPE. Emits the post-RoPE
+# compressed_kv consumed by dsv4_dsa_index_score; validated vs hc_dsa_oracle.py
+# (DSA.compressed) through debug_dsv4_dsa_compress.
+compile "dsv4_dsa_compress" "dsv4_dsa_compress.comp"
+
+# DeepSeek-V4-Flash Phase 2e — DSA causal TOP-512 SELECT. Consumes the
+# index_scores from dsv4_dsa_index_score and emits the causal top-k(512) window
+# indices with the -1 sentinel (the sparse-attention candidate set). Rank-scatter
+# selection; set-match vs the host dsa_topk_causal mirror through
+# debug_dsv4_dsa_topk. Completes the DSA GPU trio (compress -> score -> select).
+compile "dsv4_dsa_topk" "dsv4_dsa_topk.comp"
+
+# NVFP4 (NVIDIA FP4 / modelopt W4A16) dequantize matvec (VLLM_VULKAN_NVFP4_GPU=1).
+# Like mlx4 but the 4-bit codes map through the E2M1 LUT (not a raw int) and the
+# per-block e4m3 scale * per-tensor f32 global are pre-folded into one f32 scale
+# buffer on upload — so no bias buffer and no in-shader e4m3/global. Packed 4-bit
+# weight stays resident (~1/4 of bf16). Mirrors model::dequantize_nvfp4.
+compile "mul_mat_vec_nvfp4_f32_f32" "mul_mat_vec_nvfp4.comp"
+
+# NVFP4 VALU-bound repack refactor (VLLM_VULKAN_NVFP4_REPACK, default OFF) for the
+# NVFP4 mlp/expert path (k%32==0, group_size=16). The nvfp4 twin of the mlx4
+# repack: dwordx4 (uvec4) word-granular load = 32 nibbles/load, folded f32 scale
+# ONCE per 16-elem group (2 groups/chunk), E2M1-LUT dot + subgroupAdd reduction.
+# Cuts the same ~190-addr-VALU/16-unpack address-gen the gfx1013 ISA probe found
+# in v1 (mul_mat_vec_nvfp4.comp). Packed layout unchanged (contiguous-4-word-per-
+# thread == existing row-major pack order). Lands e2e on the PP-resident NVFP4
+# fleet (nemotron-75B PP-5, gemma-31B, Laguna, Step-3.7, qwen-27B-NVFP4).
+compile "mul_mat_vec_nvfp4repack_f32_f32" "mul_mat_vec_nvfp4repack_f32_f32.comp"
+
+# NVFP4 repack + E4M3-RESIDENT scale variant (VLLM_VULKAN_NVFP4_REPACK=1 AND
+# VLLM_VULKAN_NVFP4_E4M3_SCALES=1). Same dwordx4/subgroupAdd repack, but the
+# per-group scale is the raw e4m3 byte (0.5 bits/param) decoded * f32 global
+# hoisted ONCE per chunk — stacks the >=150B footprint lever on the address-gen
+# win. Bit-exact vs the f32-fold repack (parenthesized global fold).
+compile "mul_mat_vec_nvfp4_e4m3repack_f32_f32" "mul_mat_vec_nvfp4_e4m3repack_f32_f32.comp"
+
+# NVFP4 E4M3-RESIDENT scale variant (VLLM_VULKAN_NVFP4_E4M3_SCALES=1). Keeps the
+# raw per-group e4m3 block scale resident (1 byte) + the per-tensor f32 global as
+# a push-constant, re-adding the e4m3 decode in-loop (0.5 bits/param vs the
+# f32-fold's 2.0). The >=150B NVFP4 OOM-vs-fit lever (6.0 -> 4.5 bits/param).
+# Same mul_mat_vec_ prefix -> build.rs classes it Matvec -> auto _r2/_r4/_r8.
+compile "mul_mat_vec_nvfp4_e4m3_f32_f32" "mul_mat_vec_nvfp4_e4m3.comp"
+
+# EXPERT-BATCHED e4m3 NVFP4 matvec (Laguna MoE CB-batch lever,
+# VLLM_VULKAN_LAGUNA_CBBATCH): computes one projection (gate/up/down) for ALL
+# routed experts in ONE dispatch (gl_WorkGroupID.y = expert slot; per-slice
+# offsets + per-tensor global read from a small meta buffer). BIT-EXACT with the
+# per-expert mul_mat_vec_nvfp4_e4m3 dispatches it replaces (identical
+# BLOCK_SIZE/NUM_ROWS spec constants + dequant + reduction). Same mul_mat_vec_
+# prefix -> build.rs classes it Matvec -> auto _r2/_r4/_r8.
+compile "mul_mat_vec_laguna_expb_e4m3_f32_f32" "mul_mat_vec_laguna_expb_e4m3.comp"
+
+# Genuine single-stream multi-column (NUM_COLS) matvec kernels for the
+# spec-decode Phase-0 batched-verify amortization microbench
+# (debug_matvec_cols_timing). Unlike the generic mul_mat_vec.comp base.glsl
+# _r*_c* path — which re-streams the weight per token-column — these load/
+# dequantize each weight element ONCE and reuse it across all NUM_COLS columns
+# (the f16/q8_0 siblings of mul_mat_vec_nvfp4.comp). Same BLOCK_SIZE/NUM_ROWS/
+# NUM_COLS spec constants; self-contained, no -D type defines. 2D workgroup
+# grid so n can exceed the 65535 one-dimension limit (lm_head n=131072).
+compile "mul_mat_vec_f16_cols"  "mul_mat_vec_f16_cols.comp"
+compile "mul_mat_vec_q8_0_cols" "mul_mat_vec_q8_0_cols.comp"
+# mlx4 4-bit DEQUANT-cols batched matvec (on-node ACO gate for the fleet's REAL
+# 4-bit weight format). Same single-stream design as q8_0_cols: unpack+affine-
+# dequantize each nibble ONCE and reuse the scalar across NUM_COLS token columns
+# (columns = inner loop), amortizing the weight read AND the nibble-unpack+affine
+# ALU across the batch. Minimal live state (only NUM_ROWS*NUM_COLS accumulators
+# cross the column loop) to stay LDS-bound and avoid the repack VGPR trap.
+# NUM_COLS=1 is byte-identical to mul_mat_vec_mlx4_f32_f32. Bindings match
+# mul_mat_vec_mlx4.comp: [packed, scales, biases, x, out].
+compile "mul_mat_vec_mlx4_cols" "mul_mat_vec_mlx4_cols.comp"
+
+# FP8-E4M3 (modelopt W8A16) dequantize matvec (VLLM_VULKAN_NVFP4_GPU=1, attention).
+# 1 byte/weight, per-tensor (or per-row) f32 scale kept in a scale buffer; the
+# 256-entry E4M3 LUT is baked in (proven == model::e4m3_to_f32). Same BLOCK_SIZE/
+# NUM_ROWS spec constants as nvfp4/mlx4, so no -D type defines.
+compile "mul_mat_vec_fp8_f32_f32" "mul_mat_vec_fp8.comp"
+
+# FP8-E4M3 fast variant (VLLM_VULKAN_FP8_FAST): arithmetic decode + vec4 loads
+# instead of the const-LUT gather + scalar byte loads above. Default OFF.
+compile "mul_mat_vec_fp8fast_f32_f32" "mul_mat_vec_fp8_fast.comp"
+
+# FP8-E4M3 subgroup-reduction twin (VLLM_VULKAN_FP8_REPACK): fp8_fast hot loop +
+# subgroupAdd reduction (no LDS barrier tree). Reduction-epilogue-only lever
+# (fp8 is not address-gen-bound per the s4rig ISA rig). Default OFF.
+compile "mul_mat_vec_fp8repack_f32_f32" "mul_mat_vec_fp8repack_f32_f32.comp"
+
+# ── Qwen3.6 GatedDeltaNet decode kernels (WS1b, VLLM_VULKAN_DN_GPU) ───────────
+# Plain-class shaders (fixed local_size, no spec constants, no -D defines):
+# depthwise conv1d step + SiLU with sliding-window state update; per-head Q/K
+# RMSNorm(no-weight) + inv-scale; per-value-head delta-rule recurrence + gated
+# RMSNorm. The conv/delta state stays GTT-resident between decode steps and the
+# whole deltanet block records into ONE command buffer
+# (qwen35_delta_net_gpu_fused).
+compile "q35_dn_conv_step" "q35_dn_conv_step.comp"
+compile "q35_gdn_qknorm"   "q35_gdn_qknorm.comp"
+compile "q35_gdn_step"     "q35_gdn_step.comp"
+# Kimi Phase-B / Block-2: KDA decode-step recurrence — q35_gdn_step with
+# per-KEY-CHANNEL decay (binding 3 = decay_in[nk*kd]) + sigmoid output gate.
+compile "kda_gdn_step"     "kda_gdn_step.comp"
+# Kimi decode lever #5: per-key-channel decay precompute (softplus/exp), moved
+# off the host into the fused KDA command buffer.
+compile "kda_decay"        "kda_decay.comp"
+# Ling decode Phase-3 (fused 1-CB KDA): the NEW-MATH glue variants for Ling's
+# safe_gate decay (lower_bound*sigmoid(exp(A_log)*fb)) and L2-norm qknorm
+# (scale-on-q-only), distinct from the Kimi kda_decay / q35_gdn_qknorm forms.
+compile "ling_kda_decay"   "ling_kda_decay.comp"
+compile "ling_kda_l2norm"  "ling_kda_l2norm.comp"
+# Phase-1 GPU MoE router (VLLM_VULKAN_LING_MOE_INDIRECT): grouped-topk scoring +
+# selection in one dispatch (adapted from laguna_router for Ling n_group=8/
+# topk_group=4). Emits top_k indices + weights; only the top-k is read back.
+compile "ling_moe_router"  "ling_moe_router.comp"
+# GPU meta-builder: consumes ling_moe_router top-k -> per-expert gather descriptors
+# (meta[] for gate/up/down) + routed scores, so the route->meta->matvec chain
+# records into one CB with no host index readback (VLLM_VULKAN_LING_MOE_INDIRECT).
+compile "ling_moe_meta"    "ling_moe_meta.comp"
+# WS3: MoE tail (score-weighted routed accumulate + sigmoid-gated shared add +
+# residual) in one dispatch, so the fused MoE CB writes the next hidden on-GPU.
+compile "q35_moe_accum"    "q35_moe_accum.comp"
+# Nemotron MoE-tail collapse (R1b): same routed-accumulate role as
+# q35_moe_accum but variable top_k (loop in-shader) instead of fixed top-8,
+# and latent-space output (fc2 projects to hidden separately).
+compile "nemotron_moe_accum" "nemotron_moe_accum.comp"
+# Laguna-S-2.1 MoE tail (VLLM_VULKAN_LAGUNA_GPU_ACCUM): top-10 score-weighted
+# routed accumulate + UNGATED shared add (NO sigmoid gate, unlike q35_moe_accum's
+# fixed top-8 sigmoid-gated shared) in one dispatch, so moe_token_1cb reads back
+# ONE [hidden] vector instead of the 10 routed down + shared down.
+compile "laguna_moe_accum" "laguna_moe_accum.comp"
+# CB-batch twin (VLLM_VULKAN_LAGUNA_CBBATCH): same top-10 accumulate but reads
+# the 10 routed down outputs from ONE concatenated [10*n] buffer (d[e*n+i])
+# instead of 10 bindings, matching the batched down projection. BIT-EXACT.
+compile "laguna_moe_accum_b" "laguna_moe_accum_b.comp"
+
+# Nemotron-H Mamba2 GPU SSD decode-scan (R2, VLLM_VULKAN_NEMOTRON_GPU_SCAN):
+# depthwise conv1d+SiLU (full-kern state row, unlike q35's split state) +
+# per-head SSD recurrence/gate + gated RMSNorm, ported verbatim from the CPU
+# reference in src/nemotron.rs. Plain-class (fixed local_size, no spec
+# constants), same geometry posture as the q35 GDN decode chain above.
+compile "nemotron_ssm_conv_step"   "nemotron_ssm_conv_step.comp"
+compile "nemotron_ssd_scan"        "nemotron_ssd_scan.comp"
+compile "nemotron_gated_rmsnorm"   "nemotron_gated_rmsnorm.comp"
+# Phase 3 (plan-epilogue-fused-moe-gemm.md §5): BATCHED, runtime-top_k variant
+# of the MoE tail for the grouped PREFILL path -- score-weighted routed combine
+# + sigmoid-gated shared add over all T tokens in one dispatch, so `down_out`
+# never leaves VRAM (readback 16384->2048 f/tok) and the host combine is gone.
+# Gather-reduce (no scatter) -> atomic-free + deterministic (cos=1.0).
+compile "q35_moe_accum_batched" "q35_moe_accum_batched.comp"
+# P1a (batched-prefill foundation): q35_gdn_step + an inner `for t in
+# 0..n_tokens` loop, state column register-resident across the loop — ONE
+# dispatch per linear layer instead of one per token. See
+# plan-batched-prefill.md §1c/§7 and debug_gdn_scan for the CPU-ref cos gate.
+compile "q35_gdn_scan"     "q35_gdn_scan.comp"
 
 # K-quant dedicated shaders. B_TYPEV2/V4 needed for packed buffer views.
 # FLOAT_TYPEV2 for local dm values: use vec2 (f32) not f16vec2, to avoid
@@ -302,6 +621,109 @@ compile "matmul_f32_f16_aligned" "mul_mm.comp" DATA_A_F32=1 DATA_B_F16=1 B_TYPE=
 compile "matmul_f32_f32"         "mul_mm.comp" DATA_A_F32=1 DATA_B_F32=1 B_TYPE=float     ${MM_F32} RMS_NORM_ROPE_FUSION=0
 compile "matmul_f32_f32_fp32"    "mul_mm.comp" DATA_A_F32=1 DATA_B_F32=1 B_TYPE=float     ${MM_F32} ACC_F32=1 RMS_NORM_ROPE_FUSION=0
 compile "matmul_f16_f32_fp32"    "mul_mm.comp" DATA_A_F16=1 DATA_B_F32=1 B_TYPE=float     ${MM_F32} ACC_F32=1 RMS_NORM_ROPE_FUSION=0
+
+# ── Design A: quantized tiled GEMM (PREFILL / M6 Mamba2) ────────────────────────
+# mul_mm.comp already dequantizes GGUF blocks into the f16 LDS `buf_a` tile ONCE
+# per streamed block (mul_mm_funcs.glsl::load_a_to_shmem: DATA_A_Q8_0 :119,
+# Q4_K :190, Q6_K :265), then the register-blocked MAC loop reuses that tile
+# across all BN output columns — the "dequant-to-LDS then f16-GEMM" that
+# amortizes weight read+dequant across N. It WINS at prefill N (many BN tiles
+# fill the machine); it is the WRONG tool for spec-decode N=T<=8 (occupancy-
+# starved ~18 GB/s — use Design C's column-batched matvec there instead).
+#
+# LOAD_VEC_A=4 is LOAD-BEARING (proven on perf/quant-batched-cols): it makes the
+# loader's per-thread `row` range over BK/LOAD_VEC_A=8 values, matching the
+# 8-value-per-thread `idx = pos_a + col*stride_a/LOAD_VEC_A + row` addressing in
+# mul_mm_funcs.glsl's DATA_A_Q8_0 branch. A_TYPE / A_TYPE_PACKED16 are supplied
+# by types.glsl from the DATA_A_* macro; the packed16 path needs no explicit
+# A_TYPE.
+#
+# ⚠ SCAFFOLD ONLY — these .spv are compiled + verified but INTENTIONALLY
+# UNREGISTERED (build.rs SKIP). The quant mul_mm path needs BK=32 (spec
+# constant_id 3, default 16 = "assumed 32 for a quant"), which the current f16
+# compile_mul_mm (src/pipeline.rs) does NOT set, and a quant-aware prefill
+# dispatch swap. Registering them through the f16 MulMm class would create a
+# BK=16 pipeline = wrong. Wiring (compile_mul_mm_quant + dispatch) is the
+# remaining GPU-gated work — see quant-batched-matmul-impl.md.
+compile "matmul_q8_0_f32_fp32" "mul_mm.comp" DATA_A_Q8_0=1 DATA_B_F32=1 B_TYPE=float \
+  ${MM_F32} ACC_F32=1 LOAD_VEC_A=4 RMS_NORM_ROPE_FUSION=0
+compile "matmul_q4_k_f32_fp32" "mul_mm.comp" DATA_A_Q4_K=1 DATA_B_F32=1 B_TYPE=float \
+  ${MM_F32} ACC_F32=1 LOAD_VEC_A=4 RMS_NORM_ROPE_FUSION=0
+compile "matmul_q6_k_f32_fp32" "mul_mm.comp" DATA_A_Q6_K=1 DATA_B_F32=1 B_TYPE=float \
+  ${MM_F32} ACC_F32=1 LOAD_VEC_A=4 RMS_NORM_ROPE_FUSION=0
+# GEMM campaign Phase 0 (mul_mm sweep-able variants; see IMPROVEMENTS.md /
+# the gemm-campaign plan). All three keep A=f16 (DATA_A_F16), B=f32
+# (DATA_B_F32) like the live matmul_f16_f32_fp32 -- only the arithmetic
+# (MM_F32 vs MM_F16) and the load path (ALIGNED) differ. BM/BN/WM/WN/WMITER/
+# TM/TN/WARP are all spec constants (mul_mm.comp constant_id 1/2/4/5/6/7/8/10),
+# so the sweep tool (debug_gemm_geometry) tries the whole tile/warp grid on
+# THESE SAME 4 SPIR-V without recompiling.
+#
+# _aligned fix (load-bearing, not just a flag flip): ALIGNED=1 alone leaves
+# LOAD_VEC_A/B at their #ifndef default of 1, which falls through to the
+# SAME unaligned 2x-scalar branch as the non-aligned build -- this is why the
+# in-tree matmul_f32_f16_aligned/matmul_f32_f32_fp32 aligned variants were
+# dead/unvalidated (never dispatched, and would have been no-ops even if
+# wired). Setting LOAD_VEC_A=8 LOAD_VEC_B=8 selects the true vec8-coalesced
+# branch in mul_mm_funcs.glsl -- but that branch also references a
+# `FLOAT_TYPEV8` macro that is NEVER DEFINED anywhere in this tree (only
+# FLOAT_TYPEV2/V4 are wired via MM_F32/MM_F16); it is dead upstream code that
+# would fail to compile as-is. Defining FLOAT_TYPEV8 here (mirroring
+# FLOAT_TYPEV4's f32/f16 split: mat2x4 / f16mat2x4) is what actually makes the
+# vec8 path buildable. B_TYPE must ALSO become mat2x4 (not float) for
+# LOAD_VEC_B=8: mul_mm.comp declares `buffer B { B_TYPE data_b[]; }` with no
+# separate vec4/vec8 view binding (unlike the matvec kernels' B_TYPEV4
+# convention), so the vec8 load `FLOAT_TYPEV8(data_b[idx])` requires the
+# buffer's own element type to already be a 2x4 matrix. Requires K % 8 == 0
+# (all live shapes are K multiples of 256 -- OK; enforced in the sweep tool).
+compile "matmul_f16_f32_fp32_aligned" "mul_mm.comp" DATA_A_F16=1 DATA_B_F32=1 \
+  B_TYPE=mat2x4 ${MM_F32} ACC_F32=1 ALIGNED=1 LOAD_VEC_A=8 LOAD_VEC_B=8 \
+  FLOAT_TYPEV8=mat2x4 RMS_NORM_ROPE_FUSION=0
+# f16 arithmetic (MM_F16 already sets ACC_TYPE=float -- f32 accumulate per the
+# plan), unaligned load path (2x-scalar, same as the live kernel).
+compile "matmul_f16_f32_f16" "mul_mm.comp" DATA_A_F16=1 DATA_B_F32=1 B_TYPE=float \
+  ${MM_F16} RMS_NORM_ROPE_FUSION=0
+# f16 arithmetic + ALIGNED vec8 loads (the "everything on" corner from the plan).
+compile "matmul_f16_f32_f16_aligned" "mul_mm.comp" DATA_A_F16=1 DATA_B_F32=1 \
+  B_TYPE=mat2x4 ${MM_F16} ALIGNED=1 LOAD_VEC_A=8 LOAD_VEC_B=8 \
+  FLOAT_TYPEV8=f16mat2x4 RMS_NORM_ROPE_FUSION=0
+
+# GEMM campaign Phase A (quantized batched matmul; see plan-quant-batched-
+# matmul.md): dequant-to-shmem `mul_mm` heads for quantized A already existed
+# source-side (mul_mm_funcs.glsl) but were compiled by NOTHING -- these are
+# the first quant `mul_mm` variants ever built. ACC_F32 for the tight
+# correctness gate (cos>=0.999). BK=32 is set via a spec constant at pipeline
+# creation (pipeline.rs::compile_mul_mm_quant*), not a compile-time -D, so it
+# is NOT listed here.
+#
+# A1 -- MLX-affine 4-bit dense (the production 4-bit path). No ggml block
+# struct backs this format (scale/bias live in separate Scales/Biases SSBOs,
+# bindings 3/4 -- see mul_mm.comp's DATA_A_MLX4 guard), so A_TYPE=uint (raw
+# packed nibble words) MUST be passed explicitly -- types.glsl has no
+# DATA_A_MLX4 branch to derive it. Same LOAD_VEC_A=4 addressing convention as
+# Q8_0 (see mul_mm_funcs.glsl's DATA_A_MLX4 branch doc-comment).
+compile "matmul_mlx4_f32_fp32" "mul_mm.comp" DATA_A_MLX4=1 A_TYPE=uint DATA_B_F32=1 B_TYPE=float \
+  ${MM_F32} ACC_F32=1 LOAD_VEC_A=4 RMS_NORM_ROPE_FUSION=0
+# B (Phase B) -- MLX-affine 4-bit GROUPED-expert GEMM (MUL_MAT_ID). Same dequant
+# head + LOAD_VEC_A=4 addressing as the dense mlx4 line above, but the
+# MUL_MAT_ID machinery (IDS/Counts bindings 3/4, per-workgroup expert scan,
+# in-shader B-gather + output scatter) batches the Qwen3.6 MoE routed experts:
+# one dispatch per gate/up/down over ALL routed (token,slot) pairs instead of
+# T*top_k per-token matvecs. Scales/Biases move to bindings 5/6 (3/4 are IDS/
+# Counts under MUL_MAT_ID). No MUL_MAT_ID_USE_SUBGROUPS -- the scalar data_ids
+# scan works on wave64; the subgroup-ballot variant is a deferred micro-opt.
+# Do NOT pass LOAD_VEC_B (batch-2 B path, matching the dense mlx4 line).
+compile "matmul_mlx4_id_f32_fp32" "mul_mm.comp" DATA_A_MLX4=1 MUL_MAT_ID=1 A_TYPE=uint DATA_B_F32=1 B_TYPE=float \
+  ${MM_F32} ACC_F32=1 LOAD_VEC_A=4 RMS_NORM_ROPE_FUSION=0
+# C (epilogue-fused MoE GEMM, plan-epilogue-fused-moe-gemm.md) -- gate+up
+# fused into ONE dispatch: a SECOND A-binding (up weight, bindings 7/8/9) +
+# a silu(gate)*up epilogue at the store (mul_mm.comp's MLX4_ID_GATEUP branch)
+# replace the separate gu_gate/gu_up buffers + the silu_f32/mul_f32_f32_f32
+# dispatches entirely. Same dequant head/LOAD_VEC_A=4 addressing as the base
+# matmul_mlx4_id_f32_fp32 line above; VLLM_VULKAN_MOE_GEMM_FUSED gates
+# whether qwen35_forward.rs ever selects this pipeline (default OFF).
+compile "matmul_mlx4_id_gateup_silu_f32_fp32" "mul_mm.comp" DATA_A_MLX4=1 MUL_MAT_ID=1 MLX4_ID_GATEUP=1 A_TYPE=uint DATA_B_F32=1 B_TYPE=float \
+  ${MM_F32} ACC_F32=1 LOAD_VEC_A=4 RMS_NORM_ROPE_FUSION=0
 
 # ── Flash attention ────────────────────────────────────────────────────────────
 echo ""
@@ -346,11 +768,22 @@ echo "=== Paged KV cache ==="
 compile "paged_kv_write_f16" "paged_kv_write_f16.comp"
 compile "paged_kv_write_f32" "paged_kv_write_f32.comp"
 compile "paged_attn_decode_f16" "paged_attn_decode_f16.comp"
-compile "paged_attn_decode_f16_coop" "paged_attn_decode_f16_coop.comp" BLOCK_SIZE=256
-compile "paged_attn_decode_f16_coop_512" "paged_attn_decode_f16_coop.comp" BLOCK_SIZE=512
+compile "paged_attn_decode_f16_coop" "paged_attn_decode_f16_coop.comp"
 compile "paged_attn_decode_f32" "paged_attn_decode_f32.comp"
-compile "paged_attn_decode_f32_coop" "paged_attn_decode_f32_coop.comp" BLOCK_SIZE=256
-compile "paged_attn_decode_f32_coop_512" "paged_attn_decode_f32_coop.comp" BLOCK_SIZE=512
+compile "paged_attn_decode_f32_coop" "paged_attn_decode_f32_coop.comp"
+# Fork's GFX1013 wave64 subgroup decode kernel (not in upstream); still
+# referenced by the fork's attn-kernel dispatch — keep it.
+compile "paged_attn_decode_f32_sg" "paged_attn_decode_f32_sg.comp"
+# item-4b: f16-KV counterpart of the _sg kernel above (the existing
+# paged_attn_decode_f16/_coop variants lack `window_start` and are the slow
+# scalar/tree-reduce dispatch shapes, so they can't back the resident
+# 1-CB/decode seam under VLLM_VULKAN_Q35_KV_F16).
+compile "paged_attn_decode_f16_sg" "paged_attn_decode_f16_sg.comp"
+# NB: upstream's BLOCK_SIZE=512 `_coop_512` decode variants (#56) are
+# perf-opts to the replaced Python paged-attention decode path; the fork's
+# Rust engine never dispatches them (no reference in src/), and its
+# `cutover_guard_registry_len` intentionally pins the lean shader set — so
+# they are deliberately NOT compiled here.
 
 # ── Summary ────────────────────────────────────────────────────────────────────
 echo ""
@@ -358,5 +791,13 @@ if [ "${FAILED}" -gt 0 ]; then
   echo "ERROR: ${FAILED}/${TOTAL} shaders failed to compile." >&2
   exit 1
 else
-  echo "OK: all ${TOTAL} shaders compiled to ${OUT_DIR}"
+  if [ "${SKIPPED}" -gt 0 ]; then
+    # Not an error: a feature slice ships only the shaders it uses, and the
+    # rest are skipped by design. Reported so a shader that goes missing by
+    # ACCIDENT (renamed file, typo'd entry) is visible in the build log rather
+    # than silently absent from the registry.
+    echo "OK: ${TOTAL} shaders compiled to ${OUT_DIR} (${SKIPPED} skipped: source not in this slice)"
+  else
+    echo "OK: all ${TOTAL} shaders compiled to ${OUT_DIR}"
+  fi
 fi

--- a/shaders/mul_mat_vec_f16_cols.comp
+++ b/shaders/mul_mat_vec_f16_cols.comp
@@ -1,0 +1,101 @@
+#version 450
+
+// F16 batched multi-column matrix-vector kernel (spec-decode "batched verify"
+// primitive). Computes, for each output row r in [0,n) and token-column c in
+// [0,NUM_COLS):  dst[c,r] = sum_{j=0..k} w[r,j] * x[c,j].
+//
+// The whole point vs the generic mul_mat_vec.comp (base.glsl) path: base.glsl's
+// iter() loops columns OUTER and loads/dequantizes the weight INSIDE that loop,
+// so the weight row is RE-STREAMED once per token-column -> ~linear T scaling,
+// zero amortization. Here each thread loads each weight element w[r,j] EXACTLY
+// ONCE and reuses it across all NUM_COLS columns (columns are the INNER loop),
+// so on BW-bound GFX1013 the extra verify tokens are nearly free. This is the
+// f16 sibling of mul_mat_vec_nvfp4.comp's multi-column path.
+//
+// Layout: weight [n,k] row-major (w[r*k+j], f16); activation [NUM_COLS,k]
+// row-major (x[c*k+j], f32); output [NUM_COLS,n] row-major (dst[c*n+r], f32) --
+// the same [T,k]->[T,n] convention as the nvfp4/q8_0 cols kernels.
+//
+// Rows are addressed via a LINEAR workgroup index across a 2D dispatch grid
+// (gl_WorkGroupID.x + gl_WorkGroupID.y*gl_NumWorkGroups.x) so n can exceed the
+// 65535 one-dimension workgroup limit (e.g. lm_head n=131072).
+//
+// Bindings: 0 = weight (f16), 1 = activation x (f32), 2 = output (f32).
+// Push constants: { uint ncols(=k); uint nrows(=n); }.
+// One workgroup handles NUM_ROWS rows; BLOCK_SIZE threads partition k.
+// NUM_ROWS*NUM_COLS<=8 keeps LDS (rows*cols*BLOCK_SIZE*4) <= 16 KB.
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 512;
+layout(constant_id = 1) const uint NUM_ROWS = 1;
+layout(constant_id = 2) const uint NUM_COLS = 1;
+
+layout(push_constant) uniform parameter {
+    uint ncols;  // k = in_features (contraction dim)
+    uint nrows;  // n = out_features
+} p;
+
+layout(binding = 0) readonly buffer W    { float16_t w[]; };
+layout(binding = 1) readonly buffer Activ { float x[];    };
+layout(binding = 2) writeonly buffer Dst { float dst[];   };
+
+shared float tmpsh[NUM_ROWS][NUM_COLS][BLOCK_SIZE];
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint wg_lin = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x;
+    const uint first_row = NUM_ROWS * wg_lin;
+    const uint k = p.ncols;
+
+    float temp[NUM_ROWS][NUM_COLS];
+    [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            temp[nr][c] = 0.0;
+        }
+    }
+
+    // Each thread walks columns j = tid, tid+BLOCK_SIZE, ... The weight element
+    // w[r,j] is read ONCE and reused across all NUM_COLS token columns.
+    for (uint j = tid; j < k; j += BLOCK_SIZE) {
+        [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+            const uint r = first_row + nr;
+            if (r >= p.nrows) { continue; }
+            const float wv = float(w[r * k + j]);
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                temp[nr][c] += wv * x[c * k + j];
+            }
+        }
+    }
+
+    [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            tmpsh[nr][c][tid] = temp[nr][c];
+        }
+    }
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    tmpsh[nr][c][tid] += tmpsh[nr][c][tid + s];
+                }
+            }
+        }
+        barrier();
+    }
+    if (tid == 0) {
+        [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+            const uint r = first_row + nr;
+            if (r < p.nrows) {
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    dst[c * p.nrows + r] = tmpsh[nr][c][0];
+                }
+            }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_fp8.comp
+++ b/shaders/mul_mat_vec_fp8.comp
@@ -1,0 +1,120 @@
+#version 450
+
+// FP8 (OCP E4M3 / modelopt W8A16) matrix-vector kernel for vllm-vulkan.
+//
+// Computes, for each output row r in [0, n):
+//   out[r] = sum_{j=0..k} ( kE4M3[ byte(w, r, j) ] * scale ) * x[j]
+// exactly mirroring model::dequantize_fp8. The weight is UNPACKED FP8-E4M3,
+// 1 byte per element, row-major [out, in]. `scale` is per-tensor (scalar,
+// broadcast) or per-output-row; selected by push-constant `scale_per_row`.
+// The 256-entry kE4M3 LUT is baked in and is PROVEN bit-equal to
+// model::e4m3_to_f32 for all 256 codes by fp8_shader_lut_matches_e4m3.
+//
+// Absolute-byte addressing: bi = r*k + j; word = bi>>2; shift = (bi&3)*8;
+// code = (word>>shift)&0xFF. Requires k%4==0 (each row word-aligned), asserted
+// host-side by matvec_fp8_pc. Reinterpret-as-uint mirrors mlx4/nvfp4 (no 8-bit
+// storage extension needed).
+//
+// Bindings (auto-numbered 0.. by record_to in buffer order):
+//   0 = packed weight  (uint[], FP8 bytes, 4 per u32)
+//   1 = scale          (float[], length 1 per-tensor OR n per-row)
+//   2 = activation x   (float[], length k)
+//   3 = output         (float[], length n)
+// Push constants: { uint ncols(=k); uint nrows(=n); uint scale_per_row(0|1);
+//                   uint packed_off; uint sb_off; }
+
+#extension GL_EXT_control_flow_attributes : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 512;
+layout(constant_id = 1) const uint NUM_ROWS = 1;
+
+layout(push_constant) uniform parameter {
+    uint ncols;         // k = in_features
+    uint nrows;         // n = out_features
+    uint scale_per_row; // 0 = per-tensor scalar (scale[sb_off]); 1 = per-row (scale[sb_off+r])
+    uint packed_off;    // base BYTE offset into the weight for this slice (0 for dense)
+    uint sb_off;        // base ELEMENT offset into scale[] (0 for dense)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uint   packed[]; };
+layout(binding = 1) readonly buffer Scales { float  scale[];  };
+layout(binding = 2) readonly buffer Activ  { float  x[];      };
+layout(binding = 3) writeonly buffer Dst   { float  dst[];    };
+
+shared float tmpsh[NUM_ROWS][BLOCK_SIZE];
+
+// E4M3 (1 sign, 4 exp bias-7, 3 mantissa) code -> value. Generated from
+// model::e4m3_to_f32 (subnormal man*2^-9; NaN code 0x7f/0xff -> 0). DO NOT EDIT
+// BY HAND — fp8_shader_lut_matches_e4m3 asserts this equals e4m3_to_f32 exactly.
+const float kE4M3[256] = float[256](
+    0.0, 0.001953125, 0.00390625, 0.005859375, 0.0078125, 0.009765625, 0.01171875, 0.013671875,
+    0.015625, 0.017578125, 0.01953125, 0.021484375, 0.0234375, 0.025390625, 0.02734375, 0.029296875,
+    0.03125, 0.03515625, 0.0390625, 0.04296875, 0.046875, 0.05078125, 0.0546875, 0.05859375,
+    0.0625, 0.0703125, 0.078125, 0.0859375, 0.09375, 0.1015625, 0.109375, 0.1171875,
+    0.125, 0.140625, 0.15625, 0.171875, 0.1875, 0.203125, 0.21875, 0.234375,
+    0.25, 0.28125, 0.3125, 0.34375, 0.375, 0.40625, 0.4375, 0.46875,
+    0.5, 0.5625, 0.625, 0.6875, 0.75, 0.8125, 0.875, 0.9375,
+    1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 1.875,
+    2.0, 2.25, 2.5, 2.75, 3.0, 3.25, 3.5, 3.75,
+    4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5,
+    8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+    16.0, 18.0, 20.0, 22.0, 24.0, 26.0, 28.0, 30.0,
+    32.0, 36.0, 40.0, 44.0, 48.0, 52.0, 56.0, 60.0,
+    64.0, 72.0, 80.0, 88.0, 96.0, 104.0, 112.0, 120.0,
+    128.0, 144.0, 160.0, 176.0, 192.0, 208.0, 224.0, 240.0,
+    256.0, 288.0, 320.0, 352.0, 384.0, 416.0, 448.0, 0.0,
+    -0.0, -0.001953125, -0.00390625, -0.005859375, -0.0078125, -0.009765625, -0.01171875, -0.013671875,
+    -0.015625, -0.017578125, -0.01953125, -0.021484375, -0.0234375, -0.025390625, -0.02734375, -0.029296875,
+    -0.03125, -0.03515625, -0.0390625, -0.04296875, -0.046875, -0.05078125, -0.0546875, -0.05859375,
+    -0.0625, -0.0703125, -0.078125, -0.0859375, -0.09375, -0.1015625, -0.109375, -0.1171875,
+    -0.125, -0.140625, -0.15625, -0.171875, -0.1875, -0.203125, -0.21875, -0.234375,
+    -0.25, -0.28125, -0.3125, -0.34375, -0.375, -0.40625, -0.4375, -0.46875,
+    -0.5, -0.5625, -0.625, -0.6875, -0.75, -0.8125, -0.875, -0.9375,
+    -1.0, -1.125, -1.25, -1.375, -1.5, -1.625, -1.75, -1.875,
+    -2.0, -2.25, -2.5, -2.75, -3.0, -3.25, -3.5, -3.75,
+    -4.0, -4.5, -5.0, -5.5, -6.0, -6.5, -7.0, -7.5,
+    -8.0, -9.0, -10.0, -11.0, -12.0, -13.0, -14.0, -15.0,
+    -16.0, -18.0, -20.0, -22.0, -24.0, -26.0, -28.0, -30.0,
+    -32.0, -36.0, -40.0, -44.0, -48.0, -52.0, -56.0, -60.0,
+    -64.0, -72.0, -80.0, -88.0, -96.0, -104.0, -112.0, -120.0,
+    -128.0, -144.0, -160.0, -176.0, -192.0, -208.0, -224.0, -240.0,
+    -256.0, -288.0, -320.0, -352.0, -384.0, -416.0, -448.0, -0.0
+);
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+    const uint k = p.ncols;
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint m = 0; m < NUM_ROWS; ++m) { temp[m] = 0.0; }
+
+    for (uint j = tid; j < k; j += BLOCK_SIZE) {
+        const float xv = x[j];
+        [[unroll]] for (uint m = 0; m < NUM_ROWS; ++m) {
+            const uint r = first_row + m;
+            if (r >= p.nrows) { continue; }
+            const uint bi = p.packed_off + r * k + j;      // absolute byte index
+            const uint code = (packed[bi >> 2u] >> ((bi & 3u) * 8u)) & 0xFFu;
+            const uint sidx = p.sb_off + (p.scale_per_row != 0u ? r : 0u);
+            temp[m] += kE4M3[code] * scale[sidx] * xv;
+        }
+    }
+
+    [[unroll]] for (uint m = 0; m < NUM_ROWS; ++m) { tmpsh[m][tid] = temp[m]; }
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            [[unroll]] for (uint m = 0; m < NUM_ROWS; ++m) { tmpsh[m][tid] += tmpsh[m][tid + s]; }
+        }
+        barrier();
+    }
+    if (tid == 0) {
+        [[unroll]] for (uint m = 0; m < NUM_ROWS; ++m) {
+            const uint r = first_row + m;
+            if (r < p.nrows) { dst[r] = tmpsh[m][0]; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_fp8_fast.comp
+++ b/shaders/mul_mat_vec_fp8_fast.comp
@@ -1,0 +1,110 @@
+#version 450
+
+// FP8 (OCP E4M3 / modelopt W8A16) matrix-vector kernel for vllm-vulkan — FAST
+// variant (VLLM_VULKAN_FP8_FAST): arithmetic decode + vec4 loads instead of
+// the 256-entry const-LUT gather + scalar byte loads in mul_mat_vec_fp8.comp.
+//
+// Computes, for each output row r in [0, n):
+//   out[r] = sum_{j=0..k} ( e4m3_decode( byte(w, r, j) ) * scale ) * x[j]
+// exactly mirroring model::dequantize_fp8. The weight is UNPACKED FP8-E4M3,
+// 1 byte per element, row-major [out, in]. `scale` is per-tensor (scalar,
+// broadcast) or per-output-row; selected by push-constant `scale_per_row`.
+//
+// Absolute-byte addressing: bi = r*k + j; word = bi>>2; shift = (bi&3)*8;
+// code = (word>>shift)&0xFF. Requires k%4==0 (each row word-aligned), asserted
+// host-side by matvec_fp8_pc. Reinterpret-as-uint mirrors mlx4/nvfp4 (no 8-bit
+// storage extension needed).
+//
+// This variant additionally requires packed_off%4==0 (word-aligned row start,
+// true for every real dispatch since packed_off is always 0 for dense fp8
+// matvecs — matvec_fp8_pc hardcodes it) so the hot loop can address whole
+// uint words (4 codes) and vec4-load 4 activations per iteration with no
+// tail/OOB handling.
+//
+// Bindings (auto-numbered 0.. by record_to in buffer order):
+//   0 = packed weight  (uint[], FP8 bytes, 4 per u32)
+//   1 = scale          (float[], length 1 per-tensor OR n per-row)
+//   2 = activation x   (float[], length k) — aliased as vec4[] (ActivV4)
+//   3 = output         (float[], length n)
+// Push constants: { uint ncols(=k); uint nrows(=n); uint scale_per_row(0|1);
+//                   uint packed_off; uint sb_off; }
+
+#extension GL_EXT_control_flow_attributes : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 512;
+layout(constant_id = 1) const uint NUM_ROWS = 1;
+
+layout(push_constant) uniform parameter {
+    uint ncols;         // k = in_features
+    uint nrows;         // n = out_features
+    uint scale_per_row; // 0 = per-tensor scalar (scale[sb_off]); 1 = per-row (scale[sb_off+r])
+    uint packed_off;    // base BYTE offset into the weight for this slice (0 for dense)
+    uint sb_off;        // base ELEMENT offset into scale[] (0 for dense)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uint   packed[]; };
+layout(binding = 1) readonly buffer Scales { float  scale[];  };
+layout(binding = 2) readonly buffer Activ   { float x[];   };
+layout(binding = 2) readonly buffer ActivV4 { vec4  xv4[]; };
+layout(binding = 3) writeonly buffer Dst   { float  dst[];    };
+
+shared float tmpsh[NUM_ROWS][BLOCK_SIZE];
+
+// E4M3 (1 sign / 4 exp bias-7 / 3 mant) -> f32, bit-exact vs model::e4m3_to_f32.
+float e4m3_decode(uint code) {
+    uint s = (code >> 7) & 1u;
+    uint e = (code >> 3) & 0xFu;
+    uint m =  code       & 0x7u;
+    float mag;
+    if (e == 0u) {
+        mag = float(m) * (1.0 / 512.0);          // subnormal (m==0 -> +0.0)
+    } else if (e == 0xFu && m == 7u) {
+        mag = 0.0;                                // NaN code -> 0 (ref parity)
+    } else {
+        mag = uintBitsToFloat(((e + 120u) << 23) | (m << 20));
+    }
+    return uintBitsToFloat(floatBitsToUint(mag) | (s << 31u));
+}
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+    const uint k = p.ncols;
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint m = 0; m < NUM_ROWS; ++m) { temp[m] = 0.0; }
+
+    const uint kw = k >> 2u;                 // words per row; k%4==0
+    for (uint wi = tid; wi < kw; wi += BLOCK_SIZE) {
+        const vec4 xv = xv4[wi];
+        [[unroll]] for (uint mrow = 0; mrow < NUM_ROWS; ++mrow) {
+            const uint r = first_row + mrow;
+            if (r >= p.nrows) { continue; }
+            const uint bi = p.packed_off + r * k + (wi << 2u);
+            const uint w  = packed[bi >> 2u];
+            const vec4 wv = vec4(e4m3_decode( w        & 0xFFu),
+                                 e4m3_decode((w >>  8u) & 0xFFu),
+                                 e4m3_decode((w >> 16u) & 0xFFu),
+                                 e4m3_decode((w >> 24u) & 0xFFu));
+            const uint sidx = p.sb_off + (p.scale_per_row != 0u ? r : 0u);
+            temp[mrow] += scale[sidx] * dot(wv, xv);
+        }
+    }
+
+    [[unroll]] for (uint m = 0; m < NUM_ROWS; ++m) { tmpsh[m][tid] = temp[m]; }
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            [[unroll]] for (uint m = 0; m < NUM_ROWS; ++m) { tmpsh[m][tid] += tmpsh[m][tid + s]; }
+        }
+        barrier();
+    }
+    if (tid == 0) {
+        [[unroll]] for (uint m = 0; m < NUM_ROWS; ++m) {
+            const uint r = first_row + m;
+            if (r < p.nrows) { dst[r] = tmpsh[m][0]; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_fp8repack_f32_f32.comp
+++ b/shaders/mul_mat_vec_fp8repack_f32_f32.comp
@@ -1,0 +1,129 @@
+#version 450
+
+// FP8 (OCP E4M3 / modelopt W8A16) matvec — VALU-refactor twin of
+// mul_mat_vec_fp8_fast.comp. Gated by VLLM_VULKAN_FP8_REPACK.
+//
+// UNLIKE the mlx4/nvfp4 repack twins, there is NO load repack here: the fp8
+// weight is 1 byte/element and the fast kernel ALREADY reads a whole uint word
+// (4 codes) per iteration, so its address-gen is already ~4x amortized (the
+// s4rig ISA rig confirms fp8_v1 addr_gen/unpack = 1.76, NOT address-gen-bound,
+// vs mlx4_v1's 20.11). The ONLY fp8 lever is the REDUCTION EPILOGUE: fp8_fast
+// still reduces through a shared[NUM_ROWS][BLOCK_SIZE] LDS log2(BLOCK) barrier
+// tree (~148-instr class epilogue + a 16KB-LDS-class occupancy cap at BLOCK=512).
+// This twin replaces it with the same per-row subgroupAdd reduction the mlx4/
+// nvfp4 repack twins use (no LDS + no barrier for BLOCK_SIZE<=64 = one wave64
+// subgroup on GFX1013; a tiny LDS combine only when BLOCK_SIZE spans >1 wave).
+// Estimate ~1.2-1.4x/op on the compute-bound nemotron FP8 attn matvecs (the
+// win scales with the epilogue's share, i.e. larger at small k / BLOCK=512).
+//
+// The hot loop (e4m3 arithmetic decode + uint-word load + dot4) is byte-for-byte
+// fp8_fast — same math, same accumulation order → cosine-invisible vs the fast
+// kernel (only the reduction reassociates across the subgroup, ~ULP; re-gate
+// argmax-exact on-node exactly as the mlx4/nvfp4 twins were).
+//
+// Bindings + push constants: identical to mul_mat_vec_fp8_fast.comp.
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+#extension GL_KHR_shader_subgroup_vote : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 64;
+layout(constant_id = 1) const uint NUM_ROWS = 1;
+
+layout(push_constant) uniform parameter {
+    uint ncols;         // k = in_features
+    uint nrows;         // n = out_features
+    uint scale_per_row; // 0 = per-tensor scalar (scale[sb_off]); 1 = per-row (scale[sb_off+r])
+    uint packed_off;    // base BYTE offset into the weight for this slice (0 for dense)
+    uint sb_off;        // base ELEMENT offset into scale[] (0 for dense)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uint   packed[]; };
+layout(binding = 1) readonly buffer Scales { float  scale[];  };
+layout(binding = 2) readonly buffer Activ   { float x[];   };
+layout(binding = 2) readonly buffer ActivV4 { vec4  xv4[]; };
+layout(binding = 3) writeonly buffer Dst   { float  dst[];    };
+
+// Cross-subgroup combine scratch (only touched when BLOCK_SIZE > subgroup size).
+shared float part[NUM_ROWS][16];
+
+// E4M3 (1 sign / 4 exp bias-7 / 3 mant) -> f32, bit-exact vs model::e4m3_to_f32
+// and mul_mat_vec_fp8_fast.comp::e4m3_decode.
+float e4m3_decode(uint code) {
+    uint s = (code >> 7) & 1u;
+    uint e = (code >> 3) & 0xFu;
+    uint m =  code       & 0x7u;
+    float mag;
+    if (e == 0u) {
+        mag = float(m) * (1.0 / 512.0);          // subnormal (m==0 -> +0.0)
+    } else if (e == 0xFu && m == 7u) {
+        mag = 0.0;                                // NaN code -> 0 (ref parity)
+    } else {
+        mag = uintBitsToFloat(((e + 120u) << 23) | (m << 20));
+    }
+    return uintBitsToFloat(floatBitsToUint(mag) | (s << 31u));
+}
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+    const uint k = p.ncols;
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint m = 0; m < NUM_ROWS; ++m) { temp[m] = 0.0; }
+
+    const uint kw = k >> 2u;                 // words per row; k%4==0
+    for (uint wi = tid; wi < kw; wi += BLOCK_SIZE) {
+        const vec4 xv = xv4[wi];
+        [[unroll]] for (uint mrow = 0; mrow < NUM_ROWS; ++mrow) {
+            const uint r = first_row + mrow;
+            if (r >= p.nrows) { continue; }
+            const uint bi = p.packed_off + r * k + (wi << 2u);
+            const uint w  = packed[bi >> 2u];
+            const vec4 wv = vec4(e4m3_decode( w        & 0xFFu),
+                                 e4m3_decode((w >>  8u) & 0xFFu),
+                                 e4m3_decode((w >> 16u) & 0xFFu),
+                                 e4m3_decode((w >> 24u) & 0xFFu));
+            const uint sidx = p.sb_off + (p.scale_per_row != 0u ? r : 0u);
+            temp[mrow] += scale[sidx] * dot(wv, xv);
+        }
+    }
+
+    // Reduce each row across the subgroup (replaces fp8_fast's LDS barrier tree).
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = subgroupAdd(temp[n]);
+    }
+
+    // Single-subgroup workgroup (BLOCK_SIZE<=64, the target): lane 0 writes.
+    if (gl_NumSubgroups == 1u) {
+        if (subgroupElect()) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                const uint r = first_row + n;
+                if (r < p.nrows) { dst[r] = temp[n]; }
+            }
+        }
+        return;
+    }
+
+    // Multi-subgroup: each subgroup stashes its partial, subgroup 0 combines.
+    if (subgroupElect()) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            part[n][gl_SubgroupID] = temp[n];
+        }
+    }
+    barrier();
+    if (gl_SubgroupID == 0u) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            float acc = 0.0;
+            for (uint s = gl_SubgroupInvocationID; s < gl_NumSubgroups; s += gl_SubgroupSize) {
+                acc += part[n][s];
+            }
+            acc = subgroupAdd(acc);
+            const uint r = first_row + n;
+            if (subgroupElect() && r < p.nrows) { dst[r] = acc; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx2repack_batched_f32_f32.comp
+++ b/shaders/mul_mat_vec_mlx2repack_batched_f32_f32.comp
@@ -1,0 +1,135 @@
+#version 450
+// MLX-affine 2-bit EXPERT-BATCHED matvec — the DeepSeek-V4-Flash MoE decode
+// dispatch-collapse lever (top-k routed experts = the 84% bucket). Computes the
+// SAME gate/up/down projection over ALL top_k routed experts in ONE dispatch,
+// each expert's slice through the EXACT per-word repack inner loop of
+// mul_mat_vec_mlx2repack_f32_f32.comp (dwordx4 = 64 codes/load + fma-factored
+// affine + subgroupAdd reduction). The 2-bit twin of
+// mul_mat_vec_mlx4repack_batched_f32_f32.comp (the Ling primitive).
+//
+// ★ GUARDRAIL: batching MUST go THROUGH the repack body, NOT a v1 LDS tree —
+// per-expert VGPR/LDS/occupancy is IDENTICAL to the single-expert repack (single
+// token, no live-weight-across-cols blowup) while the DISPATCH count collapses
+// top_k -> 1 per projection and the experts' workgroups fill the CUs concurrently.
+//
+// Dispatch grid: (ceil(n / NUM_ROWS), num_experts, 1). gl_WorkGroupID.y = expert
+// slot. meta[e] = (packed_off, sb_off, x_off, dst_off):
+//   packed_off  WORD offset into packed[]  for expert e (= slot[e]*n*(k/16))
+//   sb_off      ELEMENT offset into scales[]/biases[] for expert e (= slot[e]*n*(k/gs))
+//   x_off       FLOAT offset into activations (0 for gate/up shared x; e*k for down)
+//   dst_off     FLOAT offset into dst[] (= e*n)
+//
+// REQUIRES k % 64 == 0 (chunks_per_row = k/64), packed base 16B-aligned
+// (packed_off and words_per_row = k/16 multiples of 4 — true for every DSV4
+// expert: gate/up k=4096 wpr=256, down k=2048 wpr=128; per-expert pack_stride =
+// n*wpr = 2048*256 / 4096*128 both mult 4). group_size generic (chunks_per_group
+// = gs/64; DSV4 routed experts gs=128 -> 2 chunks/group).
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 64;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k = in_features (contraction)
+    uint nrows;       // n = out_features
+    uint group_size;  // affine group size (128 for DSV4 routed experts)
+    uint packed_off;  // UNUSED (per-expert offset from meta[]); kept for the 5-uint layout
+    uint sb_off;
+} p;
+
+layout(binding = 0) readonly buffer Packed { uvec4 packed4[]; }; // 4 words / uvec4 = 64 codes
+layout(binding = 1) readonly buffer Scales { float scales[]; };
+layout(binding = 2) readonly buffer Biases { float biases[]; };
+layout(binding = 3) readonly buffer Activ  { vec4  x4[];     };  // (num_experts*)k/4 vec4s
+layout(binding = 4) writeonly buffer Dst   { float dst[];    };  // num_experts*n floats
+layout(binding = 5) readonly buffer Meta   { uvec4 meta[];   };  // per-expert bases
+
+shared float part[NUM_ROWS][16];
+
+#define Q4(w, s) vec4(float(((w) >> (s + 0u)) & 0x3u), float(((w) >> (s + 2u)) & 0x3u), \
+                      float(((w) >> (s + 4u)) & 0x3u), float(((w) >> (s + 6u)) & 0x3u))
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+    const uint e = gl_WorkGroupID.y;
+
+    const uvec4 md = meta[e];
+    const uint packed_off = md.x;
+    const uint sb_off     = md.y;
+    const uint x_base4    = md.z >> 2u;
+    const uint dst_off    = md.w;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;
+    const uint words_per_row = k >> 4u;               // k/16
+    const uint chunks_per_row = k >> 6u;              // k/64
+    const uint chunks_per_group = p.group_size >> 6u; // gs/64
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint c = tid; c < chunks_per_row; c += BLOCK_SIZE) {
+        const uint g = c / chunks_per_group;
+        const uint xb = x_base4 + (c << 4u);
+        vec4 xv[16];
+        [[unroll]] for (uint j = 0; j < 16; ++j) { xv[j] = x4[xb + j]; }
+        vec4 xacc = vec4(0.0);
+        [[unroll]] for (uint j = 0; j < 16; ++j) { xacc += xv[j]; }
+        const float xsum = dot(xacc, vec4(1.0));
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint base4 = ((packed_off + r * words_per_row) >> 2u) + c;
+            const uvec4 pw = packed4[base4];
+            float qx = dot(Q4(pw.x,  0u), xv[0])  + dot(Q4(pw.x, 8u), xv[1])
+                     + dot(Q4(pw.x, 16u), xv[2])  + dot(Q4(pw.x, 24u), xv[3])
+                     + dot(Q4(pw.y,  0u), xv[4])  + dot(Q4(pw.y, 8u), xv[5])
+                     + dot(Q4(pw.y, 16u), xv[6])  + dot(Q4(pw.y, 24u), xv[7])
+                     + dot(Q4(pw.z,  0u), xv[8])  + dot(Q4(pw.z, 8u), xv[9])
+                     + dot(Q4(pw.z, 16u), xv[10]) + dot(Q4(pw.z, 24u), xv[11])
+                     + dot(Q4(pw.w,  0u), xv[12]) + dot(Q4(pw.w, 8u), xv[13])
+                     + dot(Q4(pw.w, 16u), xv[14]) + dot(Q4(pw.w, 24u), xv[15]);
+            const uint sb = sb_off + r * groups + g;
+            temp[n] = fma(scales[sb], qx, fma(biases[sb], xsum, temp[n]));
+        }
+    }
+
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = subgroupAdd(temp[n]);
+    }
+
+    if (gl_NumSubgroups == 1u) {
+        if (subgroupElect()) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                const uint r = first_row + n;
+                if (r < p.nrows) { dst[dst_off + r] = temp[n]; }
+            }
+        }
+        return;
+    }
+
+    if (subgroupElect()) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            part[n][gl_SubgroupID] = temp[n];
+        }
+    }
+    barrier();
+    if (gl_SubgroupID == 0u) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            float acc = 0.0;
+            for (uint s = gl_SubgroupInvocationID; s < gl_NumSubgroups; s += gl_SubgroupSize) {
+                acc += part[n][s];
+            }
+            acc = subgroupAdd(acc);
+            const uint r = first_row + n;
+            if (subgroupElect() && r < p.nrows) { dst[dst_off + r] = acc; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx2repack_f32_f32.comp
+++ b/shaders/mul_mat_vec_mlx2repack_f32_f32.comp
@@ -1,0 +1,136 @@
+#version 450
+// MLX-affine 2-bit matvec — VALU-bound repack refactor (DeepSeek-V4-Flash routed
+// experts, the 84%-of-model bucket). The 2-bit twin of
+// mul_mat_vec_mlx4repack_f32_f32.comp: identical dwordx4 word-granular load +
+// fma-factored affine + subgroupAdd reduction, but each u32 packs 16 2-bit codes
+// (vs 8 nibbles at 4-bit) so one uvec4 = 64 codes = 64 output-contraction
+// elements.
+//
+// LAYOUT (MLX affine, aligned): codes are little-bits-first, 16 per u32
+//   q_j = (word >> (2*(j%16))) & 0x3
+// A code NEVER crosses a u32 boundary (2 divides 32), so this is the aligned
+// `dequantize_mlx_affine` layout (per_word=16) — byte-identical packed bytes,
+// ZERO loader change. Confirmed vs the Phase-0 oracle model::dequantize_mlx_affine
+// (== dequantize_mlx_affine_bits for bits ∈ {2,4,8}).
+//
+//  (1) DWORDX4: one uvec4 load (128b) = 4 words = 64 codes; one packed address
+//      amortized over 64 elements. Across a wave the uvec4 chunks are contiguous
+//      -> coalesced. Packed layout unchanged (contiguous 4-word-per-thread order
+//      IS row-major), loader permutation = identity.
+//  (2) SCALE/BIAS ONCE PER CHUNK + fused affine: DSV4 routed experts are gs=128,
+//      so chunks_per_group = 128/64 = 2 and each 64-elem chunk lies wholly within
+//      one affine group. affine factored exactly like the 4-bit repack:
+//        temp += scale*sum(q_j*x_j) + bias*sum(x_j)     (one fma per chunk)
+//      Algebraically == v1's per-element (scale*q_j+bias)*x_j; f32 rounding
+//      differs (fma + subgroup reassoc) -> gate ARGMAX-EXACT + max_abs_err.
+//  (3) SUBGROUP REDUCTION: per-row subgroupAdd (wave64 GFX1013, BLOCK_SIZE<=64 =
+//      one subgroup -> no LDS, no barrier); tiny LDS combine only if BLOCK_SIZE
+//      spans >1 subgroup.
+//
+// REQUIRES k % 64 == 0 (chunks_per_row = k/64) AND packed base 16B-aligned:
+// packed_off and words_per_row (=k/16) both multiples of 4. True for every DSV4
+// expert shape (gate/up k=4096 -> wpr=256; down k=2048 -> wpr=128; both mult 4).
+// Bindings / push-constants IDENTICAL to mul_mat_vec_mlx4.comp (5 buffers, 5
+// uints) so it drops into the same matvec_mlx4_pc / record_to dispatch.
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 64;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k = in_features (contraction)
+    uint nrows;       // n = out_features
+    uint group_size;  // affine group size (128 for DSV4 routed experts)
+    uint packed_off;  // WORD offset into packed[] for this weight (0 for dense 2D)
+    uint sb_off;      // ELEMENT offset into scales[]/biases[]  (0 for dense 2D)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uvec4 packed4[]; }; // 4 words / uvec4 = 64 codes
+layout(binding = 1) readonly buffer Scales { float scales[]; };
+layout(binding = 2) readonly buffer Biases { float biases[]; };
+layout(binding = 3) readonly buffer Activ  { vec4  x4[];     };  // k/4 vec4s
+layout(binding = 4) writeonly buffer Dst   { float dst[];    };
+
+shared float part[NUM_ROWS][16];
+
+// Unpack the low 16 2-bit codes of `w` into 4 vec4 (codes 0..3,4..7,8..11,12..15).
+#define Q4(w, s) vec4(float(((w) >> (s + 0u)) & 0x3u), float(((w) >> (s + 2u)) & 0x3u), \
+                      float(((w) >> (s + 4u)) & 0x3u), float(((w) >> (s + 6u)) & 0x3u))
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;
+    const uint words_per_row = k >> 4u;               // k/16 (16 codes/word)
+    const uint chunks_per_row = k >> 6u;              // k/64 (4 words = 64 codes each)
+    const uint chunks_per_group = p.group_size >> 6u; // gs/64 = 2 for gs=128
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint c = tid; c < chunks_per_row; c += BLOCK_SIZE) {
+        const uint g = c / chunks_per_group;   // affine group of this 64-elem chunk
+        const uint xb = c << 4u;               // 16*c (vec4 index base)
+        vec4 xv[16];
+        [[unroll]] for (uint j = 0; j < 16; ++j) { xv[j] = x4[xb + j]; }
+        vec4 xacc = vec4(0.0);
+        [[unroll]] for (uint j = 0; j < 16; ++j) { xacc += xv[j]; }
+        const float xsum = dot(xacc, vec4(1.0));
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint base4 = ((p.packed_off + r * words_per_row) >> 2u) + c;
+            const uvec4 pw = packed4[base4];   // ONE dwordx4 = 64 codes
+            float qx = dot(Q4(pw.x,  0u), xv[0])  + dot(Q4(pw.x, 8u), xv[1])
+                     + dot(Q4(pw.x, 16u), xv[2])  + dot(Q4(pw.x, 24u), xv[3])
+                     + dot(Q4(pw.y,  0u), xv[4])  + dot(Q4(pw.y, 8u), xv[5])
+                     + dot(Q4(pw.y, 16u), xv[6])  + dot(Q4(pw.y, 24u), xv[7])
+                     + dot(Q4(pw.z,  0u), xv[8])  + dot(Q4(pw.z, 8u), xv[9])
+                     + dot(Q4(pw.z, 16u), xv[10]) + dot(Q4(pw.z, 24u), xv[11])
+                     + dot(Q4(pw.w,  0u), xv[12]) + dot(Q4(pw.w, 8u), xv[13])
+                     + dot(Q4(pw.w, 16u), xv[14]) + dot(Q4(pw.w, 24u), xv[15]);
+            const uint sb = p.sb_off + r * groups + g;
+            temp[n] = fma(scales[sb], qx, fma(biases[sb], xsum, temp[n]));
+        }
+    }
+
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = subgroupAdd(temp[n]);
+    }
+
+    if (gl_NumSubgroups == 1u) {
+        if (subgroupElect()) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                const uint r = first_row + n;
+                if (r < p.nrows) { dst[r] = temp[n]; }
+            }
+        }
+        return;
+    }
+
+    if (subgroupElect()) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            part[n][gl_SubgroupID] = temp[n];
+        }
+    }
+    barrier();
+    if (gl_SubgroupID == 0u) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            float acc = 0.0;
+            for (uint s = gl_SubgroupInvocationID; s < gl_NumSubgroups; s += gl_SubgroupSize) {
+                acc += part[n][s];
+            }
+            acc = subgroupAdd(acc);
+            const uint r = first_row + n;
+            if (subgroupElect() && r < p.nrows) { dst[r] = acc; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx4.comp
+++ b/shaders/mul_mat_vec_mlx4.comp
@@ -1,0 +1,123 @@
+#version 450
+
+// MLX-affine 4-bit matrix-vector kernel for vllm-vulkan.
+//
+// Computes, for each output row r in [0, n):
+//   out[r] = sum_{j=0..k} ( nibble(w, r, j) * scale[r, g] + bias[r, g] ) * x[j]
+// where g = j / group_size, exactly mirroring the validated CPU reference
+// `model::dequantize_mlx_affine` (bits=4):
+//
+//   per_word      = 32 / 4 = 8 nibbles per u32 word
+//   mask          = 0xF
+//   groups        = k / group_size
+//   words_per_row = k / 8
+//   word          = packed[r * words_per_row + j/8]
+//   q             = (word >> ((j % 8) * 4)) & 0xF          (LSB-first nibbles)
+//   scale/bias    = scales[r*groups + g] / biases[r*groups + g]
+//
+// Bindings (auto-numbered 0.. by record_to in buffer order):
+//   0 = packed weight  (uint[],  4-bit nibbles, 8 per u32)
+//   1 = scales         (float[], one per output-row x group)
+//   2 = biases         (float[], one per output-row x group)
+//   3 = activation x   (float[], length k)
+//   4 = output         (float[], length n)
+//
+// Push constants: { uint ncols(=k); uint nrows(=n); uint group_size; }
+//
+// One workgroup handles NUM_ROWS output rows. The BLOCK_SIZE threads of the
+// workgroup partition the k-dimension (strided by BLOCK_SIZE) and reduce their
+// partial dot products through shared memory. Wave64 on GFX1013; NUM_ROWS<=8
+// (r16/r32 hang pipeline creation on this driver — see compile_matvec).
+
+#extension GL_EXT_control_flow_attributes : enable
+
+// f16-resident scales/biases variant (VLLM_VULKAN_MOE_F16_SCALES): the affine
+// scales+biases are stored f16 in the resident MoE buffer (half the GTT of f32,
+// the fit-enabler for 122B PP-6). f16 has 10 mantissa bits vs bf16's 7, so every
+// in-range bf16-sourced scale is represented EXACTLY -- bit-identical to f32,
+// verified by the exact round-trip guard on the host upload side.
+#ifdef SCALE_F16
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#endif
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 512;
+layout(constant_id = 1) const uint NUM_ROWS = 1;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k = in_features (contraction dim)
+    uint nrows;       // n = out_features
+    uint group_size;  // affine group size along k (typically 64)
+    uint packed_off;  // base WORD offset into packed[] for this expert's slice
+    uint sb_off;      // base ELEMENT offset into scales[]/biases[] for this expert
+} p;
+
+layout(binding = 0) readonly buffer Packed { uint   packed[]; };
+#ifdef SCALE_F16
+layout(binding = 1) readonly buffer Scales { float16_t scales[]; };
+layout(binding = 2) readonly buffer Biases { float16_t biases[]; };
+#else
+layout(binding = 1) readonly buffer Scales { float  scales[]; };
+layout(binding = 2) readonly buffer Biases { float  biases[]; };
+#endif
+layout(binding = 3) readonly buffer Activ  { float  x[];      };
+layout(binding = 4) writeonly buffer Dst   { float  dst[];    };
+
+shared float tmpsh[NUM_ROWS][BLOCK_SIZE];
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint gs = p.group_size;
+    const uint groups = k / gs;
+    const uint words_per_row = k / 8u;
+
+    // Per-row running partial sums for this thread's strided slice of k.
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = 0.0;
+    }
+
+    // Each thread walks columns j = tid, tid+BLOCK_SIZE, ...
+    for (uint j = tid; j < k; j += BLOCK_SIZE) {
+        const float xv = x[j];
+        const uint widx = j >> 3u;             // j / 8  word index within a row
+        const uint shift = (j & 7u) * 4u;      // (j % 8) * 4  nibble bit offset
+        const uint g = j / gs;                 // affine group index
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint word = packed[p.packed_off + r * words_per_row + widx];
+            const float q = float((word >> shift) & 0xFu);
+            const float w = float(scales[p.sb_off + r * groups + g]) * q + float(biases[p.sb_off + r * groups + g]);
+            temp[n] += w * xv;
+        }
+    }
+
+    // Reduce partial sums across the workgroup via shared memory.
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        tmpsh[n][tid] = temp[n];
+    }
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                tmpsh[n][tid] += tmpsh[n][tid + s];
+            }
+        }
+        barrier();
+    }
+    if (tid == 0) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r < p.nrows) {
+                dst[r] = tmpsh[n][0];
+            }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx4_cols.comp
+++ b/shaders/mul_mat_vec_mlx4_cols.comp
@@ -1,0 +1,156 @@
+#version 450
+
+// MLX-affine 4-bit batched multi-column matrix-vector kernel (spec-decode
+// "batched verify" primitive). The 4-bit DEQUANT-cols twin of the q8_0 winner
+// shaders/mul_mat_vec_q8_0_cols.comp, targeting the fleet's REAL weight format
+// (mlx4 affine 4-bit), NOT the q8_0 debug format.
+//
+// Computes, for each output row r in [0,n) and token-column c in [0,NUM_COLS):
+//   dst[c,r] = sum_{j=0..k} ( nibble(w,r,j) * scale[r,g] + bias[r,g] ) * x[c,j]
+// where g = j / group_size, exactly mirroring the validated CPU reference
+// `model::dequantize_mlx_affine` (bits=4) and the single-column
+// shaders/mul_mat_vec_mlx4.comp:
+//
+//   words_per_row = k / 8              (8 nibbles per u32 word, LSB-first)
+//   q  = (packed[r*words_per_row + j/8] >> ((j%8)*4)) & 0xF
+//   w  = scales[r*groups + g] * q + biases[r*groups + g]
+//
+// ─── DESIGN: minimal live state (avoid the repack VGPR trap) ──────────────────
+// Like mul_mat_vec_q8_0_cols / mul_mat_vec_nvfp4 (cols), each thread UNPACKS +
+// DEQUANTIZES each weight element EXACTLY ONCE (nibble unpack + affine
+// scale*q+bias) and reuses that single scalar `w` across all NUM_COLS token
+// columns (columns are the INNER loop). The ONLY column-scaled live state is the
+// accumulator array temp[NUM_ROWS][NUM_COLS]; the decoded weight `w`, the packed
+// `word`, `q`, and the per-group scale/bias are TRANSIENT scalars consumed
+// immediately. This is the crucial contrast with the DEAD mlx4 REPACK-cols
+// design (on-node refuted 2026-07-26, 0.19–0.38×): repack decoded a whole block
+// of 8 weights (w0..w7) and held that vector LIVE across the T columns, pushing
+// VGPR 56→96 → occupancy collapse. Here nothing but the T accumulators lives
+// across the column loop, so the kernel stays in the q8-like LDS-bound regime
+// (VGPR ~ base + T) rather than the repack VGPR-bound regime.
+//
+// Since the fleet 4-bit matvec is DEQUANT-ALU-bound at ~263 GB/s (not at the
+// ~380 GB/s BW roof like q8) [[gfx1013-4bit-decode-bw-ceiling]], the cols reuse
+// amortizes BOTH the weight read AND the nibble-unpack+affine ALU across T — a
+// potentially BIGGER win than q8, contingent on occupancy holding (the whole
+// point of the spike). The heavier per-element VALU (shift/mask + mul+add vs
+// q8's single int8*scale) can pull the T-plateau IN vs q8's T≈8 — the sweep
+// measures where.
+//
+// Activation x is laid out [NUM_COLS,k] row-major (x[c*k+j], f32); output
+// [NUM_COLS,n] row-major (dst[c*n+r], f32) — the same [T,k]->[T,n] convention as
+// q8_0_cols / nvfp4-cols. 2D workgroup grid so n may exceed 65535.
+//
+// Bindings (auto-numbered 0.. by record_to in buffer order, matching
+// mul_mat_vec_mlx4.comp):
+//   0 = packed weight  (uint[],  4-bit nibbles, 8 per u32)
+//   1 = scales         (float[], one per output-row x group)
+//   2 = biases         (float[], one per output-row x group)
+//   3 = activation x   (float[], [NUM_COLS,k] row-major)
+//   4 = output         (float[], [NUM_COLS,n] row-major)
+//
+// Push constants: { uint ncols(=k); uint nrows(=n); uint group_size;
+//                   uint packed_off; uint sb_off; } — identical to
+// mul_mat_vec_mlx4.comp, so the single-column dispatch path is reused verbatim.
+//
+// NUM_COLS (spec constant 2, default 1) is the batch width. NUM_COLS=1 is
+// byte-identical to mul_mat_vec_mlx4.comp by construction (the inner column loop
+// collapses to the original single MAC and the [c*..] indices collapse to [..]).
+// LDS = NUM_ROWS*NUM_COLS*BLOCK_SIZE*4; callers keep NUM_ROWS*NUM_COLS<=8 so LDS
+// <= 16 KB (BLOCK_SIZE=512). Wave64 on GFX1013; NUM_ROWS<=8.
+
+#extension GL_EXT_control_flow_attributes : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 512;
+layout(constant_id = 1) const uint NUM_ROWS = 1;
+layout(constant_id = 2) const uint NUM_COLS = 1;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k = in_features (contraction dim)
+    uint nrows;       // n = out_features
+    uint group_size;  // affine group size along k (typically 64)
+    uint packed_off;  // base WORD offset into packed[] for this expert's slice
+    uint sb_off;      // base ELEMENT offset into scales[]/biases[] for this expert
+} p;
+
+layout(binding = 0) readonly buffer Packed { uint   packed[]; };
+layout(binding = 1) readonly buffer Scales { float  scales[]; };
+layout(binding = 2) readonly buffer Biases { float  biases[]; };
+layout(binding = 3) readonly buffer Activ  { float  x[];      };
+layout(binding = 4) writeonly buffer Dst   { float  dst[];    };
+
+shared float tmpsh[NUM_ROWS][NUM_COLS][BLOCK_SIZE];
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint wg_lin = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x;
+    const uint first_row = NUM_ROWS * wg_lin;
+
+    const uint k = p.ncols;
+    const uint gs = p.group_size;
+    const uint groups = k / gs;
+    const uint words_per_row = k >> 3u;   // k / 8
+
+    // Per-(row,col) running partial sums for this thread's strided slice of k.
+    // This is the ONLY column-scaled live state (NUM_ROWS*NUM_COLS f32).
+    float temp[NUM_ROWS][NUM_COLS];
+    [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            temp[nr][c] = 0.0;
+        }
+    }
+
+    // Each thread walks columns j = tid, tid+BLOCK_SIZE, ... The weight element
+    // at (r,j) is unpacked + affine-dequantized ONCE into the scalar `w` and
+    // reused across all NUM_COLS token columns (x is [NUM_COLS,k] row-major).
+    for (uint j = tid; j < k; j += BLOCK_SIZE) {
+        const uint widx  = j >> 3u;         // j / 8   word index within a row
+        const uint shift = (j & 7u) * 4u;   // (j % 8) * 4  nibble bit offset
+        const uint g = j / gs;              // affine group index
+
+        [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+            const uint r = first_row + nr;
+            if (r >= p.nrows) { continue; }
+            const uint word = packed[p.packed_off + r * words_per_row + widx];
+            const float q = float((word >> shift) & 0xFu);
+            // Dequantize ONCE: affine scale*q + bias (transient scalar, not held
+            // across columns -- the anti-repack-trap invariant).
+            const float w = scales[p.sb_off + r * groups + g] * q
+                          + biases[p.sb_off + r * groups + g];
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                temp[nr][c] += w * x[c * k + j];
+            }
+        }
+    }
+
+    // Reduce partial sums across the workgroup via shared memory (same order as
+    // mul_mat_vec_mlx4.comp / q8_0_cols).
+    [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            tmpsh[nr][c][tid] = temp[nr][c];
+        }
+    }
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    tmpsh[nr][c][tid] += tmpsh[nr][c][tid + s];
+                }
+            }
+        }
+        barrier();
+    }
+    if (tid == 0) {
+        [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+            const uint r = first_row + nr;
+            if (r < p.nrows) {
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    dst[c * p.nrows + r] = tmpsh[nr][c][0];
+                }
+            }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx4_w16.comp
+++ b/shaders/mul_mat_vec_mlx4_w16.comp
@@ -1,0 +1,99 @@
+#version 450
+// MLX-affine 4-bit matvec, word-granular inner loop, uvec2 sibling (16 nibbles/load).
+// Each thread owns a pair of consecutive u32 words (16 nibbles). Per 16 weights/row:
+//   1 uvec2 load + 1 scale load + 1 bias load  (was 16+16+16 in v1)
+// x is read as four vec4 per word-pair, once per pair, shared across NUM_ROWS.
+// Affine factoring per word-pair: sum((q*s+b)*x) == s*dot(q,x) + b*sum(x).
+// group_size (64) is a multiple of 16, so a word-pair never straddles an
+// affine group boundary (asserted host-side; requires k % 16 == 0).
+
+#extension GL_EXT_control_flow_attributes : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 128;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k
+    uint nrows;       // n
+    uint group_size;  // 64
+    uint packed_off;  // WORD offset (expert slice)
+    uint sb_off;      // ELEMENT offset (expert slice)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uvec2 packed2[]; };
+layout(binding = 1) readonly buffer Scales { float scales[]; };
+layout(binding = 2) readonly buffer Biases { float biases[]; };
+layout(binding = 3) readonly buffer Activ  { vec4  x4[];     };  // k/4 vec4s
+layout(binding = 4) writeonly buffer Dst   { float dst[];    };
+
+shared float tmpsh[NUM_ROWS][BLOCK_SIZE];
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;
+    const uint words_per_row = k >> 3u;               // k/8
+    const uint pairs_per_row = words_per_row >> 1u;   // k/16
+    const uint words_per_group = p.group_size >> 3u;  // 8 for gs=64
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint wp = tid; wp < pairs_per_row; wp += BLOCK_SIZE) {
+        const uint w0 = 2u * wp;
+        const uint g = w0 / words_per_group;
+        const vec4 xa = x4[4u * wp];
+        const vec4 xb = x4[4u * wp + 1u];
+        const vec4 xc = x4[4u * wp + 2u];
+        const vec4 xd = x4[4u * wp + 3u];
+        const float xsum = dot(xa + xb + xc + xd, vec4(1.0));
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uvec2 word2 = packed2[(p.packed_off + r * words_per_row + w0) >> 1u];
+            const uint word0 = word2.x;
+            const uint word1 = word2.y;
+            const vec4 qa = vec4(float( word0         & 0xFu),
+                                 float((word0 >>  4u) & 0xFu),
+                                 float((word0 >>  8u) & 0xFu),
+                                 float((word0 >> 12u) & 0xFu));
+            const vec4 qb = vec4(float((word0 >> 16u) & 0xFu),
+                                 float((word0 >> 20u) & 0xFu),
+                                 float((word0 >> 24u) & 0xFu),
+                                 float((word0 >> 28u) & 0xFu));
+            const vec4 qc = vec4(float( word1         & 0xFu),
+                                 float((word1 >>  4u) & 0xFu),
+                                 float((word1 >>  8u) & 0xFu),
+                                 float((word1 >> 12u) & 0xFu));
+            const vec4 qd = vec4(float((word1 >> 16u) & 0xFu),
+                                 float((word1 >> 20u) & 0xFu),
+                                 float((word1 >> 24u) & 0xFu),
+                                 float((word1 >> 28u) & 0xFu));
+            const float qx = dot(qa, xa) + dot(qb, xb) + dot(qc, xc) + dot(qd, xd);
+            const uint sb = p.sb_off + r * groups + g;
+            temp[n] = fma(scales[sb], qx, fma(biases[sb], xsum, temp[n]));
+        }
+    }
+
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { tmpsh[n][tid] = temp[n]; }
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                tmpsh[n][tid] += tmpsh[n][tid + s];
+            }
+        }
+        barrier();
+    }
+    if (tid == 0) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r < p.nrows) { dst[r] = tmpsh[n][0]; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx4_w8.comp
+++ b/shaders/mul_mat_vec_mlx4_w8.comp
@@ -1,0 +1,87 @@
+#version 450
+// MLX-affine 4-bit matvec, word-granular inner loop (v2).
+// Each thread owns whole u32 words (8 nibbles). Per 8 weights per row:
+//   1 word load + 1 scale load + 1 bias load  (was 8+8+8)
+// x is read as two vec4 per word, once per word, shared across NUM_ROWS
+//   (was 8 scalar loads per row).
+// Affine factoring per word: sum((q*s+b)*x) == s*dot(q,x) + b*sum(x).
+// Identical math over the reals; f32 rounding order differs from v1 -> cos gate.
+// group_size is a multiple of 8, so the 8 nibbles of one word never straddle
+// an affine group (gs=64 for every MLX-affine tensor we load; asserted host-side).
+
+#extension GL_EXT_control_flow_attributes : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 128;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k
+    uint nrows;       // n
+    uint group_size;  // 64
+    uint packed_off;  // WORD offset (expert slice)
+    uint sb_off;      // ELEMENT offset (expert slice)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uint  packed[]; };
+layout(binding = 1) readonly buffer Scales { float scales[]; };
+layout(binding = 2) readonly buffer Biases { float biases[]; };
+layout(binding = 3) readonly buffer Activ  { vec4  x4[];     };  // k/4 vec4s
+layout(binding = 4) writeonly buffer Dst   { float dst[];    };
+
+shared float tmpsh[NUM_ROWS][BLOCK_SIZE];
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;
+    const uint words_per_row = k >> 3u;          // k/8
+    const uint words_per_group = p.group_size >> 3u;  // 8 for gs=64
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint w = tid; w < words_per_row; w += BLOCK_SIZE) {
+        const uint g = w / words_per_group;
+        const vec4 xa = x4[2u * w];
+        const vec4 xb = x4[2u * w + 1u];
+        const float xsum = dot(xa + xb, vec4(1.0));
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint word = packed[p.packed_off + r * words_per_row + w];
+            const vec4 qa = vec4(float( word         & 0xFu),
+                                 float((word >>  4u) & 0xFu),
+                                 float((word >>  8u) & 0xFu),
+                                 float((word >> 12u) & 0xFu));
+            const vec4 qb = vec4(float((word >> 16u) & 0xFu),
+                                 float((word >> 20u) & 0xFu),
+                                 float((word >> 24u) & 0xFu),
+                                 float((word >> 28u) & 0xFu));
+            const float qx = dot(qa, xa) + dot(qb, xb);
+            const uint sb = p.sb_off + r * groups + g;
+            temp[n] = fma(scales[sb], qx, fma(biases[sb], xsum, temp[n]));
+        }
+    }
+
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { tmpsh[n][tid] = temp[n]; }
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                tmpsh[n][tid] += tmpsh[n][tid + s];
+            }
+        }
+        barrier();
+    }
+    if (tid == 0) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r < p.nrows) { dst[r] = tmpsh[n][0]; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx4repack_batched_f32_f32.comp
+++ b/shaders/mul_mat_vec_mlx4repack_batched_f32_f32.comp
@@ -1,0 +1,150 @@
+#version 450
+// MLX-affine 4-bit EXPERT-BATCHED matvec — the Ling MoE decode dispatch-collapse
+// lever (VLLM_VULKAN_LING_MOE_BATCH). Computes the SAME gate/up/down projection
+// over ALL top_k routed experts in ONE dispatch, each expert's slice processed
+// through the EXACT per-byte repack inner loop of
+// mul_mat_vec_mlx4repack_f32_f32.comp (dwordx4 word-granular load + fma-factored
+// affine + subgroupAdd reduction, at the ~62us weight-read BW floor).
+//
+// ★ THE GUARDRAIL (why Laguna's cbbatch was a 2x REGRESSION): batching MUST go
+// THROUGH the repack kernel, NOT the v1 LDS tree-reduce. This kernel's per-(row,
+// chunk) body is BYTE-FOR-BYTE the repack body; the ONLY additions are a per-
+// expert base lookup from `meta[gl_WorkGroupID.y]` and a per-expert activation/
+// output base offset. So per-expert throughput is IDENTICAL to the single-expert
+// repack (VGPR/LDS/occupancy unchanged — single token, no live-weight-across-cols
+// blowup) while the DISPATCH count collapses 24->3 per MoE layer and the 8 experts'
+// workgroups fill the CUs concurrently.
+//
+// Dispatch grid: (ceil(n / NUM_ROWS), num_experts, 1). gl_WorkGroupID.y = expert
+// slot in [0, num_experts). meta[e] = (packed_off, sb_off, x_off, dst_off):
+//   packed_off  WORD offset into packed[]  for expert e's weight  (= slot[e]*n*(k/8))
+//   sb_off      ELEMENT offset into scales[]/biases[] for expert e (= slot[e]*n*(k/gs))
+//   x_off       FLOAT offset into the activation buffer for expert e
+//               (0 for gate/up: all experts share x; e*k for down: per-expert mid)
+//   dst_off     FLOAT offset into dst[] for expert e (= e*n)
+// x_off is a multiple of 4 (k%4==0) so the vec4 activation index is exact.
+//
+// REQUIRES (same as the single-expert repack, guaranteed by k%32==0 for every Ling
+// MoE shape): chunks_per_row = k/32, packed base 16B-aligned (packed_off and
+// words_per_row = k/8 both multiples of 4). group_size generic (chunks_per_group =
+// gs/32; Ling routed experts are gs=32 -> 1 chunk/group).
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 64;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k = in_features (contraction)
+    uint nrows;       // n = out_features
+    uint group_size;  // affine group size (32 for Ling routed experts)
+    uint packed_off;  // UNUSED here (per-expert offset comes from meta[]); kept so
+    uint sb_off;      // matvec_mlx4_pc's 5-uint layout is reused verbatim.
+} p;
+
+layout(binding = 0) readonly buffer Packed { uvec4 packed4[]; }; // 4 words / uvec4 = 32 nibbles
+layout(binding = 1) readonly buffer Scales { float scales[]; };
+layout(binding = 2) readonly buffer Biases { float biases[]; };
+layout(binding = 3) readonly buffer Activ  { vec4  x4[];     };  // (num_experts*)k/4 vec4s
+layout(binding = 4) writeonly buffer Dst   { float dst[];    };  // num_experts*n floats
+layout(binding = 5) readonly buffer Meta   { uvec4 meta[];   };  // per-expert bases
+
+// Cross-subgroup combine scratch (only touched when BLOCK_SIZE > subgroup size).
+shared float part[NUM_ROWS][16];
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+    const uint e = gl_WorkGroupID.y;              // expert slot
+
+    const uvec4 md = meta[e];
+    const uint packed_off = md.x;
+    const uint sb_off     = md.y;
+    const uint x_base4    = md.z >> 2u;           // FLOAT x_off -> vec4 index base
+    const uint dst_off    = md.w;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;
+    const uint words_per_row = k >> 3u;               // k/8
+    const uint chunks_per_row = k >> 5u;              // k/32 (4 words each)
+    const uint chunks_per_group = p.group_size >> 5u; // gs/32
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint c = tid; c < chunks_per_row; c += BLOCK_SIZE) {
+        const uint g = c / chunks_per_group;   // affine group of this 32-elem chunk
+        const uint xb = x_base4 + (c << 3u);   // 8 vec4 of activations for j in [32c,32c+32)
+        const vec4 x0 = x4[xb + 0u];
+        const vec4 x1 = x4[xb + 1u];
+        const vec4 x2 = x4[xb + 2u];
+        const vec4 x3 = x4[xb + 3u];
+        const vec4 x4v = x4[xb + 4u];
+        const vec4 x5 = x4[xb + 5u];
+        const vec4 x6 = x4[xb + 6u];
+        const vec4 x7 = x4[xb + 7u];
+        const float xsum = dot(x0 + x1 + x2 + x3 + x4v + x5 + x6 + x7, vec4(1.0));
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint base4 = ((packed_off + r * words_per_row) >> 2u) + c;
+            const uvec4 pw = packed4[base4];   // ONE dwordx4 = 32 nibbles (words 4c..4c+3)
+            float qx = dot(vec4(float( pw.x        & 0xFu), float((pw.x >>  4u) & 0xFu),
+                                float((pw.x >>  8u) & 0xFu), float((pw.x >> 12u) & 0xFu)), x0)
+                     + dot(vec4(float((pw.x >> 16u) & 0xFu), float((pw.x >> 20u) & 0xFu),
+                                float((pw.x >> 24u) & 0xFu), float((pw.x >> 28u) & 0xFu)), x1)
+                     + dot(vec4(float( pw.y        & 0xFu), float((pw.y >>  4u) & 0xFu),
+                                float((pw.y >>  8u) & 0xFu), float((pw.y >> 12u) & 0xFu)), x2)
+                     + dot(vec4(float((pw.y >> 16u) & 0xFu), float((pw.y >> 20u) & 0xFu),
+                                float((pw.y >> 24u) & 0xFu), float((pw.y >> 28u) & 0xFu)), x3)
+                     + dot(vec4(float( pw.z        & 0xFu), float((pw.z >>  4u) & 0xFu),
+                                float((pw.z >>  8u) & 0xFu), float((pw.z >> 12u) & 0xFu)), x4v)
+                     + dot(vec4(float((pw.z >> 16u) & 0xFu), float((pw.z >> 20u) & 0xFu),
+                                float((pw.z >> 24u) & 0xFu), float((pw.z >> 28u) & 0xFu)), x5)
+                     + dot(vec4(float( pw.w        & 0xFu), float((pw.w >>  4u) & 0xFu),
+                                float((pw.w >>  8u) & 0xFu), float((pw.w >> 12u) & 0xFu)), x6)
+                     + dot(vec4(float((pw.w >> 16u) & 0xFu), float((pw.w >> 20u) & 0xFu),
+                                float((pw.w >> 24u) & 0xFu), float((pw.w >> 28u) & 0xFu)), x7);
+            const uint sb = sb_off + r * groups + g;
+            temp[n] = fma(scales[sb], qx, fma(biases[sb], xsum, temp[n]));
+        }
+    }
+
+    // Reduce each row across the subgroup.
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = subgroupAdd(temp[n]);
+    }
+
+    if (gl_NumSubgroups == 1u) {
+        if (subgroupElect()) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                const uint r = first_row + n;
+                if (r < p.nrows) { dst[dst_off + r] = temp[n]; }
+            }
+        }
+        return;
+    }
+
+    if (subgroupElect()) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            part[n][gl_SubgroupID] = temp[n];
+        }
+    }
+    barrier();
+    if (gl_SubgroupID == 0u) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            float acc = 0.0;
+            for (uint s = gl_SubgroupInvocationID; s < gl_NumSubgroups; s += gl_SubgroupSize) {
+                acc += part[n][s];
+            }
+            acc = subgroupAdd(acc);
+            const uint r = first_row + n;
+            if (subgroupElect() && r < p.nrows) { dst[dst_off + r] = acc; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx4repack_f32_f32.comp
+++ b/shaders/mul_mat_vec_mlx4repack_f32_f32.comp
@@ -1,0 +1,180 @@
+#version 450
+// MLX-affine 4-bit matvec — VALU-bound repack refactor (VLLM_VULKAN_MLX4_REPACK).
+//
+// Tunnels through the mlx4 4-bit matvec roofline identified by the zero-hazard
+// probe: the v1 kernel (mul_mat_vec_mlx4.comp, bs512/r8) is VALU-bound with ~90%
+// of the VALU spent on ADDRESS GENERATION for uncoalesced per-element loads
+// (~190 addr VALU vs 16 unpack, gfx1013 ISA). This kernel cuts the address-gen:
+//
+//  (1) DWORDX4 word-granular processing: each thread walks a CONTIGUOUS run of
+//      4 packed words (= 32 nibbles = 32 output-contraction elements) via ONE
+//      uvec4 load (global_load_dwordx4, 128b). One packed address amortizes over
+//      32 elements (v1 recomputed a full 64-bit address PER element). Across a
+//      wave the 4-word chunks are contiguous -> coalesced. NOTE: the packed
+//      layout is UNCHANGED — for a contiguous-4-word-per-thread mapping the
+//      "repacked" (coalescing-friendly) order IS the existing row-major order,
+//      so the loader-side permutation is the identity (bytes bit-identical to
+//      mul_mat_vec_mlx4.comp's packed buffer). See push_constants::
+//      matvec_mlx4_variant_k / geom_combos_for.
+//
+//  (2) SCALE/BIAS ONCE PER CHUNK + fused affine: gs=64 = 2 chunks, so each 32-
+//      element chunk lies wholly within one affine group -> scale/bias loaded
+//      ONCE per chunk (v1 loaded them per element). The affine is factored
+//      exactly like mul_mat_vec_mlx4w8sg (the shipped MoE-down kernel):
+//        temp += scale*sum(q_j*x_j) + bias*sum(x_j)     (one fma per chunk)
+//      This is algebraically == v1's per-element (scale*q_j + bias)*x_j but the
+//      f32 rounding differs (fma + reassociation) -> re-gate ARGMAX-EXACT +
+//      max_abs_err, NOT byte-identity (the w8sg factoring is already argmax-
+//      validated on real 4-bit weights).
+//
+//  (3) SUBGROUP REDUCTION: the 16KB-LDS log2(BLOCK) barrier tree of v1 is
+//      replaced by a per-row subgroupAdd (wave64 GFX1013: BLOCK_SIZE<=64 is one
+//      subgroup -> no LDS, no barrier), with a tiny LDS combine only when
+//      BLOCK_SIZE spans >1 subgroup. Removes the ~148-instr epilogue and raises
+//      occupancy above the LDS-4-wg/CU cap.
+//
+// REQUIRES k % 32 == 0 (chunks_per_row = k/32) AND packed base 16B-aligned:
+// packed_off and words_per_row (=k/8) both multiples of 4 — true for the dense
+// (packed_off=0, k%32==0) decode shapes this kernel is gated to. Bindings /
+// push-constants are IDENTICAL to mul_mat_vec_mlx4.comp (5 buffers, 5 uints), so
+// it drops into the same dispatch (matvec_mlx4_pc / record_to).
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+// f16-resident scales/biases variant (VLLM_VULKAN_MOE_F16_SCALES): the MoE
+// routed-expert affine scales+biases are stored f16 in the resident buffer (half
+// the GTT of f32, the fit-enabler for 122B PP-8). f16 has 10 mantissa bits vs
+// bf16's 7, so every in-range bf16-sourced scale is EXACT -> the f16 loads add no
+// error beyond the f32-repack twin's fma/subgroup reassociation. This is the
+// SCALE_F16 sibling of mul_mat_vec_mlx4.comp's f16scale variant, routed by
+// push_constants::matvec_mlx4_moe_variant_k so the address-gen-bound v1 f16scale
+// kernel (mul_mat_vec_mlx4_f16scale_f32_f32) no longer runs the 122B experts.
+#ifdef SCALE_F16
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#endif
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 64;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k = in_features (contraction)
+    uint nrows;       // n = out_features
+    uint group_size;  // affine group size (64)
+    uint packed_off;  // WORD offset into packed[] for this weight (0 for dense 2D)
+    uint sb_off;      // ELEMENT offset into scales[]/biases[]  (0 for dense 2D)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uvec4 packed4[]; }; // 4 words / uvec4 = 32 nibbles
+#ifdef SCALE_F16
+layout(binding = 1) readonly buffer Scales { float16_t scales[]; };
+layout(binding = 2) readonly buffer Biases { float16_t biases[]; };
+#else
+layout(binding = 1) readonly buffer Scales { float scales[]; };
+layout(binding = 2) readonly buffer Biases { float biases[]; };
+#endif
+layout(binding = 3) readonly buffer Activ  { vec4  x4[];     };  // k/4 vec4s
+layout(binding = 4) writeonly buffer Dst   { float dst[];    };
+
+// Cross-subgroup combine scratch (only touched when BLOCK_SIZE > subgroup size).
+shared float part[NUM_ROWS][16];
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;
+    const uint words_per_row = k >> 3u;               // k/8
+    const uint chunks_per_row = k >> 5u;              // k/32 (4 words each)
+    const uint chunks_per_group = p.group_size >> 5u; // gs/32 = 2 for gs=64
+    // packed4 element base for a row: (packed_off + r*words_per_row)/4.
+    const uint row_words4 = words_per_row >> 2u;      // uvec4s per row = (k/8)/4 = k/32
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint c = tid; c < chunks_per_row; c += BLOCK_SIZE) {
+        const uint g = c / chunks_per_group;   // affine group of this 32-elem chunk
+        // 8 vec4 of activations covering j in [32c, 32c+32).
+        const uint xb = c << 3u;               // 8*c  (vec4 index base)
+        const vec4 x0 = x4[xb + 0u];
+        const vec4 x1 = x4[xb + 1u];
+        const vec4 x2 = x4[xb + 2u];
+        const vec4 x3 = x4[xb + 3u];
+        const vec4 x4v = x4[xb + 4u];
+        const vec4 x5 = x4[xb + 5u];
+        const vec4 x6 = x4[xb + 6u];
+        const vec4 x7 = x4[xb + 7u];
+        const float xsum = dot(x0 + x1 + x2 + x3 + x4v + x5 + x6 + x7, vec4(1.0));
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint base4 = ((p.packed_off + r * words_per_row) >> 2u) + c;
+            const uvec4 pw = packed4[base4];   // ONE dwordx4 = 32 nibbles (words 4c..4c+3)
+            // word pw.x -> j[32c .. 32c+8) -> x0(lo 4), x1(hi 4); pw.y -> x2,x3; ...
+            float qx = dot(vec4(float( pw.x        & 0xFu), float((pw.x >>  4u) & 0xFu),
+                                float((pw.x >>  8u) & 0xFu), float((pw.x >> 12u) & 0xFu)), x0)
+                     + dot(vec4(float((pw.x >> 16u) & 0xFu), float((pw.x >> 20u) & 0xFu),
+                                float((pw.x >> 24u) & 0xFu), float((pw.x >> 28u) & 0xFu)), x1)
+                     + dot(vec4(float( pw.y        & 0xFu), float((pw.y >>  4u) & 0xFu),
+                                float((pw.y >>  8u) & 0xFu), float((pw.y >> 12u) & 0xFu)), x2)
+                     + dot(vec4(float((pw.y >> 16u) & 0xFu), float((pw.y >> 20u) & 0xFu),
+                                float((pw.y >> 24u) & 0xFu), float((pw.y >> 28u) & 0xFu)), x3)
+                     + dot(vec4(float( pw.z        & 0xFu), float((pw.z >>  4u) & 0xFu),
+                                float((pw.z >>  8u) & 0xFu), float((pw.z >> 12u) & 0xFu)), x4v)
+                     + dot(vec4(float((pw.z >> 16u) & 0xFu), float((pw.z >> 20u) & 0xFu),
+                                float((pw.z >> 24u) & 0xFu), float((pw.z >> 28u) & 0xFu)), x5)
+                     + dot(vec4(float( pw.w        & 0xFu), float((pw.w >>  4u) & 0xFu),
+                                float((pw.w >>  8u) & 0xFu), float((pw.w >> 12u) & 0xFu)), x6)
+                     + dot(vec4(float((pw.w >> 16u) & 0xFu), float((pw.w >> 20u) & 0xFu),
+                                float((pw.w >> 24u) & 0xFu), float((pw.w >> 28u) & 0xFu)), x7);
+            const uint sb = p.sb_off + r * groups + g;
+            // float() casts are no-ops for the f32 buffer; for SCALE_F16 they
+            // widen the f16 scale/bias to f32 BEFORE the fma (the affine math and
+            // the accumulator stay f32, identical to the f32 twin — only the
+            // stored scale precision differs, and f16 holds bf16 exactly in range).
+            temp[n] = fma(float(scales[sb]), qx, fma(float(biases[sb]), xsum, temp[n]));
+        }
+    }
+
+    // Reduce each row across the subgroup.
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = subgroupAdd(temp[n]);
+    }
+
+    // Single-subgroup workgroup (BLOCK_SIZE<=64, the target): lane 0 writes.
+    if (gl_NumSubgroups == 1u) {
+        if (subgroupElect()) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                const uint r = first_row + n;
+                if (r < p.nrows) { dst[r] = temp[n]; }
+            }
+        }
+        return;
+    }
+
+    // Multi-subgroup: each subgroup stashes its partial, subgroup 0 combines.
+    if (subgroupElect()) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            part[n][gl_SubgroupID] = temp[n];
+        }
+    }
+    barrier();
+    if (gl_SubgroupID == 0u) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            float acc = 0.0;
+            for (uint s = gl_SubgroupInvocationID; s < gl_NumSubgroups; s += gl_SubgroupSize) {
+                acc += part[n][s];
+            }
+            acc = subgroupAdd(acc);
+            const uint r = first_row + n;
+            if (subgroupElect() && r < p.nrows) { dst[r] = acc; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx4w8sg_f32_f32.comp
+++ b/shaders/mul_mat_vec_mlx4w8sg_f32_f32.comp
@@ -1,0 +1,115 @@
+#version 450
+// MLX-affine 4-bit matvec — word-granular load/dequant (identical to
+// mul_mat_vec_mlx4w8) but the log2(BLOCK_SIZE) LDS tree reduction is replaced
+// by a per-row subgroupAdd, with a tiny LDS combine ONLY when the workgroup
+// spans more than one subgroup.
+//
+// Motivation: the down (k=512,n=2048) MoE dispatch launches 2048 tiny
+// workgroups; a wave-cost decomposition of the w8 sweep attributes ~30% of its
+// 27.3 µs to the barrier-separated shared-memory reduction (paid once per
+// workgroup, i.e. 2048x). On wave64 GFX1013 a workgroup of BLOCK_SIZE<=64 is a
+// SINGLE subgroup, so subgroupAdd collapses the entire reduction to one op with
+// no barrier and no LDS round-trip. Load/dequant math is bit-identical to w8;
+// only the reduction summation order differs (f32) -> cos gate.
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 128;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k
+    uint nrows;       // n
+    uint group_size;  // 64
+    uint packed_off;  // WORD offset (expert slice)
+    uint sb_off;      // ELEMENT offset (expert slice)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uint  packed[]; };
+layout(binding = 1) readonly buffer Scales { float scales[]; };
+layout(binding = 2) readonly buffer Biases { float biases[]; };
+layout(binding = 3) readonly buffer Activ  { vec4  x4[];     };  // k/4 vec4s
+layout(binding = 4) writeonly buffer Dst   { float dst[];    };
+
+// Cross-subgroup combine scratch. Max subgroups per workgroup =
+// BLOCK_SIZE(<=512) / min subgroup size(32) = 16. Only touched when
+// gl_NumSubgroups > 1 (BLOCK_SIZE > subgroup size), never on the target bs<=64.
+shared float part[NUM_ROWS][16];
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;
+    const uint words_per_row = k >> 3u;               // k/8
+    const uint words_per_group = p.group_size >> 3u;  // 8 for gs=64
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint w = tid; w < words_per_row; w += BLOCK_SIZE) {
+        const uint g = w / words_per_group;
+        const vec4 xa = x4[2u * w];
+        const vec4 xb = x4[2u * w + 1u];
+        const float xsum = dot(xa + xb, vec4(1.0));
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint word = packed[p.packed_off + r * words_per_row + w];
+            const vec4 qa = vec4(float( word         & 0xFu),
+                                 float((word >>  4u) & 0xFu),
+                                 float((word >>  8u) & 0xFu),
+                                 float((word >> 12u) & 0xFu));
+            const vec4 qb = vec4(float((word >> 16u) & 0xFu),
+                                 float((word >> 20u) & 0xFu),
+                                 float((word >> 24u) & 0xFu),
+                                 float((word >> 28u) & 0xFu));
+            const float qx = dot(qa, xa) + dot(qb, xb);
+            const uint sb = p.sb_off + r * groups + g;
+            temp[n] = fma(scales[sb], qx, fma(biases[sb], xsum, temp[n]));
+        }
+    }
+
+    // Reduce each row across the subgroup.
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = subgroupAdd(temp[n]);
+    }
+
+    // Single-subgroup workgroup (the target geometry): lane 0 writes directly.
+    // gl_NumSubgroups is workgroup-uniform, so this branch never splits barrier
+    // reachability.
+    if (gl_NumSubgroups == 1u) {
+        if (subgroupElect()) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                const uint r = first_row + n;
+                if (r < p.nrows) { dst[r] = temp[n]; }
+            }
+        }
+        return;
+    }
+
+    // Multi-subgroup: each subgroup stashes its partial, subgroup 0 combines.
+    if (subgroupElect()) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            part[n][gl_SubgroupID] = temp[n];
+        }
+    }
+    barrier();
+    if (gl_SubgroupID == 0u) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            float acc = 0.0;
+            for (uint s = gl_SubgroupInvocationID; s < gl_NumSubgroups; s += gl_SubgroupSize) {
+                acc += part[n][s];
+            }
+            acc = subgroupAdd(acc);
+            const uint r = first_row + n;
+            if (subgroupElect() && r < p.nrows) { dst[r] = acc; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx6_f32_f32.comp
+++ b/shaders/mul_mat_vec_mlx6_f32_f32.comp
@@ -1,0 +1,134 @@
+#version 450
+// MLX-affine 6-bit CONTIGUOUS matvec — DeepSeek-V4-Flash attn/MLA/DSA
+// (indexer + compressor) tensors. The HARD width: 6-bit codes are packed as a
+// CONTIGUOUS little-endian bitstream that CROSSES u32 word boundaries (bits ∉
+// {2,4,8} => in*bits/32 packed cols, NOT in/(32/bits)). This is the layout the
+// Phase-0 oracle model::dequantize_mlx_affine_bits (6-bit path) handles; this
+// kernel ports the contiguous unpack to GLSL and is gated ARGMAX-EXACT/ULP
+// against it.
+//
+// SCHEME — "3 words per 16 codes" (16*6 = 96 bits = 3 u32 EXACTLY). Each thread
+// processes a chunk of 16 codes = 3 consecutive words (w0,w1,w2). Only codes 5
+// and 10 straddle a word boundary inside the 3-word block; every extract shift
+// is a COMPILE-TIME CONSTANT (fully unrolled), so wi/off never become dynamic
+// array indices — the 3 words stay register-resident, no scratch spill. Across a
+// wave the (3*chunk) word runs are contiguous -> coalesced global loads.
+//
+//   code i (i=0..15) at bit 6i in the 96-bit little-endian window w0|w1<<32|w2<<64:
+//     0: (w0>> 0)&63   1: (w0>> 6)&63   2: (w0>>12)&63   3: (w0>>18)&63
+//     4: (w0>>24)&63   5: ((w0>>30)|(w1<<2))&63          6: (w1>> 4)&63
+//     7: (w1>>10)&63   8: (w1>>16)&63   9: (w1>>22)&63  10: ((w1>>28)|(w2<<4))&63
+//    11: (w2>> 2)&63  12: (w2>> 8)&63  13: (w2>>14)&63  14: (w2>>20)&63  15: (w2>>26)&63
+//
+// AFFINE (gs=128 for every DSV4 6-bit tensor; chunks_per_group = 128/16 = 8, so a
+// 16-code chunk lies wholly within one group): factored exactly like the 2/4-bit
+// repack: temp += scale*sum(q_j*x_j) + bias*sum(x_j). subgroupAdd reduction.
+//
+// REQUIRES k % 16 == 0 (=> words_per_row = k*6/32 = 3*(k/16) integer;
+// chunks_per_row = k/16). packed[] bound as plain u32 (no dwordx4 alignment
+// needed — 3-word chunks are not 16B-multiples). Bindings/push-constants match
+// mul_mat_vec_mlx4.comp (5 buffers, 5 uints); dispatch via matvec_mlx4_pc.
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 64;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k = in_features (contraction)
+    uint nrows;       // n = out_features
+    uint group_size;  // affine group size (128 for DSV4 6-bit tensors)
+    uint packed_off;  // WORD offset into packed[] for this weight (0 for dense 2D)
+    uint sb_off;      // ELEMENT offset into scales[]/biases[]  (0 for dense 2D)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uint  packed[]; };  // contiguous 6-bit stream
+layout(binding = 1) readonly buffer Scales { float scales[]; };
+layout(binding = 2) readonly buffer Biases { float biases[]; };
+layout(binding = 3) readonly buffer Activ  { vec4  x4[];     };  // k/4 vec4s
+layout(binding = 4) writeonly buffer Dst   { float dst[];    };
+
+shared float part[NUM_ROWS][16];
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;
+    const uint words_per_row = (k >> 4u) * 3u;        // k*6/32 = 3*(k/16)
+    const uint chunks_per_row = k >> 4u;              // k/16 (3 words = 16 codes each)
+    const uint chunks_per_group = p.group_size >> 4u; // gs/16 = 8 for gs=128
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint c = tid; c < chunks_per_row; c += BLOCK_SIZE) {
+        const uint g = c / chunks_per_group;   // affine group of this 16-code chunk
+        const uint xb = c << 2u;               // 4*c (vec4 index base for 16 acts)
+        const vec4 x0 = x4[xb + 0u];
+        const vec4 x1 = x4[xb + 1u];
+        const vec4 x2 = x4[xb + 2u];
+        const vec4 x3 = x4[xb + 3u];
+        const float xsum = dot(x0 + x1 + x2 + x3, vec4(1.0));
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint wbase = p.packed_off + r * words_per_row + c * 3u;
+            const uint w0 = packed[wbase + 0u];
+            const uint w1 = packed[wbase + 1u];
+            const uint w2 = packed[wbase + 2u];
+            // 16 contiguous 6-bit codes -> 4 vec4 (codes 5 and 10 cross a word).
+            const vec4 q0 = vec4(float((w0 >>  0u) & 0x3Fu), float((w0 >>  6u) & 0x3Fu),
+                                 float((w0 >> 12u) & 0x3Fu), float((w0 >> 18u) & 0x3Fu));
+            const vec4 q1 = vec4(float((w0 >> 24u) & 0x3Fu),
+                                 float(((w0 >> 30u) | (w1 << 2u)) & 0x3Fu),
+                                 float((w1 >>  4u) & 0x3Fu), float((w1 >> 10u) & 0x3Fu));
+            const vec4 q2 = vec4(float((w1 >> 16u) & 0x3Fu), float((w1 >> 22u) & 0x3Fu),
+                                 float(((w1 >> 28u) | (w2 << 4u)) & 0x3Fu),
+                                 float((w2 >>  2u) & 0x3Fu));
+            const vec4 q3 = vec4(float((w2 >>  8u) & 0x3Fu), float((w2 >> 14u) & 0x3Fu),
+                                 float((w2 >> 20u) & 0x3Fu), float((w2 >> 26u) & 0x3Fu));
+            const float qx = dot(q0, x0) + dot(q1, x1) + dot(q2, x2) + dot(q3, x3);
+            const uint sb = p.sb_off + r * groups + g;
+            temp[n] = fma(scales[sb], qx, fma(biases[sb], xsum, temp[n]));
+        }
+    }
+
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = subgroupAdd(temp[n]);
+    }
+
+    if (gl_NumSubgroups == 1u) {
+        if (subgroupElect()) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                const uint r = first_row + n;
+                if (r < p.nrows) { dst[r] = temp[n]; }
+            }
+        }
+        return;
+    }
+
+    if (subgroupElect()) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            part[n][gl_SubgroupID] = temp[n];
+        }
+    }
+    barrier();
+    if (gl_SubgroupID == 0u) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            float acc = 0.0;
+            for (uint s = gl_SubgroupInvocationID; s < gl_NumSubgroups; s += gl_SubgroupSize) {
+                acc += part[n][s];
+            }
+            acc = subgroupAdd(acc);
+            const uint r = first_row + n;
+            if (subgroupElect() && r < p.nrows) { dst[r] = acc; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_mlx8_f32_f32.comp
+++ b/shaders/mul_mat_vec_mlx8_f32_f32.comp
@@ -1,0 +1,128 @@
+#version 450
+// MLX-affine 8-bit gs64 matvec — DeepSeek-V4-Flash shared_experts / embed_tokens
+// / lm_head (the "8-bit gs64" bucket). The thin twin of
+// mul_mat_vec_mlx2repack_f32_f32.comp for the aligned 8-bit width. NOTE: the
+// existing `mul_mat_vec_mlx4_w8` is a MISNAMED 4-bit kernel (w8 = 8 nibbles/word,
+// still 4-bit codes); this is the FIRST real 8-bit MLX-affine matvec.
+//
+// LAYOUT (MLX affine, aligned): 4 codes per u32, little-bits-first
+//   q_j = (word >> (8*(j%4))) & 0xFF
+// 8 divides 32 so a code NEVER crosses a u32 boundary — this is the aligned
+// `dequantize_mlx_affine` layout (per_word=4), byte-identical packed bytes, ZERO
+// loader change. Confirmed vs the Phase-0 oracle model::dequantize_mlx_affine_bits
+// (bits=8 path == aligned dequantize_mlx_affine).
+//
+//  (1) DWORDX4: one uvec4 load (128b) = 4 words = 16 codes; packed address
+//      amortized over 16 elements. Across a wave the uvec4 chunks are contiguous
+//      -> coalesced. Packed layout unchanged (row-major), loader permutation = id.
+//  (2) SCALE/BIAS ONCE PER CHUNK + fused affine: DSV4 8-bit tensors are gs=64, so
+//      chunks_per_group = 64/16 = 4 and each 16-elem chunk lies wholly within one
+//      affine group. affine factored exactly like the 2/4/6-bit repack:
+//        temp += scale*sum(q_j*x_j) + bias*sum(x_j)     (one fma per chunk)
+//      Algebraically == v1's per-element (scale*q_j+bias)*x_j; f32 rounding differs
+//      (fma + subgroup reassoc) -> gate ARGMAX-EXACT + max_abs_err ~ULP.
+//  (3) SUBGROUP REDUCTION: per-row subgroupAdd (wave64 GFX1013, BLOCK_SIZE<=64 =
+//      one subgroup -> no LDS, no barrier); tiny LDS combine only if BLOCK_SIZE
+//      spans >1 subgroup.
+//
+// REQUIRES k % 16 == 0 (chunks_per_row = k/16) AND packed base 16B-aligned:
+// packed_off and words_per_row (=k/4) both multiples of 4 => k % 16 == 0.
+// True for DSV4: hidden_size=4096 (k/16=256), moe/shared intermediate, vocab head
+// row length k=hidden=4096. Bindings / push-constants IDENTICAL to
+// mul_mat_vec_mlx4.comp (5 buffers, 5 uints) -> same matvec_mlx4_pc / record_to.
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 64;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k = in_features (contraction)
+    uint nrows;       // n = out_features
+    uint group_size;  // affine group size (64 for DSV4 8-bit tensors)
+    uint packed_off;  // WORD offset into packed[] for this weight (0 for dense 2D)
+    uint sb_off;      // ELEMENT offset into scales[]/biases[]  (0 for dense 2D)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uvec4 packed4[]; }; // 4 words / uvec4 = 16 codes
+layout(binding = 1) readonly buffer Scales { float scales[]; };
+layout(binding = 2) readonly buffer Biases { float biases[]; };
+layout(binding = 3) readonly buffer Activ  { vec4  x4[];     };  // k/4 vec4s
+layout(binding = 4) writeonly buffer Dst   { float dst[];    };
+
+shared float part[NUM_ROWS][16];
+
+// Unpack the 4 8-bit codes of `w` into one vec4 (codes j,j+1,j+2,j+3).
+#define Q4_8(w) vec4(float(((w) >>  0u) & 0xFFu), float(((w) >>  8u) & 0xFFu), \
+                     float(((w) >> 16u) & 0xFFu), float(((w) >> 24u) & 0xFFu))
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;
+    const uint words_per_row = k >> 2u;               // k/4 (4 codes/word)
+    const uint chunks_per_row = k >> 4u;              // k/16 (4 words = 16 codes each)
+    const uint chunks_per_group = p.group_size >> 4u; // gs/16 = 4 for gs=64
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint c = tid; c < chunks_per_row; c += BLOCK_SIZE) {
+        const uint g = c / chunks_per_group;   // affine group of this 16-elem chunk
+        const uint xb = c << 2u;               // 4*c (vec4 index base for 16 acts)
+        const vec4 x0 = x4[xb + 0u];
+        const vec4 x1 = x4[xb + 1u];
+        const vec4 x2 = x4[xb + 2u];
+        const vec4 x3 = x4[xb + 3u];
+        const float xsum = dot(x0 + x1 + x2 + x3, vec4(1.0));
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint base4 = ((p.packed_off + r * words_per_row) >> 2u) + c;
+            const uvec4 pw = packed4[base4];   // ONE dwordx4 = 16 codes
+            const float qx = dot(Q4_8(pw.x), x0) + dot(Q4_8(pw.y), x1)
+                           + dot(Q4_8(pw.z), x2) + dot(Q4_8(pw.w), x3);
+            const uint sb = p.sb_off + r * groups + g;
+            temp[n] = fma(scales[sb], qx, fma(biases[sb], xsum, temp[n]));
+        }
+    }
+
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = subgroupAdd(temp[n]);
+    }
+
+    if (gl_NumSubgroups == 1u) {
+        if (subgroupElect()) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                const uint r = first_row + n;
+                if (r < p.nrows) { dst[r] = temp[n]; }
+            }
+        }
+        return;
+    }
+
+    if (subgroupElect()) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            part[n][gl_SubgroupID] = temp[n];
+        }
+    }
+    barrier();
+    if (gl_SubgroupID == 0u) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            float acc = 0.0;
+            for (uint s = gl_SubgroupInvocationID; s < gl_NumSubgroups; s += gl_SubgroupSize) {
+                acc += part[n][s];
+            }
+            acc = subgroupAdd(acc);
+            const uint r = first_row + n;
+            if (subgroupElect() && r < p.nrows) { dst[r] = acc; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_nvfp4.comp
+++ b/shaders/mul_mat_vec_nvfp4.comp
@@ -1,0 +1,138 @@
+#version 450
+
+// NVFP4 (NVIDIA FP4 / modelopt W4A16) matrix-vector kernel for vllm-vulkan.
+//
+// Computes, for each output row r in [0, n):
+//   out[r] = sum_{j=0..k} ( E2M1[nibble(w, r, j)] * scale[r, g] ) * x[j]
+// where g = j / group_size, exactly mirroring the validated CPU reference
+// `model::dequantize_nvfp4` — EXCEPT the per-block e4m3 scale and the per-tensor
+// f32 global scale are PRE-FOLDED into `scale[r,g]` (f32) on the host at upload
+// time (`scale = e4m3(weight_scale[r,g]) * weight_scale_2`). So the shader needs
+// neither an e4m3 decode nor the global term: it just looks up the E2M1 value of
+// the 4-bit code and multiplies by the folded f32 block scale.
+//
+// The 4-bit codes are packed 2-per-byte, low nibble = even input index
+// (compressed-tensors `pack_fp4_to_uint8`). Four little-endian bytes per u32 word
+// yield the SAME bit layout as the mlx4 kernel's `shift=(j&7)*4` scheme, so the
+// nibble unpack is identical — only the value mapping (E2M1 LUT vs raw int) and
+// the absence of a bias term differ.
+//
+// Bindings (auto-numbered 0.. by record_to in buffer order):
+//   0 = packed weight  (uint[],  4-bit E2M1 codes, 8 per u32)
+//   1 = scale          (float[], folded e4m3*global, one per output-row x group)
+//   2 = activation x   (float[], length k)
+//   3 = output         (float[], length n)
+//
+// Push constants: { uint ncols(=k); uint nrows(=n); uint group_size(=16);
+//                   uint packed_off; uint sb_off; }
+// packed_off / sb_off are per-slice base offsets (0 for a plain dense weight;
+// reserved for a future per-expert MoE dispatch, mirroring mul_mat_vec_mlx4).
+//
+// One workgroup handles NUM_ROWS output rows; BLOCK_SIZE threads partition k and
+// reduce partials through shared memory. Wave64 on GFX1013; NUM_ROWS<=8.
+//
+// NUM_COLS (spec constant 2, default 1) is the batched multi-column extension
+// (spec-decode "batched verify" primitive, mirroring the f16/q8_0 base.glsl
+// `_r{rows}_c{cols}` variants). The activation is laid out [NUM_COLS, k]
+// row-major (x[col*k + j]) and the output [NUM_COLS, n] row-major
+// (dst[col*n + r]) — the same [T,k]->[T,n] convention matvec_pc13 encodes for
+// the f16/q8_0 multi-column matvec. Each thread DEQUANTIZES every weight code
+// exactly ONCE (kE2M1[code]*scale) and reuses it across all NUM_COLS token
+// columns, so the 4-bit unpack + LUT + scale ALU is amortized across the batch
+// — the whole point of the Phase-0 weight-amortization measurement. NUM_COLS=1
+// is byte-identical to the original single-column kernel by construction.
+// LDS = NUM_ROWS*NUM_COLS*BLOCK_SIZE*4; callers keep NUM_ROWS*NUM_COLS<=8.
+
+#extension GL_EXT_control_flow_attributes : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 512;
+layout(constant_id = 1) const uint NUM_ROWS = 1;
+layout(constant_id = 2) const uint NUM_COLS = 1;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k = in_features (contraction dim)
+    uint nrows;       // n = out_features
+    uint group_size;  // NVFP4 block size along k (16)
+    uint packed_off;  // base WORD offset into packed[] for this slice
+    uint sb_off;      // base ELEMENT offset into scale[] for this slice
+} p;
+
+layout(binding = 0) readonly buffer Packed { uint   packed[]; };
+layout(binding = 1) readonly buffer Scales { float  scale[];  };
+layout(binding = 2) readonly buffer Activ  { float  x[];      };
+layout(binding = 3) writeonly buffer Dst   { float  dst[];    };
+
+shared float tmpsh[NUM_ROWS][NUM_COLS][BLOCK_SIZE];
+
+// E2M1 (FP4) code -> value. Magnitudes {0,.5,1,1.5,2,3,4,6}; sign in bit 3.
+const float kE2M1[16] = float[16](
+    0.0,  0.5,  1.0,  1.5,  2.0,  3.0,  4.0,  6.0,
+   -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0
+);
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint gs = p.group_size;
+    const uint groups = k / gs;
+    const uint words_per_row = k / 8u;
+
+    float temp[NUM_ROWS][NUM_COLS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            temp[n][c] = 0.0;
+        }
+    }
+
+    // Each thread walks columns j = tid, tid+BLOCK_SIZE, ... The weight code at
+    // (r,j) is unpacked + dequantized ONCE and reused across all NUM_COLS token
+    // columns (x is [NUM_COLS,k] row-major).
+    for (uint j = tid; j < k; j += BLOCK_SIZE) {
+        const uint widx = j >> 3u;             // j / 8  word index within a row
+        const uint shift = (j & 7u) * 4u;      // (j % 8) * 4  nibble bit offset
+        const uint g = j / gs;                 // block index
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint word = packed[p.packed_off + r * words_per_row + widx];
+            const uint code = (word >> shift) & 0xFu;
+            const float w = kE2M1[code] * scale[p.sb_off + r * groups + g];
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                temp[n][c] += w * x[c * k + j];
+            }
+        }
+    }
+
+    // Reduce partial sums across the workgroup via shared memory.
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            tmpsh[n][c][tid] = temp[n][c];
+        }
+    }
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    tmpsh[n][c][tid] += tmpsh[n][c][tid + s];
+                }
+            }
+        }
+        barrier();
+    }
+    if (tid == 0) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r < p.nrows) {
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    dst[c * p.nrows + r] = tmpsh[n][c][0];
+                }
+            }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_nvfp4_e4m3.comp
+++ b/shaders/mul_mat_vec_nvfp4_e4m3.comp
@@ -1,0 +1,165 @@
+#version 450
+
+// NVFP4 (NVIDIA FP4 / modelopt W4A16) matrix-vector kernel — E4M3-RESIDENT scale
+// variant (VLLM_VULKAN_NVFP4_E4M3_SCALES=1). The footprint lever for the >=150B
+// NVFP4 tier: instead of the f32-folded per-(row,group) scale the default
+// `mul_mat_vec_nvfp4.comp` reads (32 bits / 16 elems = 2 bits/param), this kernel
+// keeps the RAW per-group e4m3 block scale resident (1 byte / 16 elems =
+// 0.5 bits/param) and re-adds the e4m3 decode + the per-tensor f32 global in the
+// inner loop. Net resident cost drops 6.0 -> 4.5 bits/param and the group=16
+// scale-buffer traffic drops 4x (1 byte vs 4). On the big BW-bound mlp/expert
+// shapes NVFP4 feeds, the extra ALU is hidden under bandwidth, so this is close
+// to a pure win (smaller + less scale traffic).
+//
+// Computes, for each output row r in [0, n):
+//   out[r] = sum_{j=0..k} ( E2M1[nibble(w,r,j)] * (E4M3[scale_byte(r,g)] * global) ) * x[j]
+// where g = j / group_size. This is the FAITHFUL two-level NVFP4 dequant of
+// `model::dequantize_nvfp4` (`E2M1[nib] * e4m3(block) * global`) with NOTHING
+// pre-folded: the raw e4m3 `.weight_scale` byte and the per-tensor
+// `.weight_scale_2` (`global`) are both applied here.
+//
+// BIT-EXACTNESS vs the f32-fold kernel: the f32-fold path stores
+// `folded = e4m3_to_f32(byte) * global` (host f32) and the shader does
+// `E2M1[code] * folded`. Here we compute `bscale = kE4M3[byte] * global` as a
+// SUBEXPRESSION (parenthesized) then `E2M1[code] * bscale`. kE4M3 is bit-equal to
+// `model::e4m3_to_f32` for all 256 codes (proven by fp8_shader_lut_matches_e4m3),
+// so `kE4M3[byte]*global` (GPU f32) == `e4m3_to_f32(byte)*global` (host f32) —
+// the same IEEE-754 single-precision multiply — and the outer `E2M1*bscale` then
+// matches the f32-fold kernel bit-for-bit. Do NOT rewrite as
+// `E2M1[code]*kE4M3[byte]*global` (left-assoc -> (E2M1*kE4M3)*global, a different
+// rounding order) — the parentheses are load-bearing for argmax-exactness.
+//
+// The e4m3 scale buffer is uploaded as raw bytes and read as uint[] with an
+// absolute-byte extract (word = sidx>>2; shift = (sidx&3)*8), exactly like the
+// fp8 kernel — no GL_EXT_shader_8bit_storage needed. The 4-bit weight nibbles are
+// unpacked identically to `mul_mat_vec_nvfp4.comp`.
+//
+// Bindings (auto-numbered 0.. by record_to in buffer order):
+//   0 = packed weight  (uint[],  4-bit E2M1 codes, 8 per u32)
+//   1 = scale          (uint[],  raw e4m3 block-scale bytes, 4 per u32)
+//   2 = activation x   (float[], length k)
+//   3 = output         (float[], length n)
+//
+// Push constants: { uint ncols(=k); uint nrows(=n); uint group_size(=16);
+//                   uint packed_off; uint sb_off; float global; }
+// packed_off is the base WORD offset into packed[] for this slice; sb_off the
+// base BYTE-ELEMENT offset into the e4m3 scale[] (both 0 for a plain dense
+// weight; reserved for a future per-expert MoE dispatch). global is the
+// per-tensor `.weight_scale_2` scalar.
+
+#extension GL_EXT_control_flow_attributes : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 512;
+layout(constant_id = 1) const uint NUM_ROWS = 1;
+
+layout(push_constant) uniform parameter {
+    uint  ncols;       // k = in_features (contraction dim)
+    uint  nrows;       // n = out_features
+    uint  group_size;  // NVFP4 block size along k (16)
+    uint  packed_off;  // base WORD offset into packed[] for this slice
+    uint  sb_off;      // base BYTE-ELEMENT offset into scale[] for this slice
+    float global;      // per-tensor weight_scale_2
+} p;
+
+layout(binding = 0) readonly buffer Packed { uint  packed[]; };
+layout(binding = 1) readonly buffer Scales { uint  scaleb[]; };
+layout(binding = 2) readonly buffer Activ  { float x[];      };
+layout(binding = 3) writeonly buffer Dst   { float dst[];    };
+
+shared float tmpsh[NUM_ROWS][BLOCK_SIZE];
+
+// E2M1 (FP4) code -> value. Magnitudes {0,.5,1,1.5,2,3,4,6}; sign in bit 3.
+const float kE2M1[16] = float[16](
+    0.0,  0.5,  1.0,  1.5,  2.0,  3.0,  4.0,  6.0,
+   -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0
+);
+
+// E4M3 (1 sign, 4 exp bias-7, 3 mantissa) code -> value, ARITHMETIC decode.
+// Was a 256-entry `const float kE4M3[256]` LUT indexed by the raw scale byte; on
+// GFX1013/ACO a DIVERGENT index into a 256-elem const array is NOT a memory load
+// — it lowers to a ~255-wide v_cndmask SELECT CASCADE (~16x the VALU of the dot's
+// kE2M1[16] lookup). Same address-gen-class pathology, and same cure, as the
+// nvfp4_e4m3repack twin (this is the verbatim kE4M3_decode from that kernel).
+// BIT-EXACT vs the old kE4M3[byte] for all 256 codes (fp8_arith_decode_matches_e4m3
+// + fp8_shader_lut_matches_e4m3 together prove decode == e4m3_to_f32 == LUT), so
+// `kE4M3_decode(byte)*global` is bit-identical to `kE4M3[byte]*global` ->
+// argmax-exactness (and the f32-fold parity below) preserved.
+float kE4M3_decode(uint b) {
+    const uint s = b & 0x80u;               // sign bit (in position 7)
+    const uint e = (b >> 3u) & 0xFu;        // 4-bit exponent (bias 7)
+    const uint m = b & 0x7u;                // 3-bit mantissa
+    float mag;
+    if (e == 0u) {
+        mag = float(m) * 0.001953125;       // subnormal: m * 2^-9 (exact)
+    } else if (e == 15u && m == 7u) {
+        mag = 0.0;                          // e4m3 nan-slot -> 0.0 (LUT contract)
+    } else {
+        mag = uintBitsToFloat(((e + 120u) << 23u) | (m << 20u));  // normal
+    }
+    return uintBitsToFloat(floatBitsToUint(mag) | (s << 24u));    // sign -> bit 31
+}
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint gs = p.group_size;
+    const uint groups = k / gs;
+    const uint words_per_row = k / 8u;
+    const float global = p.global;
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = 0.0;
+    }
+
+    // Each thread walks columns j = tid, tid+BLOCK_SIZE, ...
+    for (uint j = tid; j < k; j += BLOCK_SIZE) {
+        const float xv = x[j];
+        const uint widx = j >> 3u;             // j / 8  word index within a row
+        const uint shift = (j & 7u) * 4u;      // (j % 8) * 4  nibble bit offset
+        const uint g = j / gs;                 // block index
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint word = packed[p.packed_off + r * words_per_row + widx];
+            const uint code = (word >> shift) & 0xFu;
+            // Absolute-byte extract of the raw e4m3 block scale (reinterpret the
+            // byte buffer as uint[], mirroring the fp8 kernel).
+            const uint sidx  = p.sb_off + r * groups + g;
+            const uint sword = scaleb[sidx >> 2u];
+            const uint sbyte = (sword >> ((sidx & 3u) * 8u)) & 0xFFu;
+            // Parentheses are load-bearing for bit-exactness vs the f32-fold
+            // kernel — see the header. bscale == the f32-fold `folded[r,g]`.
+            const float bscale = kE4M3_decode(sbyte) * global;
+            const float w = kE2M1[code] * bscale;
+            temp[n] += w * xv;
+        }
+    }
+
+    // Reduce partial sums across the workgroup via shared memory.
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        tmpsh[n][tid] = temp[n];
+    }
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                tmpsh[n][tid] += tmpsh[n][tid + s];
+            }
+        }
+        barrier();
+    }
+    if (tid == 0) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r < p.nrows) {
+                dst[r] = tmpsh[n][0];
+            }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_nvfp4_e4m3repack_f32_f32.comp
+++ b/shaders/mul_mat_vec_nvfp4_e4m3repack_f32_f32.comp
@@ -1,0 +1,191 @@
+#version 450
+// NVFP4 matvec — VALU-bound repack refactor, E4M3-RESIDENT scale variant
+// (VLLM_VULKAN_NVFP4_REPACK=1 AND VLLM_VULKAN_NVFP4_E4M3_SCALES=1). The e4m3-
+// resident twin of mul_mat_vec_nvfp4repack_f32_f32: same dwordx4 word-granular
+// load + subgroupAdd reduction + per-group (not per-element) scale, but the
+// per-group scale is the RAW e4m3 block byte (0.5 bits/param resident) decoded +
+// multiplied by the per-tensor f32 global IN the inner loop (hoisted ONCE per
+// chunk, not per element), instead of the pre-folded f32 scale the default
+// repack reads. So this stacks the >=150B footprint lever (e4m3-resident scales,
+// 4.5 bits/param) on top of the address-gen win. See mul_mat_vec_nvfp4_e4m3.comp
+// (the v1 kernel this refactors) for the layout/bit-exactness contract.
+//
+// Computes, for each output row r in [0, n):
+//   out[r] = sum_j ( E2M1[nibble(w,r,j)] * (E4M3[scale_byte(r,g)] * global) ) * x[j]
+// with g = j/16, factored per 16-elem group as scale*sum(E2M1*x) (two fma/chunk).
+//
+// BIT-EXACTNESS vs the f32-fold repack: bscale = kE4M3[byte] * global as a
+// PARENTHESIZED subexpression == the f32-fold path's stored folded scale
+// (e4m3_to_f32(byte)*global, same IEEE-754 single multiply), so the outer
+// scale*dot matches the f32-fold repack bit-for-bit -> both are argmax-exact vs
+// v1. Do NOT reassociate the global into the dot.
+//
+// The e4m3 scale buffer is uploaded as raw bytes, read as uint[] with an
+// absolute-byte extract (word = sidx>>2; shift = (sidx&3)*8) — exactly like
+// mul_mat_vec_nvfp4_e4m3.comp / the fp8 kernel; no 8-bit-storage extension.
+//
+// REQUIRES k % 32 == 0, group_size == 16, packed base 16B-aligned (see
+// mul_mat_vec_nvfp4repack_f32_f32.comp). Bindings / push-constants IDENTICAL to
+// mul_mat_vec_nvfp4_e4m3.comp (4 buffers, 5 uints + float global).
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 64;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint  ncols;       // k = in_features (contraction)
+    uint  nrows;       // n = out_features
+    uint  group_size;  // NVFP4 block size along k (16)
+    uint  packed_off;  // WORD offset into packed[] for this slice (0 for dense 2D)
+    uint  sb_off;      // BYTE-ELEMENT offset into scale[] for this slice
+    float global;      // per-tensor weight_scale_2
+} p;
+
+layout(binding = 0) readonly buffer Packed { uvec4 packed4[]; }; // 4 words / uvec4 = 32 nibbles
+layout(binding = 1) readonly buffer Scales { uint  scaleb[]; };  // raw e4m3 block bytes, 4/u32
+layout(binding = 2) readonly buffer Activ  { vec4  x4[];     };  // k/4 vec4s
+layout(binding = 3) writeonly buffer Dst   { float dst[];    };
+
+shared float part[NUM_ROWS][16];
+
+// E2M1 (FP4) code -> value. Magnitudes {0,.5,1,1.5,2,3,4,6}; sign in bit 3.
+const float kE2M1[16] = float[16](
+    0.0,  0.5,  1.0,  1.5,  2.0,  3.0,  4.0,  6.0,
+   -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0
+);
+
+// E4M3 (1 sign, 4 exp bias-7, 3 mantissa) code -> value, ARITHMETIC decode.
+//
+// PERF BUG FIX (was a 256-entry `const float kE4M3[256]` LUT indexed by the raw
+// scale byte): on GFX1013/ACO a DIVERGENT index into a 256-elem const array does
+// not become a memory load — it lowers to a ~255-wide v_cndmask SELECT CASCADE
+// (or a scratch-spilled indexable temp). In v1 that cost is hidden under the
+// uncoalesced per-element address-gen; but the repack KILLED the address-gen, so
+// the LUT cascade became the whole kernel (2 lookups/chunk, ~16x the VALU of the
+// dot's kE2M1[16] lookups) -> occupancy/latency-hiding collapse -> ~14.4ms/op
+// (0.08x). Decoding e4m3 with ~8 integer/bit ops instead removes the array
+// entirely and restores the f32-fold twin's address-gen profile.
+//
+// BIT-EXACTNESS: this returns the SAME f32 bit pattern as the old kE4M3[byte] for
+// all 256 codes (verified exhaustively, incl. subnormals, both signed zeros, and
+// the e4m3 nan-slot 0x7F/0xFF -> 0.0 the LUT encodes). Normals assemble the f32
+// bits directly (E=e+120, M=m<<20) so no v_exp_f32 rounding enters; subnormals use
+// float(m)*2^-9 (exact); sign is OR'd onto bit 31. So kE4M3_decode(b)*global is
+// bit-identical to the old kE4M3[b]*global -> argmax-exactness preserved.
+float kE4M3_decode(uint b) {
+    const uint s = b & 0x80u;               // sign bit (in position 7)
+    const uint e = (b >> 3u) & 0xFu;        // 4-bit exponent (bias 7)
+    const uint m = b & 0x7u;                // 3-bit mantissa
+    float mag;
+    if (e == 0u) {
+        mag = float(m) * 0.001953125;       // subnormal: m * 2^-9 (exact)
+    } else if (e == 15u && m == 7u) {
+        mag = 0.0;                          // e4m3 nan-slot -> 0.0 (LUT contract)
+    } else {
+        // normal: (1 + m/8) * 2^(e-7); assemble the f32 bits exactly.
+        mag = uintBitsToFloat(((e + 120u) << 23u) | (m << 20u));
+    }
+    return uintBitsToFloat(floatBitsToUint(mag) | (s << 24u));
+}
+
+// Decode the raw e4m3 block-scale byte at element index `sidx` and fold the
+// per-tensor global — parenthesized to match the f32-fold repack's stored scale.
+float block_scale(uint sidx, float global) {
+    const uint sword = scaleb[sidx >> 2u];
+    const uint sbyte = (sword >> ((sidx & 3u) * 8u)) & 0xFFu;
+    return kE4M3_decode(sbyte) * global;  // == e4m3_to_f32(byte) * global (host f32-fold)
+}
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;             // = k/16 = 2*chunks_per_row
+    const uint words_per_row = k >> 3u;               // k/8
+    const uint chunks_per_row = k >> 5u;              // k/32 (4 words = 32 nibbles each)
+    const float global = p.global;
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint c = tid; c < chunks_per_row; c += BLOCK_SIZE) {
+        const uint g0 = c << 1u;               // group of first 16 elems (gs==16)
+        const uint g1 = g0 + 1u;               // group of next 16 elems
+        const uint xb = c << 3u;               // 8*c  (vec4 index base)
+        const vec4 x0 = x4[xb + 0u];
+        const vec4 x1 = x4[xb + 1u];
+        const vec4 x2 = x4[xb + 2u];
+        const vec4 x3 = x4[xb + 3u];
+        const vec4 x4v = x4[xb + 4u];
+        const vec4 x5 = x4[xb + 5u];
+        const vec4 x6 = x4[xb + 6u];
+        const vec4 x7 = x4[xb + 7u];
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint base4 = ((p.packed_off + r * words_per_row) >> 2u) + c;
+            const uvec4 pw = packed4[base4];
+            const float qxA =
+                  dot(vec4(kE2M1[ pw.x        & 0xFu], kE2M1[(pw.x >>  4u) & 0xFu],
+                           kE2M1[(pw.x >>  8u) & 0xFu], kE2M1[(pw.x >> 12u) & 0xFu]), x0)
+                + dot(vec4(kE2M1[(pw.x >> 16u) & 0xFu], kE2M1[(pw.x >> 20u) & 0xFu],
+                           kE2M1[(pw.x >> 24u) & 0xFu], kE2M1[(pw.x >> 28u) & 0xFu]), x1)
+                + dot(vec4(kE2M1[ pw.y        & 0xFu], kE2M1[(pw.y >>  4u) & 0xFu],
+                           kE2M1[(pw.y >>  8u) & 0xFu], kE2M1[(pw.y >> 12u) & 0xFu]), x2)
+                + dot(vec4(kE2M1[(pw.y >> 16u) & 0xFu], kE2M1[(pw.y >> 20u) & 0xFu],
+                           kE2M1[(pw.y >> 24u) & 0xFu], kE2M1[(pw.y >> 28u) & 0xFu]), x3);
+            const float qxB =
+                  dot(vec4(kE2M1[ pw.z        & 0xFu], kE2M1[(pw.z >>  4u) & 0xFu],
+                           kE2M1[(pw.z >>  8u) & 0xFu], kE2M1[(pw.z >> 12u) & 0xFu]), x4v)
+                + dot(vec4(kE2M1[(pw.z >> 16u) & 0xFu], kE2M1[(pw.z >> 20u) & 0xFu],
+                           kE2M1[(pw.z >> 24u) & 0xFu], kE2M1[(pw.z >> 28u) & 0xFu]), x5)
+                + dot(vec4(kE2M1[ pw.w        & 0xFu], kE2M1[(pw.w >>  4u) & 0xFu],
+                           kE2M1[(pw.w >>  8u) & 0xFu], kE2M1[(pw.w >> 12u) & 0xFu]), x6)
+                + dot(vec4(kE2M1[(pw.w >> 16u) & 0xFu], kE2M1[(pw.w >> 20u) & 0xFu],
+                           kE2M1[(pw.w >> 24u) & 0xFu], kE2M1[(pw.w >> 28u) & 0xFu]), x7);
+            const uint sbase = p.sb_off + r * groups;
+            const float scaleA = block_scale(sbase + g0, global);
+            const float scaleB = block_scale(sbase + g1, global);
+            temp[n] = fma(scaleA, qxA, fma(scaleB, qxB, temp[n]));
+        }
+    }
+
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = subgroupAdd(temp[n]);
+    }
+
+    if (gl_NumSubgroups == 1u) {
+        if (subgroupElect()) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                const uint r = first_row + n;
+                if (r < p.nrows) { dst[r] = temp[n]; }
+            }
+        }
+        return;
+    }
+
+    if (subgroupElect()) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            part[n][gl_SubgroupID] = temp[n];
+        }
+    }
+    barrier();
+    if (gl_SubgroupID == 0u) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            float acc = 0.0;
+            for (uint s = gl_SubgroupInvocationID; s < gl_NumSubgroups; s += gl_SubgroupSize) {
+                acc += part[n][s];
+            }
+            acc = subgroupAdd(acc);
+            const uint r = first_row + n;
+            if (subgroupElect() && r < p.nrows) { dst[r] = acc; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_nvfp4repack_f32_f32.comp
+++ b/shaders/mul_mat_vec_nvfp4repack_f32_f32.comp
@@ -1,0 +1,166 @@
+#version 450
+// NVFP4 (NVIDIA FP4 / modelopt W4A16) matvec — VALU-bound repack refactor
+// (VLLM_VULKAN_NVFP4_REPACK). The nvfp4 twin of mul_mat_vec_mlx4repack_f32_f32:
+// mul_mat_vec_nvfp4.comp (v1) is byte-for-byte the pre-refactor mlx4 pattern
+// (scalar-per-nibble uncoalesced load, per-element packed-address recompute,
+// per-element scale, 16KB-LDS barrier-tree epilogue) -> the same gfx1013
+// ISA disease the mlx4 probe found (~90% of VALU is address-gen). This kernel
+// tunnels through it exactly as the mlx4 repack did:
+//
+//  (1) DWORDX4 word-granular processing: each thread walks a CONTIGUOUS run of
+//      4 packed words (= 32 nibbles = 32 contraction elements) via ONE uvec4
+//      load (global_load_dwordx4, 128b). One packed address amortizes over 32
+//      elements (v1 recomputed a full address PER element). Across a wave the
+//      4-word chunks are contiguous -> coalesced. The packed layout is
+//      UNCHANGED: the compressed-tensors `pack_fp4_to_uint8` order (low nibble =
+//      even in-index, 8 nibbles/word, row-major) IS already the coalescing-
+//      friendly contiguous-4-word order, so there is ZERO loader/upload change
+//      (bytes bit-identical to mul_mat_vec_nvfp4.comp's packed buffer). See
+//      push_constants::nvfp4_dispatch / matvec_nvfp4_variant_k.
+//
+//  (2) SCALE ONCE PER GROUP + fused affine: NVFP4 group_size = 16, so a 32-elem
+//      chunk spans EXACTLY 2 blocks (halves). Each half's per-group f32 scale
+//      (folded e4m3*global on upload, like v1) is loaded ONCE per chunk and
+//      factored out of the 16-element dot:
+//        temp += scaleA*sum_{jA}(E2M1[q]*x) + scaleB*sum_{jB}(E2M1[q]*x)
+//      (two fma per chunk). This is algebraically == v1's per-element
+//      (E2M1[q]*scale)*x but the f32 rounding differs (fma + reassociation) ->
+//      re-gate ARGMAX-EXACT + max_abs_err, NOT byte-identity. Unlike mlx4 there
+//      is NO bias term (E2M1 is a value LUT, not affine int) -> simpler than the
+//      mlx4 repack (no xsum, no bias buffer).
+//
+//  (3) SUBGROUP REDUCTION: the 16KB-LDS log2(BLOCK) barrier tree of v1 is
+//      replaced by a per-row subgroupAdd (wave64 GFX1013: BLOCK_SIZE<=64 is one
+//      subgroup -> no LDS, no barrier), with a tiny LDS combine only when
+//      BLOCK_SIZE spans >1 subgroup.
+//
+// REQUIRES k % 32 == 0 (chunks_per_row = k/32), group_size == 16 (2 groups per
+// chunk) AND packed base 16B-aligned: packed_off and words_per_row (=k/8) both
+// multiples of 4 — guaranteed by k%32==0 (words_per_row = 4*(k/32); per-expert
+// packed_off = e*n*(k/8) is then a multiple of 4 for ANY expert/n). Bindings /
+// push-constants are IDENTICAL to mul_mat_vec_nvfp4.comp (4 buffers, 5 uints), so
+// it drops into the same dispatch (matvec_mlx4_pc / record_to).
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 64;
+layout(constant_id = 1) const uint NUM_ROWS = 2;
+
+layout(push_constant) uniform parameter {
+    uint ncols;       // k = in_features (contraction)
+    uint nrows;       // n = out_features
+    uint group_size;  // NVFP4 block size along k (16)
+    uint packed_off;  // WORD offset into packed[] for this slice (0 for dense 2D)
+    uint sb_off;      // ELEMENT offset into scale[] for this slice (0 for dense 2D)
+} p;
+
+layout(binding = 0) readonly buffer Packed { uvec4 packed4[]; }; // 4 words / uvec4 = 32 nibbles
+layout(binding = 1) readonly buffer Scales { float scales[]; };  // folded e4m3*global, per (row,group)
+layout(binding = 2) readonly buffer Activ  { vec4  x4[];     };  // k/4 vec4s
+layout(binding = 3) writeonly buffer Dst   { float dst[];    };
+
+// Cross-subgroup combine scratch (only touched when BLOCK_SIZE > subgroup size).
+shared float part[NUM_ROWS][16];
+
+// E2M1 (FP4) code -> value. Magnitudes {0,.5,1,1.5,2,3,4,6}; sign in bit 3.
+const float kE2M1[16] = float[16](
+    0.0,  0.5,  1.0,  1.5,  2.0,  3.0,  4.0,  6.0,
+   -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0
+);
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint first_row = NUM_ROWS * gl_WorkGroupID.x;
+
+    const uint k = p.ncols;
+    const uint groups = k / p.group_size;             // = k/16 = 2*chunks_per_row
+    const uint words_per_row = k >> 3u;               // k/8
+    const uint chunks_per_row = k >> 5u;              // k/32 (4 words = 32 nibbles each)
+
+    float temp[NUM_ROWS];
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) { temp[n] = 0.0; }
+
+    for (uint c = tid; c < chunks_per_row; c += BLOCK_SIZE) {
+        // group_size == 16: first 16 elems -> group 2c, next 16 -> group 2c+1.
+        const uint g0 = c << 1u;
+        const uint g1 = g0 + 1u;
+        // 8 vec4 of activations covering j in [32c, 32c+32).
+        const uint xb = c << 3u;               // 8*c  (vec4 index base)
+        const vec4 x0 = x4[xb + 0u];  // j[32c   ..32c+ 4)  group g0
+        const vec4 x1 = x4[xb + 1u];  // j[32c+ 4..32c+ 8)  group g0
+        const vec4 x2 = x4[xb + 2u];  // j[32c+ 8..32c+12)  group g0
+        const vec4 x3 = x4[xb + 3u];  // j[32c+12..32c+16)  group g0
+        const vec4 x4v = x4[xb + 4u]; // j[32c+16..32c+20)  group g1
+        const vec4 x5 = x4[xb + 5u];  // j[32c+20..32c+24)  group g1
+        const vec4 x6 = x4[xb + 6u];  // j[32c+24..32c+28)  group g1
+        const vec4 x7 = x4[xb + 7u];  // j[32c+28..32c+32)  group g1
+
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            const uint r = first_row + n;
+            if (r >= p.nrows) { continue; }
+            const uint base4 = ((p.packed_off + r * words_per_row) >> 2u) + c;
+            const uvec4 pw = packed4[base4];   // ONE dwordx4 = 32 nibbles
+            // Group A (first 16 elems): words pw.x (j 32c..+8) + pw.y (+8..+16).
+            const float qxA =
+                  dot(vec4(kE2M1[ pw.x        & 0xFu], kE2M1[(pw.x >>  4u) & 0xFu],
+                           kE2M1[(pw.x >>  8u) & 0xFu], kE2M1[(pw.x >> 12u) & 0xFu]), x0)
+                + dot(vec4(kE2M1[(pw.x >> 16u) & 0xFu], kE2M1[(pw.x >> 20u) & 0xFu],
+                           kE2M1[(pw.x >> 24u) & 0xFu], kE2M1[(pw.x >> 28u) & 0xFu]), x1)
+                + dot(vec4(kE2M1[ pw.y        & 0xFu], kE2M1[(pw.y >>  4u) & 0xFu],
+                           kE2M1[(pw.y >>  8u) & 0xFu], kE2M1[(pw.y >> 12u) & 0xFu]), x2)
+                + dot(vec4(kE2M1[(pw.y >> 16u) & 0xFu], kE2M1[(pw.y >> 20u) & 0xFu],
+                           kE2M1[(pw.y >> 24u) & 0xFu], kE2M1[(pw.y >> 28u) & 0xFu]), x3);
+            // Group B (next 16 elems): words pw.z (j +16..+24) + pw.w (+24..+32).
+            const float qxB =
+                  dot(vec4(kE2M1[ pw.z        & 0xFu], kE2M1[(pw.z >>  4u) & 0xFu],
+                           kE2M1[(pw.z >>  8u) & 0xFu], kE2M1[(pw.z >> 12u) & 0xFu]), x4v)
+                + dot(vec4(kE2M1[(pw.z >> 16u) & 0xFu], kE2M1[(pw.z >> 20u) & 0xFu],
+                           kE2M1[(pw.z >> 24u) & 0xFu], kE2M1[(pw.z >> 28u) & 0xFu]), x5)
+                + dot(vec4(kE2M1[ pw.w        & 0xFu], kE2M1[(pw.w >>  4u) & 0xFu],
+                           kE2M1[(pw.w >>  8u) & 0xFu], kE2M1[(pw.w >> 12u) & 0xFu]), x6)
+                + dot(vec4(kE2M1[(pw.w >> 16u) & 0xFu], kE2M1[(pw.w >> 20u) & 0xFu],
+                           kE2M1[(pw.w >> 24u) & 0xFu], kE2M1[(pw.w >> 28u) & 0xFu]), x7);
+            const uint sbase = p.sb_off + r * groups;
+            temp[n] = fma(scales[sbase + g0], qxA, fma(scales[sbase + g1], qxB, temp[n]));
+        }
+    }
+
+    // Reduce each row across the subgroup.
+    [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+        temp[n] = subgroupAdd(temp[n]);
+    }
+
+    // Single-subgroup workgroup (BLOCK_SIZE<=64, the target): lane 0 writes.
+    if (gl_NumSubgroups == 1u) {
+        if (subgroupElect()) {
+            [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+                const uint r = first_row + n;
+                if (r < p.nrows) { dst[r] = temp[n]; }
+            }
+        }
+        return;
+    }
+
+    // Multi-subgroup: each subgroup stashes its partial, subgroup 0 combines.
+    if (subgroupElect()) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            part[n][gl_SubgroupID] = temp[n];
+        }
+    }
+    barrier();
+    if (gl_SubgroupID == 0u) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            float acc = 0.0;
+            for (uint s = gl_SubgroupInvocationID; s < gl_NumSubgroups; s += gl_SubgroupSize) {
+                acc += part[n][s];
+            }
+            acc = subgroupAdd(acc);
+            const uint r = first_row + n;
+            if (subgroupElect() && r < p.nrows) { dst[r] = acc; }
+        }
+    }
+}

--- a/shaders/mul_mat_vec_q8_0_cols.comp
+++ b/shaders/mul_mat_vec_q8_0_cols.comp
@@ -1,0 +1,106 @@
+#version 450
+
+// Q8_0 batched multi-column matrix-vector kernel (spec-decode "batched verify"
+// primitive). Computes, for each output row r in [0,n) and token-column c in
+// [0,NUM_COLS):  dst[c,r] = sum_{j=0..k} (qs[r,j] * d[r,blk(j)]) * x[c,j].
+//
+// Like mul_mat_vec_f16_cols / mul_mat_vec_nvfp4, each thread DEQUANTIZES each
+// weight element (int8 * f16 block scale) EXACTLY ONCE and reuses it across all
+// NUM_COLS token columns (columns are the INNER loop) -- the genuine
+// stream-weight-once amortization the generic mul_mat_vec.comp base.glsl path
+// does NOT achieve (it re-dequantizes the weight per column -> ~linear T).
+//
+// Weight is the standard ggml q8_0 block layout (matches model::quantize_q8_0 /
+// dequant_q8_0_to_f32): row-major [n, k/32] blocks, each block = { f16 d; int8
+// qs[32] }. Block for (r,j) = data_a[r*(k/32) + j/32]; qs index = j%32.
+// Activation [NUM_COLS,k] row-major (x[c*k+j], f32); output [NUM_COLS,n]
+// row-major (dst[c*n+r], f32). 2D workgroup grid -> n may exceed 65535.
+//
+// Bindings: 0 = weight (q8_0 blocks), 1 = activation x (f32), 2 = output (f32).
+// Push constants: { uint ncols(=k); uint nrows(=n); }. k must be a multiple of
+// 32. NUM_ROWS*NUM_COLS<=8 keeps LDS (rows*cols*BLOCK_SIZE*4) <= 16 KB.
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint BLOCK_SIZE = 512;
+layout(constant_id = 1) const uint NUM_ROWS = 1;
+layout(constant_id = 2) const uint NUM_COLS = 1;
+
+layout(push_constant) uniform parameter {
+    uint ncols;  // k = in_features (contraction dim), multiple of 32
+    uint nrows;  // n = out_features
+} p;
+
+struct block_q8_0 {
+    float16_t d;
+    int8_t qs[32];
+};
+
+layout(binding = 0) readonly buffer W    { block_q8_0 data_a[]; };
+layout(binding = 1) readonly buffer Activ { float x[];         };
+layout(binding = 2) writeonly buffer Dst { float dst[];        };
+
+shared float tmpsh[NUM_ROWS][NUM_COLS][BLOCK_SIZE];
+
+void main() {
+    const uint tid = gl_LocalInvocationID.x;
+    const uint wg_lin = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x;
+    const uint first_row = NUM_ROWS * wg_lin;
+    const uint k = p.ncols;
+    const uint blocks_per_row = k >> 5;   // k / 32
+
+    float temp[NUM_ROWS][NUM_COLS];
+    [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            temp[nr][c] = 0.0;
+        }
+    }
+
+    for (uint j = tid; j < k; j += BLOCK_SIZE) {
+        const uint blk_in_row = j >> 5;    // j / 32
+        const uint qi = j & 31u;           // j % 32
+        [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+            const uint r = first_row + nr;
+            if (r >= p.nrows) { continue; }
+            const uint b = r * blocks_per_row + blk_in_row;
+            // Dequantize the weight element ONCE (int8 * f16 scale).
+            const float wv = float(int(data_a[b].qs[qi])) * float(data_a[b].d);
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                temp[nr][c] += wv * x[c * k + j];
+            }
+        }
+    }
+
+    [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            tmpsh[nr][c][tid] = temp[nr][c];
+        }
+    }
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    tmpsh[nr][c][tid] += tmpsh[nr][c][tid + s];
+                }
+            }
+        }
+        barrier();
+    }
+    if (tid == 0) {
+        [[unroll]] for (uint nr = 0; nr < NUM_ROWS; ++nr) {
+            const uint r = first_row + nr;
+            if (r < p.nrows) {
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    dst[c * p.nrows + r] = tmpsh[nr][c][0];
+                }
+            }
+        }
+    }
+}

--- a/shaders/paged_attn_decode_f16_sg.comp
+++ b/shaders/paged_attn_decode_f16_sg.comp
@@ -1,0 +1,128 @@
+#version 450
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_16bit_storage : require
+
+// f16-KV variant of paged_attn_decode_f32_sg (item 4b): same wave64
+// subgroup-reduced decode attention, but binding 2 (the KV cache) is
+// float16_t — halves the resident KV-plane footprint. The QK dot and the V
+// accumulate both promote the loaded f16 value to float before use, so all
+// arithmetic (softmax, accumulation) stays f32; only the STORED K/V loses
+// precision. Keeps `window_start` (sliding-window causal) unlike the older
+// scalar/coop f16 variants, which lack it and can't back the resident
+// 1-CB/decode seam.
+//
+// Bindings, push-constants and dispatch geometry are otherwise identical to
+// paged_attn_decode_f32_sg (drop-in: num_q_heads workgroups of 64 threads).
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer QInput {
+    float q[];
+};
+
+layout(binding = 1) readonly buffer BlockTable {
+    uint blocks[];
+};
+
+layout(binding = 2) readonly buffer KVCache {
+    float16_t cache[];
+};
+
+layout(binding = 3) writeonly buffer Output {
+    float output_data[];
+};
+
+layout(push_constant) uniform parameter {
+    uint seq_len;
+    uint num_q_heads;
+    uint num_kv_heads;
+    uint head_size;
+    uint block_size;
+    uint layer_base_elements;
+    uint plane_elements_per_block;
+    uint block_elements;
+    float scale;
+    uint window_start;   // first token_idx to attend (sliding window; 0 = full causal)
+} p;
+
+// 64 lanes * 8 dims/lane = up to head_size 512 (covers gemma global 512).
+const uint MAX_DIMS_PER_LANE = 8u;
+
+uint kv_base_for_token(uint token_idx, uint kv_head) {
+    const uint logical_block_id = token_idx / p.block_size;
+    const uint token_offset_in_block =
+        token_idx - logical_block_id * p.block_size;
+    const uint physical_block_id = blocks[logical_block_id];
+    const uint elements_per_token = p.num_kv_heads * p.head_size;
+    return p.layer_base_elements +
+        physical_block_id * p.block_elements +
+        token_offset_in_block * elements_per_token +
+        kv_head * p.head_size;
+}
+
+void main() {
+    const uint q_head = gl_WorkGroupID.x;
+    if (q_head >= p.num_q_heads) {
+        return;
+    }
+    const uint lane = gl_LocalInvocationID.x;          // 0..63
+    const uint D = p.head_size;
+    const uint dpl = (D + 63u) / 64u;                  // output dims this lane owns
+    const uint gqa_ratio = p.num_q_heads / p.num_kv_heads;
+    const uint kv_head = q_head / gqa_ratio;
+    const uint q_base = q_head * D;
+
+    // Cache this lane's q dims; init the online-softmax accumulators.
+    float qreg[MAX_DIMS_PER_LANE];
+    float acc[MAX_DIMS_PER_LANE];
+    for (uint i = 0u; i < dpl; i++) {
+        const uint d = lane + i * 64u;
+        qreg[i] = d < D ? q[q_base + d] : 0.0;
+        acc[i] = 0.0;
+    }
+
+    float running_max = -3.402823466e+38;
+    float denom = 0.0;
+
+    for (uint token_idx = p.window_start; token_idx < p.seq_len; token_idx++) {
+        const uint kv_base = kv_base_for_token(token_idx, kv_head);
+
+        // QK: each lane sums its dims, subgroupAdd reduces to the full dot
+        // (broadcast to all lanes — no shared memory, no barrier). Promote
+        // the f16-stored key to float before the multiply-accumulate.
+        float partial = 0.0;
+        for (uint i = 0u; i < dpl; i++) {
+            const uint d = lane + i * 64u;
+            if (d < D) {
+                partial += qreg[i] * float(cache[kv_base + d]);
+            }
+        }
+        const float logit = subgroupAdd(partial) * p.scale;
+
+        const float new_max = max(running_max, logit);
+        const float old_scale = exp(running_max - new_max);
+        const float weight = exp(logit - new_max);
+        denom = denom * old_scale + weight;
+
+        // V accumulate: each lane updates only the dims it owns. Promote the
+        // f16-stored value to float before the multiply-accumulate.
+        const uint v_base = kv_base + p.plane_elements_per_block;
+        for (uint i = 0u; i < dpl; i++) {
+            const uint d = lane + i * 64u;
+            if (d < D) {
+                acc[i] = acc[i] * old_scale + weight * float(cache[v_base + d]);
+            }
+        }
+        running_max = new_max;
+    }
+
+    const float inv = denom > 0.0 ? 1.0 / denom : 0.0;
+    for (uint i = 0u; i < dpl; i++) {
+        const uint d = lane + i * 64u;
+        if (d < D) {
+            output_data[q_base + d] = acc[i] * inv;
+        }
+    }
+}

--- a/shaders/paged_attn_decode_f32_sg.comp
+++ b/shaders/paged_attn_decode_f32_sg.comp
@@ -1,0 +1,142 @@
+#version 450
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+// Fast single-query decode attention: ONE wave64 subgroup per q_head.
+//
+// vs paged_attn_decode_f32 (one thread per output element, each re-scanning the
+// whole head_dim for EVERY token => the QK dot is recomputed head_dim times):
+// here the 64 lanes cooperatively compute each QK dot ONCE via subgroupAdd, and
+// each lane owns ceil(head_dim/64) output dims for the value accumulation. So the
+// work per head drops from ~head_dim^2 * seq_len to ~2 * head_dim * seq_len, and
+// the reduction is a single subgroup op per token (NO workgroup barriers, unlike
+// the shared-memory tree-reduce in paged_attn_decode_f32_coop).
+//
+// Drop-in: identical bindings + push-constants as paged_attn_decode_f32. Dispatch
+// num_q_heads workgroups of 64 threads (one subgroup each on RADV wave64).
+//
+// Subgroup ops on GFX1013 are correct ONLY at the native 64-lane width (the
+// mul_mat_vec_*_subgroup miscompile was a wrong 32-lane assumption); a 64-thread
+// workgroup is exactly one wave64 subgroup here, which is what flash_attn proved.
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer QInput {
+    float q[];
+};
+
+layout(binding = 1) readonly buffer BlockTable {
+    uint blocks[];
+};
+
+layout(binding = 2) readonly buffer KVCache {
+    float cache[];
+};
+
+layout(binding = 3) writeonly buffer Output {
+    float output_data[];
+};
+
+layout(push_constant) uniform parameter {
+    uint seq_len;
+    uint num_q_heads;
+    uint num_kv_heads;
+    uint head_size;
+    uint block_size;
+    uint layer_base_elements;
+    uint plane_elements_per_block;
+    uint block_elements;
+    float scale;
+    uint window_start;   // first token_idx to attend (sliding window; 0 = full causal)
+    uint ring_capacity;  // 0 = absolute block-table addressing (legacy, byte-identical);
+                         // >0 = window-sized RING plane, slot = token_idx % ring_capacity
+} p;
+
+// 64 lanes * 8 dims/lane = up to head_size 512 (covers gemma global 512).
+const uint MAX_DIMS_PER_LANE = 8u;
+
+uint kv_base_for_token(uint token_idx, uint kv_head) {
+    const uint elements_per_token = p.num_kv_heads * p.head_size;
+    // Per-layer-sized KV: a sliding-window layer's resident plane is a ring of
+    // `ring_capacity` (= window) slots; absolute position `token_idx` lives at
+    // slot `token_idx % ring_capacity`. When ring_capacity == 0 this is the
+    // legacy single-/multi-block absolute path (token_idx < block_size ⇒ slot ==
+    // token_idx), so full/global layers are byte-for-byte unchanged.
+    if (p.ring_capacity != 0u) {
+        const uint slot = token_idx % p.ring_capacity;
+        return p.layer_base_elements +
+            slot * elements_per_token +
+            kv_head * p.head_size;
+    }
+    const uint logical_block_id = token_idx / p.block_size;
+    const uint token_offset_in_block =
+        token_idx - logical_block_id * p.block_size;
+    const uint physical_block_id = blocks[logical_block_id];
+    return p.layer_base_elements +
+        physical_block_id * p.block_elements +
+        token_offset_in_block * elements_per_token +
+        kv_head * p.head_size;
+}
+
+void main() {
+    const uint q_head = gl_WorkGroupID.x;
+    if (q_head >= p.num_q_heads) {
+        return;
+    }
+    const uint lane = gl_LocalInvocationID.x;          // 0..63
+    const uint D = p.head_size;
+    const uint dpl = (D + 63u) / 64u;                  // output dims this lane owns
+    const uint gqa_ratio = p.num_q_heads / p.num_kv_heads;
+    const uint kv_head = q_head / gqa_ratio;
+    const uint q_base = q_head * D;
+
+    // Cache this lane's q dims; init the online-softmax accumulators.
+    float qreg[MAX_DIMS_PER_LANE];
+    float acc[MAX_DIMS_PER_LANE];
+    for (uint i = 0u; i < dpl; i++) {
+        const uint d = lane + i * 64u;
+        qreg[i] = d < D ? q[q_base + d] : 0.0;
+        acc[i] = 0.0;
+    }
+
+    float running_max = -3.402823466e+38;
+    float denom = 0.0;
+
+    for (uint token_idx = p.window_start; token_idx < p.seq_len; token_idx++) {
+        const uint kv_base = kv_base_for_token(token_idx, kv_head);
+
+        // QK: each lane sums its dims, subgroupAdd reduces to the full dot
+        // (broadcast to all lanes — no shared memory, no barrier).
+        float partial = 0.0;
+        for (uint i = 0u; i < dpl; i++) {
+            const uint d = lane + i * 64u;
+            if (d < D) {
+                partial += qreg[i] * cache[kv_base + d];
+            }
+        }
+        const float logit = subgroupAdd(partial) * p.scale;
+
+        const float new_max = max(running_max, logit);
+        const float old_scale = exp(running_max - new_max);
+        const float weight = exp(logit - new_max);
+        denom = denom * old_scale + weight;
+
+        // V accumulate: each lane updates only the dims it owns.
+        const uint v_base = kv_base + p.plane_elements_per_block;
+        for (uint i = 0u; i < dpl; i++) {
+            const uint d = lane + i * 64u;
+            if (d < D) {
+                acc[i] = acc[i] * old_scale + weight * cache[v_base + d];
+            }
+        }
+        running_max = new_max;
+    }
+
+    const float inv = denom > 0.0 ? 1.0 / denom : 0.0;
+    for (uint i = 0u; i < dpl; i++) {
+        const uint d = lane + i * 64u;
+        if (d < D) {
+            output_data[q_base + d] = acc[i] * inv;
+        }
+    }
+}

--- a/shaders/relu2.comp
+++ b/shaders/relu2.comp
@@ -1,0 +1,22 @@
+#version 450
+
+#include "generic_head.glsl"
+#include "types.glsl"
+
+#extension GL_EXT_control_flow_attributes : enable
+
+layout(local_size_x = 512, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer X {A_TYPE data_a[];};
+layout (binding = 1) writeonly buffer D {D_TYPE data_d[];};
+
+void main() {
+    const uint i = gl_GlobalInvocationID.z * 262144 + gl_GlobalInvocationID.y * 512 + gl_GlobalInvocationID.x;
+
+    if (i >= p.KX) {
+        return;
+    }
+
+    const float xi = float(data_a[i]);
+    data_d[i] = D_TYPE(max(xi, 0.0) * max(xi, 0.0));
+}

--- a/src/device_conformance.rs
+++ b/src/device_conformance.rs
@@ -1,0 +1,743 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Numerical conformance harness for the quantized matvec kernels.
+//!
+//! `registry_tests` (lib.rs) proves the 23 required kernels are *present* and
+//! that their SPIR-V is well-formed. That is a packaging check: it says nothing
+//! about whether a kernel computes the right numbers. This module closes that
+//! gap — it runs the REAL compiled SPIR-V on whatever Vulkan device the machine
+//! exposes and compares every dispatch against the CPU quantizer/dequantizer
+//! reference that already lives in `crate::model`.
+//!
+//! Design constraints (all load-bearing for CI):
+//!
+//! * **No device → no-op PASS.** The default CI job has no ICD, so
+//!   `device::is_vulkan_available()` returning false must leave the suite green.
+//!   A device only ever *adds* checks; it never turns a green run red for
+//!   environmental reasons.
+//! * **Device-shaped skips, not failures.** A kernel the `PipelineCache`
+//!   declined to compile (e.g. the wave64-baked `paged_attn_decode_*_sg` on a
+//!   subgroup!=64 device) is reported as SKIPPED. Same for the f16-typed
+//!   kernels when the device lacks `storage_buffer_16_bit_access &&
+//!   shader_float16`.
+//! * **Tiny + deterministic.** n=16 rows, k=128 contraction, a fixed LCG for
+//!   data. No RNG crate, no disk, no network, no checkpoints. The whole sweep
+//!   is a few hundred microseconds of GPU work.
+//!
+//! ─── Tolerance ──────────────────────────────────────────────────────────────
+//!
+//! Dequantization itself is EXACT on both sides (the same integer codes and the
+//! same f32 scale/bias values), so the only legitimate divergence is the ORDER
+//! and ASSOCIATIVITY of the f32 accumulation: the CPU reference sums a row
+//! left-to-right, while each kernel splits k across BLOCK_SIZE threads and
+//! recombines through an LDS tree or a `subgroupAdd`, several of them folding
+//! the affine term with `fma` (`scale*Σqx + bias*Σx`) instead of per element.
+//! Bit-equality is therefore the WRONG assertion. We use the standard forward
+//! error bound for a dot product, normalizing each row's error by that row's
+//! sum of absolute products:
+//!
+//!     rel_err = max_r |gpu[r] - ref[r]| / Σ_j |w[r,j] · x[j]|
+//!
+//! For k=128 in f32 (eps = 2^-24 ≈ 5.96e-8) any summation order is bounded by
+//! roughly k·eps ≈ 7.6e-6 of that denominator; an fma-based reassociation only
+//! lowers it. `TOL = 1e-5` sits just above that worst case and is still ~3
+//! orders of magnitude tighter than any real kernel bug (a wrong nibble shift,
+//! a transposed index, a dropped bias) which shows up at O(1) relative error.
+//! Observed values on real devices are ~1e-7, i.e. ~100x inside the bound.
+//!
+//! Measured sensitivity at k=128: corrupting ONE dequantized weight element by
+//! 1% is caught (rel_err 6.9e-5); 0.05% on one element is not (3.5e-6, inside
+//! the bound). That is the intended trade — this harness is aimed at structural
+//! kernel faults (indexing, unpacking, missing terms, unwritten rows), not at
+//! last-ulp drift, which is device-specific and not a correctness property.
+//!
+//! `harness_detects_a_corrupted_reference` is the falsifiability check: it runs
+//! a real dispatch against a deliberately perturbed reference and asserts the
+//! comparator REJECTS it, so this file can never degrade into a test that only
+//! knows how to pass.
+
+use crate::compute::{Buffer, ComputeEngine};
+use crate::device;
+use crate::include_all_shaders;
+use crate::model;
+
+/// Contraction dimension. 128 satisfies every shipped kernel's blocking rule at
+/// once: q8_0's 32-element blocks, mlx2's 64-code uvec4 chunks, mlx6's 16-code
+/// 3-word chunks, mlx4-repack's 32-nibble uvec4 chunks, and the `vec4`-typed
+/// activation bindings (k%4==0).
+const K: usize = 128;
+/// Output rows. Small, and >1 so a row-indexing bug cannot hide.
+const N: usize = 16;
+
+/// Relative-error bound. See the module docs for the derivation.
+const TOL: f64 = 1e-5;
+
+// ─── deterministic data ──────────────────────────────────────────────────────
+
+/// Numerical Recipes LCG. Deterministic across platforms and runs; deliberately
+/// not an RNG crate (this file must add no dependency to the CI slice).
+struct Lcg(u32);
+
+impl Lcg {
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self.0.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        self.0
+    }
+    /// Uniform in [-1, 1).
+    fn f32(&mut self) -> f32 {
+        ((self.next_u32() >> 8) as f32) / 8_388_608.0 - 1.0
+    }
+    /// Uniform integer in [0, m).
+    fn below(&mut self, m: u32) -> u32 {
+        self.next_u32() % m
+    }
+}
+
+fn f32_bytes(v: &[f32]) -> Vec<u8> {
+    v.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+fn u32_bytes(v: &[u32]) -> Vec<u8> {
+    v.iter().flat_map(|w| w.to_le_bytes()).collect()
+}
+
+/// Reinterpret a byte stream as little-endian u32 words (the `uint[]` /
+/// `uvec4[]` bindings that the fp8 and nvfp4-e4m3 kernels index by absolute
+/// byte). `bytes.len()` must be a multiple of 4.
+fn bytes_as_words(bytes: &[u8]) -> Vec<u32> {
+    bytes
+        .chunks_exact(4)
+        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+// ─── plan ────────────────────────────────────────────────────────────────────
+
+/// One kernel dispatch plus the CPU answer it must reproduce.
+struct Plan {
+    /// Storage buffers in binding order. `None` marks the writeonly output slot
+    /// (which is NOT always last — the batched MoE kernels bind `meta` after
+    /// `dst`).
+    bindings: Vec<Option<Vec<u8>>>,
+    /// f32 elements in the output buffer.
+    out_len: usize,
+    push_constants: Vec<u8>,
+    workgroups: (u32, u32, u32),
+    /// Expected output, accumulated in f64 (an order-independent stand-in for
+    /// "the exact value of the dequantized f32 matvec").
+    reference: Vec<f64>,
+    /// Per-output Σ_j |w·x|, the forward-error denominator.
+    abs_scale: Vec<f64>,
+}
+
+/// Reference matvec over an already-dequantized row-major `[n, k]` weight.
+/// Returns (dot products, Σ|products|), both f64.
+fn ref_matvec(deq: &[f32], x: &[f32], n: usize, k: usize) -> (Vec<f64>, Vec<f64>) {
+    let mut dots = Vec::with_capacity(n);
+    let mut abs = Vec::with_capacity(n);
+    for r in 0..n {
+        let (mut d, mut a) = (0.0f64, 0.0f64);
+        for j in 0..k {
+            let p = deq[r * k + j] as f64 * x[j] as f64;
+            d += p;
+            a += p.abs();
+        }
+        dots.push(d);
+        abs.push(a);
+    }
+    (dots, abs)
+}
+
+// ─── packing helpers (layouts defined by the CPU dequantizers) ───────────────
+
+/// Pack `codes` as a contiguous little-endian bitstream of `bits`-wide fields —
+/// the MLX layout that `model::dequantize_mlx_affine_bits` decodes and that the
+/// mlx2/mlx6/mlx8 shaders unpack. A code may straddle a u32 boundary (6-bit).
+fn pack_contiguous(codes: &[u32], bits: usize) -> Vec<u32> {
+    let nwords = (codes.len() * bits).div_ceil(32);
+    let mut out = vec![0u32; nwords];
+    for (i, &c) in codes.iter().enumerate() {
+        let bit = i * bits;
+        let (wi, off) = (bit / 32, bit % 32);
+        out[wi] |= ((c as u64) << off) as u32;
+        if off + bits > 32 {
+            out[wi + 1] |= (((c as u64) << off) >> 32) as u32;
+        }
+    }
+    out
+}
+
+/// Two 4-bit codes per byte, low nibble = even index (compressed-tensors
+/// `pack_fp4_to_uint8`, which `model::dequantize_nvfp4` decodes).
+fn pack_nibbles(codes: &[u32]) -> Vec<u8> {
+    codes
+        .chunks_exact(2)
+        .map(|c| (c[0] as u8 & 0xF) | ((c[1] as u8 & 0xF) << 4))
+        .collect()
+}
+
+/// A positive OCP-E4M3 byte with exponent in [5, 9] — magnitudes 0.25..8.0, the
+/// range real NVFP4 block scales live in, and safely clear of the NaN code.
+fn e4m3_positive(rng: &mut Lcg) -> u8 {
+    let e = 5 + rng.below(5);
+    let m = rng.below(8);
+    ((e << 3) | m) as u8
+}
+
+// ─── plan builders ───────────────────────────────────────────────────────────
+
+/// The mlx4 affine 4-bit family: `packed | scales | biases | x | dst`, push
+/// constants `{k, n, group_size, packed_off, sb_off}`. Shared verbatim by the
+/// scalar, `_cols`, `w8`, `w16`, `w8sg` and `repack` kernels — they differ only
+/// in vectorization and reduction, never in layout or math.
+fn plan_mlx4(seed: u32, gs: usize) -> Plan {
+    let mut rng = Lcg(seed);
+    let w: Vec<f32> = (0..N * K).map(|_| rng.f32()).collect();
+    let x: Vec<f32> = (0..K).map(|_| rng.f32()).collect();
+
+    let (packed, scales, biases) = model::quantize_mlx_affine_4bit(&w, N, K, gs);
+    let deq = model::dequantize_mlx_affine(&packed, &scales, &biases, N, K, gs, 4);
+    let (reference, abs_scale) = ref_matvec(&deq, &x, N, K);
+
+    Plan {
+        bindings: vec![
+            Some(u32_bytes(&packed)),
+            Some(f32_bytes(&scales)),
+            Some(f32_bytes(&biases)),
+            Some(f32_bytes(&x)),
+            None,
+        ],
+        out_len: N,
+        push_constants: u32_bytes(&[K as u32, N as u32, gs as u32, 0, 0]),
+        workgroups: (N as u32, 1, 1),
+        reference,
+        abs_scale,
+    }
+}
+
+/// The generic MLX affine bit-width family (2 / 6 / 8 bit): same five bindings
+/// and push constants as mlx4, but the codes are a contiguous bitstream and
+/// there is no CPU *quantizer* for these widths — the packing is defined by
+/// `model::dequantize_mlx_affine_bits`, so we synthesize codes + affine params
+/// and use that function as the reference.
+fn plan_mlx_bits(seed: u32, bits: usize, gs: usize) -> Plan {
+    let mut rng = Lcg(seed);
+    let groups = K / gs;
+    let hi = 1u32 << bits;
+    let codes: Vec<u32> = (0..N * K).map(|_| rng.below(hi)).collect();
+    // Per-row contiguous packing: each row is its own bitstream of K*bits bits.
+    let mut packed = Vec::with_capacity(N * K * bits / 32);
+    for r in 0..N {
+        packed.extend(pack_contiguous(&codes[r * K..(r + 1) * K], bits));
+    }
+    // Scales scaled by 1/hi so dequantized weights land in a normal O(1) range.
+    let scales: Vec<f32> = (0..N * groups)
+        .map(|_| (rng.f32().abs() + 0.05) / hi as f32)
+        .collect();
+    let biases: Vec<f32> = (0..N * groups).map(|_| rng.f32() * 0.5).collect();
+    let x: Vec<f32> = (0..K).map(|_| rng.f32()).collect();
+
+    let deq = model::dequantize_mlx_affine_bits(&packed, &scales, &biases, N, K, gs, bits);
+    let (reference, abs_scale) = ref_matvec(&deq, &x, N, K);
+
+    Plan {
+        bindings: vec![
+            Some(u32_bytes(&packed)),
+            Some(f32_bytes(&scales)),
+            Some(f32_bytes(&biases)),
+            Some(f32_bytes(&x)),
+            None,
+        ],
+        out_len: N,
+        push_constants: u32_bytes(&[K as u32, N as u32, gs as u32, 0, 0]),
+        workgroups: (N as u32, 1, 1),
+        reference,
+        abs_scale,
+    }
+}
+
+/// NVFP4 (E2M1 codes + per-group e4m3 block scale + per-tensor global).
+///
+/// `folded == true`  → `packed | scales(f32 = e4m3*global) | x | dst`, 5 uints.
+/// `folded == false` → `packed | scaleb(raw e4m3 bytes) | x | dst`, 5 uints plus
+///                     the f32 `global`, which the kernel folds itself.
+/// Both are checked against the single CPU reference `model::dequantize_nvfp4`.
+fn plan_nvfp4(seed: u32, folded: bool) -> Plan {
+    const GS: usize = 16;
+    let mut rng = Lcg(seed);
+    let groups = K / GS;
+    let codes: Vec<u32> = (0..N * K).map(|_| rng.below(16)).collect();
+    let packed_bytes = pack_nibbles(&codes);
+    let wscale: Vec<u8> = (0..N * groups).map(|_| e4m3_positive(&mut rng)).collect();
+    let global = 0.375f32;
+    let x: Vec<f32> = (0..K).map(|_| rng.f32()).collect();
+
+    let deq = model::dequantize_nvfp4(&packed_bytes, &wscale, global, N, K, GS);
+    let (reference, abs_scale) = ref_matvec(&deq, &x, N, K);
+
+    let (scale_binding, push_constants) = if folded {
+        let folded_scales: Vec<f32> = wscale
+            .iter()
+            .map(|&b| model::e4m3_to_f32(b) * global)
+            .collect();
+        (
+            f32_bytes(&folded_scales),
+            u32_bytes(&[K as u32, N as u32, GS as u32, 0, 0]),
+        )
+    } else {
+        let mut pc = u32_bytes(&[K as u32, N as u32, GS as u32, 0, 0]);
+        pc.extend_from_slice(&global.to_le_bytes());
+        (u32_bytes(&bytes_as_words(&wscale)), pc)
+    };
+
+    Plan {
+        bindings: vec![
+            Some(u32_bytes(&bytes_as_words(&packed_bytes))),
+            Some(scale_binding),
+            Some(f32_bytes(&x)),
+            None,
+        ],
+        out_len: N,
+        push_constants,
+        workgroups: (N as u32, 1, 1),
+        reference,
+        abs_scale,
+    }
+}
+
+/// FP8 E4M3 W8A16: one byte per weight, per-OUTPUT-ROW f32 scale
+/// (`scale_per_row = 1`, the harder of the two modes — a broadcast bug in the
+/// scalar mode would still read row 0). Bindings `packed | scale | x | dst`.
+/// Every one of the 256 e4m3 codes is exercised, NaN guard included.
+fn plan_fp8(seed: u32) -> Plan {
+    let mut rng = Lcg(seed);
+    let wbytes: Vec<u8> = (0..N * K).map(|_| rng.below(256) as u8).collect();
+    let scales: Vec<f32> = (0..N).map(|_| (rng.f32().abs() + 0.05) * 0.01).collect();
+    let x: Vec<f32> = (0..K).map(|_| rng.f32()).collect();
+
+    let deq = model::dequantize_fp8(&wbytes, &scales, N, K);
+    let (reference, abs_scale) = ref_matvec(&deq, &x, N, K);
+
+    Plan {
+        bindings: vec![
+            Some(u32_bytes(&bytes_as_words(&wbytes))),
+            Some(f32_bytes(&scales)),
+            Some(f32_bytes(&x)),
+            None,
+        ],
+        out_len: N,
+        // {ncols, nrows, scale_per_row, packed_off, sb_off}
+        push_constants: u32_bytes(&[K as u32, N as u32, 1, 0, 0]),
+        workgroups: (N as u32, 1, 1),
+        reference,
+        abs_scale,
+    }
+}
+
+/// GGUF q8_0 (f16 scale + 32 int8 per block), column-batched kernel at
+/// NUM_COLS=1. Bindings `data_a | x | dst`, push constants `{ncols, nrows}`.
+fn plan_q8_0(seed: u32) -> Plan {
+    let mut rng = Lcg(seed);
+    let w: Vec<f32> = (0..N * K).map(|_| rng.f32()).collect();
+    let x: Vec<f32> = (0..K).map(|_| rng.f32()).collect();
+
+    let q = model::quantize_q8_0(&w);
+    let deq = model::dequant_q8_0_to_f32(&q);
+    let (reference, abs_scale) = ref_matvec(&deq, &x, N, K);
+
+    Plan {
+        bindings: vec![Some(q), Some(f32_bytes(&x)), None],
+        out_len: N,
+        push_constants: u32_bytes(&[K as u32, N as u32]),
+        workgroups: (N as u32, 1, 1),
+        reference,
+        abs_scale,
+    }
+}
+
+/// f16 weights, f32 activation. Bindings `w | x | dst`, `{ncols, nrows}`.
+fn plan_f16(seed: u32) -> Plan {
+    let mut rng = Lcg(seed);
+    let w: Vec<half::f16> = (0..N * K).map(|_| half::f16::from_f32(rng.f32())).collect();
+    let x: Vec<f32> = (0..K).map(|_| rng.f32()).collect();
+    let deq: Vec<f32> = w.iter().map(|h| h.to_f32()).collect();
+    let (reference, abs_scale) = ref_matvec(&deq, &x, N, K);
+
+    Plan {
+        bindings: vec![
+            Some(w.iter().flat_map(|h| h.to_bits().to_le_bytes()).collect()),
+            Some(f32_bytes(&x)),
+            None,
+        ],
+        out_len: N,
+        push_constants: u32_bytes(&[K as u32, N as u32]),
+        workgroups: (N as u32, 1, 1),
+        reference,
+        abs_scale,
+    }
+}
+
+/// The batched MoE twins (`*repack_batched`): E independent expert slices in one
+/// dispatch, addressed through a `meta[]` uvec4 per expert
+/// `(packed_off_words, sb_off_elems, x_off_floats, dst_off_floats)` with the
+/// expert on the grid's Y axis. Bindings are
+/// `packed | scales | biases | x | dst | meta` — note `dst` is binding 4, i.e.
+/// the output is NOT the last slot, which is exactly why `Plan::bindings` uses
+/// an explicit `None` hole rather than appending outputs at the end.
+///
+/// `bits == 4` builds the mlx4 twin (via the real `quantize_mlx_affine_4bit`),
+/// `bits == 2` the mlx2 twin (synthesized codes + `dequantize_mlx_affine_bits`).
+fn plan_batched(seed: u32, bits: usize, gs: usize) -> Plan {
+    const E: usize = 2;
+    let mut rng = Lcg(seed);
+    let groups = K / gs;
+    let words_per_row = K * bits / 32;
+
+    let mut packed = Vec::new();
+    let mut scales = Vec::new();
+    let mut biases = Vec::new();
+    let mut x = Vec::new();
+    let mut reference = Vec::new();
+    let mut abs_scale = Vec::new();
+    let mut meta: Vec<u32> = Vec::new();
+
+    for e in 0..E {
+        let deq: Vec<f32> = if bits == 4 {
+            let w: Vec<f32> = (0..N * K).map(|_| rng.f32()).collect();
+            let (p, s, b) = model::quantize_mlx_affine_4bit(&w, N, K, gs);
+            let d = model::dequantize_mlx_affine(&p, &s, &b, N, K, gs, 4);
+            packed.extend_from_slice(&p);
+            scales.extend_from_slice(&s);
+            biases.extend_from_slice(&b);
+            d
+        } else {
+            let hi = 1u32 << bits;
+            let codes: Vec<u32> = (0..N * K).map(|_| rng.below(hi)).collect();
+            let mut p = Vec::new();
+            for r in 0..N {
+                p.extend(pack_contiguous(&codes[r * K..(r + 1) * K], bits));
+            }
+            let s: Vec<f32> = (0..N * groups)
+                .map(|_| (rng.f32().abs() + 0.05) / hi as f32)
+                .collect();
+            let b: Vec<f32> = (0..N * groups).map(|_| rng.f32() * 0.5).collect();
+            let d = model::dequantize_mlx_affine_bits(&p, &s, &b, N, K, gs, bits);
+            packed.extend_from_slice(&p);
+            scales.extend_from_slice(&s);
+            biases.extend_from_slice(&b);
+            d
+        };
+        let xe: Vec<f32> = (0..K).map(|_| rng.f32()).collect();
+        let (dots, abs) = ref_matvec(&deq, &xe, N, K);
+        x.extend_from_slice(&xe);
+        reference.extend_from_slice(&dots);
+        abs_scale.extend_from_slice(&abs);
+        meta.extend_from_slice(&[
+            (e * N * words_per_row) as u32, // packed_off (words)
+            (e * N * groups) as u32,        // sb_off (elements)
+            (e * K) as u32,                 // x_off (floats)
+            (e * N) as u32,                 // dst_off (floats)
+        ]);
+    }
+
+    Plan {
+        bindings: vec![
+            Some(u32_bytes(&packed)),
+            Some(f32_bytes(&scales)),
+            Some(f32_bytes(&biases)),
+            Some(f32_bytes(&x)),
+            None,
+            Some(u32_bytes(&meta)),
+        ],
+        out_len: E * N,
+        push_constants: u32_bytes(&[K as u32, N as u32, gs as u32, 0, 0]),
+        workgroups: (N as u32, E as u32, 1),
+        reference,
+        abs_scale,
+    }
+}
+
+// ─── dispatch + compare ──────────────────────────────────────────────────────
+
+/// Upload the plan's buffers, run the real pipeline, read `dst` back, and
+/// return the max relative error (see module docs) — or `Err` describing the
+/// first output that exceeds `TOL`.
+fn run_plan(engine: &mut ComputeEngine, name: &str, plan: &Plan) -> Result<f64, String> {
+    let mut bufs: Vec<Buffer> = Vec::with_capacity(plan.bindings.len());
+    for slot in &plan.bindings {
+        match slot {
+            Some(bytes) => {
+                let b = engine.alloc_host_coherent_storage(bytes.len() as u64)?;
+                b.write(bytes)?;
+                bufs.push(b);
+            }
+            None => {
+                let b = engine.alloc_host_coherent_storage((plan.out_len * 4) as u64)?;
+                // Poison the output so a kernel that never writes a row is
+                // caught as a mismatch rather than passing on a lucky zero.
+                b.write(&f32_bytes(&vec![f32::NAN; plan.out_len]))?;
+                bufs.push(b);
+            }
+        }
+    }
+
+    let refs: Vec<&Buffer> = bufs.iter().collect();
+    engine.dispatch(name, &refs, &plan.push_constants, plan.workgroups)?;
+
+    let out_idx = plan
+        .bindings
+        .iter()
+        .position(|s| s.is_none())
+        .ok_or_else(|| format!("{name}: plan has no output slot"))?;
+    let mut raw = vec![0u8; plan.out_len * 4];
+    bufs[out_idx].read(&mut raw)?;
+    let got: Vec<f32> = bytes_as_words(&raw)
+        .into_iter()
+        .map(f32::from_bits)
+        .collect();
+
+    for b in bufs {
+        engine.return_to_pool(b);
+    }
+
+    let mut worst = 0.0f64;
+    let mut worst_at = 0usize;
+    for r in 0..plan.out_len {
+        if !got[r].is_finite() {
+            return Err(format!(
+                "{name}: output[{r}] = {} (non-finite; row never written or NaN-producing)",
+                got[r]
+            ));
+        }
+        // A degenerate all-zero row would divide by zero; floor the denominator
+        // at the reference magnitude so the metric stays meaningful.
+        let denom = plan.abs_scale[r].max(plan.reference[r].abs()).max(1e-30);
+        let rel = (got[r] as f64 - plan.reference[r]).abs() / denom;
+        if rel > worst {
+            worst = rel;
+            worst_at = r;
+        }
+    }
+    if worst > TOL {
+        return Err(format!(
+            "{name}: rel_err {worst:.3e} > {TOL:.0e} at output[{worst_at}] \
+             (gpu={:.9e} cpu={:.9e}, |w·x| scale={:.3e})",
+            got[worst_at], plan.reference[worst_at], plan.abs_scale[worst_at]
+        ));
+    }
+    Ok(worst)
+}
+
+// ─── the sweep ───────────────────────────────────────────────────────────────
+
+/// Kernel name, whether it needs device fp16, and how to build its plan.
+/// The names are the same registry names `registry_tests::REQUIRED_QUANT_KERNELS`
+/// asserts are present — this file checks that they also compute the right
+/// numbers. Kernels in that list with no entry here are accounted for in
+/// `every_matvec_kernel_is_covered_or_excused`.
+type PlanFn = fn() -> Plan;
+
+const CASES: &[(&str, bool, PlanFn)] = &[
+    // ── mlx4 affine 4-bit: five vectorizations of one layout ───────────────
+    ("mul_mat_vec_mlx4_f32_f32", false, || plan_mlx4(0x1234_5678, 64)),
+    ("mul_mat_vec_mlx4_cols", false, || plan_mlx4(0x1234_5678, 64)),
+    ("mul_mat_vec_mlx4w8_f32_f32", false, || plan_mlx4(0x1234_5678, 64)),
+    ("mul_mat_vec_mlx4w16_f32_f32", false, || plan_mlx4(0x1234_5678, 64)),
+    ("mul_mat_vec_mlx4w8sg_f32_f32", false, || plan_mlx4(0x1234_5678, 64)),
+    ("mul_mat_vec_mlx4repack_f32_f32", false, || plan_mlx4(0x1234_5678, 64)),
+    // ── other MLX affine widths ────────────────────────────────────────────
+    ("mul_mat_vec_mlx2repack_f32_f32", false, || plan_mlx_bits(0x0BAD_F00D, 2, 128)),
+    ("mul_mat_vec_mlx6_f32_f32", false, || plan_mlx_bits(0x0BAD_F00D, 6, 128)),
+    ("mul_mat_vec_mlx8_f32_f32", false, || plan_mlx_bits(0x0BAD_F00D, 8, 64)),
+    // ── batched MoE twins (expert on grid.y, meta[] bases) ─────────────────
+    ("mul_mat_vec_mlx4repack_batched_f32_f32", false, || plan_batched(0x00C0_FFEE, 4, 64)),
+    ("mul_mat_vec_mlx2repack_batched_f32_f32", false, || plan_batched(0x00C0_FFEE, 2, 128)),
+    // ── nvfp4 ──────────────────────────────────────────────────────────────
+    ("mul_mat_vec_nvfp4_f32_f32", false, || plan_nvfp4(0x5EED_1111, true)),
+    ("mul_mat_vec_nvfp4repack_f32_f32", false, || plan_nvfp4(0x5EED_1111, true)),
+    ("mul_mat_vec_nvfp4_e4m3_f32_f32", false, || plan_nvfp4(0x5EED_1111, false)),
+    ("mul_mat_vec_nvfp4_e4m3repack_f32_f32", false, || plan_nvfp4(0x5EED_1111, false)),
+    // ── fp8 ────────────────────────────────────────────────────────────────
+    ("mul_mat_vec_fp8_f32_f32", false, || plan_fp8(0x2222_ABCD)),
+    ("mul_mat_vec_fp8fast_f32_f32", false, || plan_fp8(0x2222_ABCD)),
+    ("mul_mat_vec_fp8repack_f32_f32", false, || plan_fp8(0x2222_ABCD)),
+    // ── column-batched dequant matvec (f16-typed bindings) ─────────────────
+    ("mul_mat_vec_q8_0_cols", true, || plan_q8_0(0x3333_5555)),
+    ("mul_mat_vec_f16_cols", true, || plan_f16(0x3333_5555)),
+];
+
+/// Kernels in `REQUIRED_QUANT_KERNELS` that this harness deliberately does not
+/// cover, with the reason. Keeping the list here (rather than silently) means
+/// `every_matvec_kernel_is_covered_or_excused` fails the moment a new kernel
+/// lands without either a plan or an explicit excuse.
+const EXCUSED: &[(&str, &str)] = &[
+    (
+        "paged_attn_decode_f32_sg",
+        "paged attention, not a matvec: needs a populated KV page table + \
+         block tables, and is wave64-baked (pipeline.rs skips it on subgroup!=64)",
+    ),
+    (
+        "paged_attn_decode_f16_sg",
+        "as paged_attn_decode_f32_sg, plus f16 KV storage",
+    ),
+    (
+        "relu2_f32",
+        "elementwise activation, not a quantized matvec; no dequant reference",
+    ),
+];
+
+struct Report {
+    ran: Vec<(String, f64)>,
+    skipped: Vec<(String, String)>,
+}
+
+fn sweep(engine: &mut ComputeEngine, fp16: bool) -> Report {
+    let mut ran = Vec::new();
+    let mut skipped = Vec::new();
+    for &(name, needs_fp16, build) in CASES {
+        if !engine.has_pipeline(name) {
+            skipped.push((
+                name.to_string(),
+                "pipeline not compiled on this device (see PipelineCache::new)".to_string(),
+            ));
+            continue;
+        }
+        if needs_fp16 && !fp16 {
+            skipped.push((
+                name.to_string(),
+                "device lacks storage_buffer_16_bit_access && shader_float16".to_string(),
+            ));
+            continue;
+        }
+        let plan = build();
+        match run_plan(engine, name, &plan) {
+            Ok(err) => ran.push((name.to_string(), err)),
+            Err(e) => panic!("GPU conformance FAILED — {e}"),
+        }
+    }
+    Report { ran, skipped }
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+/// Build a `ComputeEngine` on device 0, or `None` when the machine has no
+/// Vulkan ICD (the default CI job). This is the single place the whole module
+/// no-ops through.
+fn engine_or_skip() -> Option<(ComputeEngine, bool, u32)> {
+    if !device::is_vulkan_available() {
+        eprintln!(
+            "device_conformance: no Vulkan device (no ICD) — GPU conformance SKIPPED. \
+             Point VK_ICD_FILENAMES at a driver (e.g. Mesa lavapipe \
+             /usr/share/vulkan/icd.d/lvp_icd.x86_64.json) to run it."
+        );
+        return None;
+    }
+    let dev = device::ComputeDevice::create(0).expect("Vulkan reported available but device 0 failed to create");
+    let (fp16, subgroup) = (dev.fp16, dev.subgroup_size);
+    let spvs = include_all_shaders();
+    let refs: std::collections::HashMap<&str, &[u8]> =
+        spvs.iter().map(|(k, v)| (k.as_str(), v.as_slice())).collect();
+    let engine = ComputeEngine::new(
+        dev.instance.clone(),
+        dev.physical_device,
+        dev.device.clone(),
+        dev.compute_queue,
+        dev.compute_queue_family,
+        dev.caps(),
+        &refs,
+    )
+    .expect("ComputeEngine::new failed on an available device");
+    Some((engine, fp16, subgroup))
+}
+
+/// Every quant matvec kernel this branch ships, run for real against the CPU
+/// dequant reference. No-ops (PASS) with no device.
+#[test]
+fn quant_matvec_kernels_match_cpu_reference() {
+    let Some((mut engine, fp16, subgroup)) = engine_or_skip() else { return };
+    eprintln!("device_conformance: subgroup_size={subgroup} fp16={fp16} k={K} n={N} tol={TOL:e}");
+
+    let report = sweep(&mut engine, fp16);
+
+    for (name, err) in &report.ran {
+        eprintln!("  RAN  {name:<42} max_rel_err={err:.3e}");
+    }
+    for (name, why) in &report.skipped {
+        eprintln!("  SKIP {name:<42} {why}");
+    }
+    for (name, why) in EXCUSED {
+        eprintln!("  N/A  {name:<42} {why}");
+    }
+    eprintln!(
+        "device_conformance: {} kernel(s) ran, {} skipped, {} out of scope",
+        report.ran.len(),
+        report.skipped.len(),
+        EXCUSED.len()
+    );
+
+    assert!(
+        !report.ran.is_empty(),
+        "a Vulkan device was present but not one quant matvec kernel ran — \
+         every pipeline was missing. That is a packaging/compile regression, \
+         not a device limitation."
+    );
+}
+
+/// Falsifiability: the comparator must REJECT a wrong answer.
+///
+/// We run a genuine mlx4 dispatch but hand `run_plan` a reference whose group-0
+/// scale has been perturbed by 1e-3 relative — a change far smaller than any
+/// realistic kernel bug, and far larger than TOL. If this ever returns `Ok`,
+/// every other assertion in this file is worthless.
+#[test]
+fn harness_detects_a_corrupted_reference() {
+    let Some((mut engine, _fp16, _sg)) = engine_or_skip() else { return };
+    const NAME: &str = "mul_mat_vec_mlx4_f32_f32";
+    if !engine.has_pipeline(NAME) {
+        eprintln!("device_conformance: {NAME} not compiled here — fail-injection SKIPPED");
+        return;
+    }
+
+    // Sanity: the untouched plan must pass, so a rejection below is attributable
+    // to the perturbation and not to a broken kernel or a mis-sized buffer.
+    let clean = plan_mlx4(0x1234_5678, 64);
+    let clean_err = run_plan(&mut engine, NAME, &clean).expect("clean mlx4 plan should pass");
+
+    // Rebuild with one perturbed affine scale and recompute the reference the
+    // same way the honest builder does.
+    let mut rng = Lcg(0x1234_5678);
+    let w: Vec<f32> = (0..N * K).map(|_| rng.f32()).collect();
+    let x: Vec<f32> = (0..K).map(|_| rng.f32()).collect();
+    let (packed, mut scales, biases) = model::quantize_mlx_affine_4bit(&w, N, K, 64);
+    scales[0] *= 1.0 + 1e-3; // <- the injected fault (reference only; GPU sees the true bytes)
+    let bad_deq = model::dequantize_mlx_affine(&packed, &scales, &biases, N, K, 64, 4);
+    let (reference, abs_scale) = ref_matvec(&bad_deq, &x, N, K);
+    let corrupted = Plan { reference, abs_scale, ..clean };
+
+    let err = run_plan(&mut engine, NAME, &corrupted)
+        .expect_err("harness accepted a knowingly-wrong reference — the comparator is inert");
+    eprintln!(
+        "device_conformance: fail-injection OK (clean rel_err={clean_err:.3e}); rejected with: {err}"
+    );
+}
+
+/// Structural guard: every kernel in `REQUIRED_QUANT_KERNELS` must either have a
+/// conformance plan or an explicit written excuse. Pure bookkeeping — runs with
+/// or without a device, so a new kernel landing without numerical coverage is
+/// caught in the ICD-less CI job too.
+#[test]
+fn every_matvec_kernel_is_covered_or_excused() {
+    let uncovered: Vec<&str> = crate::registry_tests::REQUIRED_QUANT_KERNELS
+        .iter()
+        .copied()
+        .filter(|n| {
+            !CASES.iter().any(|(c, _, _)| c == n) && !EXCUSED.iter().any(|(e, _)| e == n)
+        })
+        .collect();
+    assert!(
+        uncovered.is_empty(),
+        "{} shipped kernel(s) have neither a device_conformance plan nor an \
+         entry in EXCUSED: {uncovered:?}. Add a Plan builder, or an EXCUSED \
+         line saying why a numerical check is not possible.",
+        uncovered.len()
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ use flags::{Flags, QuantFormat};
 mod gpu_error;
 mod push_constants;
 use push_constants::*;
+#[cfg(test)] mod spirv_reflect_tests;
 #[cfg(feature = "debug-api")]
 mod debug_api;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@ mod direct_kernels;
 #[cfg(feature = "debug-api")]
 use debug_api::*;
 mod vulkan_ctx;
+// GPU numerical conformance harness (test-only; no-ops without a Vulkan ICD).
+#[cfg(test)]
+mod device_conformance;
 use vulkan_ctx::{VulkanContext, GpuTensor};
 mod tp;
 #[cfg(feature = "qwen35")]
@@ -8880,7 +8883,7 @@ mod registry_tests {
     /// shader never breaks it, losing one always does. Each name below is a
     /// kernel some model path dispatches by name; if one is absent the dispatch
     /// would fail at runtime on the GPU, which CI has no way to reach.
-    const REQUIRED_QUANT_KERNELS: &[&str] = &[
+    pub(crate) const REQUIRED_QUANT_KERNELS: &[&str] = &[
         // mlx4 (4-bit) family
         "mul_mat_vec_mlx4_f32_f32",
         "mul_mat_vec_mlx4_cols",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8863,6 +8863,96 @@ mod registry_tests {
         }
     }
 
+    /// Every quantized-matvec / subgroup-attention kernel this crate ships must
+    /// survive into the runtime shader map.
+    ///
+    /// This is the counterpart to `scripts/compile_shaders.sh`'s
+    /// skip-when-absent behaviour. That guard lets ONE compile script drive any
+    /// feature slice (it compiles the shaders present in the tree and skips the
+    /// rest), but it means a `.comp` that goes missing — a renamed file, a
+    /// typo'd entry in the compile script, a bad carve — no longer fails the
+    /// build. It compiles zero shaders for that entry, exits 0, and the kernel
+    /// simply vanishes from the registry.
+    ///
+    /// A length/self-consistency check cannot catch that: when an entry
+    /// disappears, the registry and the runtime map shrink together and stay
+    /// 1:1. So this test names the kernels instead of counting them — adding a
+    /// shader never breaks it, losing one always does. Each name below is a
+    /// kernel some model path dispatches by name; if one is absent the dispatch
+    /// would fail at runtime on the GPU, which CI has no way to reach.
+    const REQUIRED_QUANT_KERNELS: &[&str] = &[
+        // mlx4 (4-bit) family
+        "mul_mat_vec_mlx4_f32_f32",
+        "mul_mat_vec_mlx4_cols",
+        "mul_mat_vec_mlx4w8_f32_f32",
+        "mul_mat_vec_mlx4w16_f32_f32",
+        "mul_mat_vec_mlx4w8sg_f32_f32",
+        "mul_mat_vec_mlx4repack_f32_f32",
+        "mul_mat_vec_mlx4repack_batched_f32_f32",
+        // mlx2 / mlx6 / mlx8 repack variants
+        "mul_mat_vec_mlx2repack_f32_f32",
+        "mul_mat_vec_mlx2repack_batched_f32_f32",
+        "mul_mat_vec_mlx6_f32_f32",
+        "mul_mat_vec_mlx8_f32_f32",
+        // nvfp4 family
+        "mul_mat_vec_nvfp4_f32_f32",
+        "mul_mat_vec_nvfp4_e4m3_f32_f32",
+        "mul_mat_vec_nvfp4repack_f32_f32",
+        "mul_mat_vec_nvfp4_e4m3repack_f32_f32",
+        // fp8 family
+        "mul_mat_vec_fp8_f32_f32",
+        "mul_mat_vec_fp8fast_f32_f32",
+        "mul_mat_vec_fp8repack_f32_f32",
+        // column-batched dequant matvec
+        "mul_mat_vec_q8_0_cols",
+        "mul_mat_vec_f16_cols",
+        // subgroup paged decode attention
+        "paged_attn_decode_f32_sg",
+        "paged_attn_decode_f16_sg",
+        "relu2_f32",
+    ];
+
+    #[test]
+    fn quant_matvec_kernels_are_registered() {
+        let map = include_all_shaders();
+        let missing: Vec<&str> = REQUIRED_QUANT_KERNELS
+            .iter()
+            .copied()
+            .filter(|n| !map.contains_key(*n))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "{} required shader(s) missing from the registry: {:?}\n\
+             The SPIR-V for these was not produced, so any dispatch of them would \
+             fail on device. Check that the .comp source exists under shaders/ and \
+             that scripts/compile_shaders.sh still has a compile entry for it \
+             (a missing source is SKIPPED, not an error, by design).",
+            missing.len(),
+            missing,
+        );
+    }
+
+    /// The SPIR-V behind each required kernel must be non-empty and well-formed
+    /// enough to be a SPIR-V module: correct magic number and a 5-word header.
+    /// Catches a truncated or empty .spv surviving into the registry.
+    #[test]
+    fn required_kernel_spirv_is_wellformed() {
+        let map = include_all_shaders();
+        for name in REQUIRED_QUANT_KERNELS {
+            let Some(bytes) = map.get(*name) else { continue };
+            assert!(
+                bytes.len() >= 20 && bytes.len() % 4 == 0,
+                "{name}: SPIR-V is {} bytes — too short or not word-aligned",
+                bytes.len()
+            );
+            let magic = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(
+                magic, 0x0723_0203,
+                "{name}: bad SPIR-V magic 0x{magic:08x} (expected 0x07230203)"
+            );
+        }
+    }
+
     #[test]
     fn cutover_guard_registry_len() {
         // Registry-integrity guard. The absolute shader count is a BUILD-TIME

--- a/src/spirv_reflect_tests.rs
+++ b/src/spirv_reflect_tests.rs
@@ -1,0 +1,1019 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Static (no-GPU) SPIR-V reflection gates for the shipped compute shaders.
+//!
+//! Descriptor-binding and push-constant mismatches between a `.comp` and the
+//! Rust code that dispatches it are *silent* on the host: `vkCmdPushConstants`
+//! happily writes 20 bytes into a block the shader declared as 24, and
+//! `vkUpdateDescriptorSets` happily writes binding 3 for a shader whose third
+//! buffer is at binding 4. The failure only shows up on device, as garbage
+//! output or a hang — and CI has no GPU.
+//!
+//! So we reflect the compiled SPIR-V ourselves (a small hand-rolled word-stream
+//! parser; no new crate dependency) and assert, statically, the invariants the
+//! dispatch path in `compute.rs` / `pipeline.rs` genuinely relies on. See
+//! `check_module` for the list, each with its code citation.
+
+use std::collections::HashMap;
+
+// ── SPIR-V constants (SPIR-V 1.6 spec, §3) ─────────────────────────────────
+
+const SPIRV_MAGIC: u32 = 0x0723_0203;
+
+// Opcodes.
+const OP_ENTRY_POINT: u16 = 15;
+const OP_EXECUTION_MODE: u16 = 16;
+const OP_TYPE_INT: u16 = 21;
+const OP_TYPE_FLOAT: u16 = 22;
+const OP_TYPE_VECTOR: u16 = 23;
+const OP_TYPE_MATRIX: u16 = 24;
+const OP_TYPE_ARRAY: u16 = 28;
+const OP_TYPE_RUNTIME_ARRAY: u16 = 29;
+const OP_TYPE_STRUCT: u16 = 30;
+const OP_TYPE_POINTER: u16 = 32;
+const OP_CONSTANT: u16 = 43;
+const OP_SPEC_CONSTANT: u16 = 50;
+const OP_VARIABLE: u16 = 59;
+const OP_DECORATE: u16 = 71;
+const OP_MEMBER_DECORATE: u16 = 72;
+const OP_EXECUTION_MODE_ID: u16 = 331;
+
+// Decorations.
+const DEC_BUILT_IN: u32 = 11;
+const DEC_ARRAY_STRIDE: u32 = 6;
+const DEC_MATRIX_STRIDE: u32 = 7;
+const DEC_BINDING: u32 = 33;
+const DEC_DESCRIPTOR_SET: u32 = 34;
+const DEC_OFFSET: u32 = 35;
+
+const BUILTIN_WORKGROUP_SIZE: u32 = 25;
+
+// Storage classes.
+const SC_PUSH_CONSTANT: u32 = 9;
+
+// Execution model / modes.
+const EXEC_MODEL_GL_COMPUTE: u32 = 5;
+const EXEC_MODE_LOCAL_SIZE: u32 = 17;
+const EXEC_MODE_LOCAL_SIZE_ID: u32 = 38;
+
+/// Vulkan's guaranteed-minimum `maxPushConstantsSize`, and exactly the range
+/// size every pipeline layout in `pipeline.rs` declares (`PushConstantRange`
+/// `.offset(0).size(128)` — see `compile_one_with_spec` and
+/// `compile_with_spec_timeout`). A shader whose block exceeds this could not
+/// be fed at all.
+const PUSH_CONSTANT_RANGE_BYTES: u32 = 128;
+
+// ── Reflection ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Ty {
+    Scalar(u32),          // byte width
+    Vector(u32, u32),     // component type id, count
+    Matrix(u32, u32),     // column type id, count
+    Array(u32, u32),      // element type id, length constant id
+    RuntimeArray(u32),    // element type id
+    Struct,               // members held in `struct_members`
+    Pointer(u32, u32),    // storage class, pointee
+}
+
+#[derive(Debug, Default)]
+pub struct Reflection {
+    /// (major, minor) from the SPIR-V header word 1.
+    pub version: (u8, u8),
+    /// (execution model, entry-point name).
+    pub entry_points: Vec<(u32, String)>,
+    /// (descriptor set, binding) for every decorated variable, sorted.
+    pub bindings: Vec<(u32, u32)>,
+    /// Size in bytes of the push-constant block, if the module declares one.
+    pub push_constant_size: Option<u32>,
+    /// Literal `LocalSize` execution mode, if present.
+    pub local_size: Option<(u32, u32, u32)>,
+    /// True when the workgroup size comes from specialization constants
+    /// (`local_size_x_id` → `BuiltIn WorkgroupSize`, or `LocalSizeId`).
+    pub local_size_is_spec: bool,
+}
+
+/// Parse `spv` (a little-endian SPIR-V binary) far enough to answer the
+/// questions the dispatch path cares about. Returns `Err` for anything that
+/// is not a structurally valid module.
+pub fn reflect(spv: &[u8]) -> Result<Reflection, String> {
+    if spv.len() < 20 {
+        return Err(format!("too short to be SPIR-V: {} bytes", spv.len()));
+    }
+    if spv.len() % 4 != 0 {
+        return Err(format!("not word-aligned: {} bytes", spv.len()));
+    }
+    let words: Vec<u32> = spv
+        .chunks_exact(4)
+        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect();
+    if words[0] != SPIRV_MAGIC {
+        return Err(format!("bad magic 0x{:08x} (expected 0x07230203)", words[0]));
+    }
+
+    let mut r = Reflection {
+        version: (((words[1] >> 16) & 0xff) as u8, ((words[1] >> 8) & 0xff) as u8),
+        ..Default::default()
+    };
+
+    // id → decoration → operands
+    let mut decorations: HashMap<u32, HashMap<u32, Vec<u32>>> = HashMap::new();
+    // (struct id, member) → decoration → operands
+    let mut member_decorations: HashMap<(u32, u32), HashMap<u32, Vec<u32>>> = HashMap::new();
+    let mut types: HashMap<u32, Ty> = HashMap::new();
+    let mut struct_members: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut constants: HashMap<u32, u32> = HashMap::new();
+    // (result type, result id, storage class)
+    let mut variables: Vec<(u32, u32, u32)> = Vec::new();
+    let mut exec_modes: Vec<(u32, u32, Vec<u32>)> = Vec::new();
+
+    let mut i = 5usize;
+    while i < words.len() {
+        let word0 = words[i];
+        let count = (word0 >> 16) as usize;
+        let op = (word0 & 0xffff) as u16;
+        if count == 0 {
+            return Err(format!("zero-length instruction at word {i}"));
+        }
+        if i + count > words.len() {
+            return Err(format!(
+                "instruction at word {i} claims {count} words but only {} remain",
+                words.len() - i
+            ));
+        }
+        let ops = &words[i + 1..i + count];
+
+        match op {
+            OP_ENTRY_POINT if ops.len() >= 3 => {
+                r.entry_points.push((ops[0], decode_string(&ops[2..])));
+            }
+            OP_EXECUTION_MODE | OP_EXECUTION_MODE_ID if ops.len() >= 2 => {
+                exec_modes.push((ops[0], ops[1], ops[2..].to_vec()));
+            }
+            OP_DECORATE if ops.len() >= 2 => {
+                decorations
+                    .entry(ops[0])
+                    .or_default()
+                    .insert(ops[1], ops[2..].to_vec());
+            }
+            OP_MEMBER_DECORATE if ops.len() >= 3 => {
+                member_decorations
+                    .entry((ops[0], ops[1]))
+                    .or_default()
+                    .insert(ops[2], ops[3..].to_vec());
+            }
+            OP_TYPE_INT if ops.len() >= 2 => {
+                types.insert(ops[0], Ty::Scalar(ops[1].div_ceil(8)));
+            }
+            OP_TYPE_FLOAT if ops.len() >= 2 => {
+                types.insert(ops[0], Ty::Scalar(ops[1].div_ceil(8)));
+            }
+            OP_TYPE_VECTOR if ops.len() >= 3 => {
+                types.insert(ops[0], Ty::Vector(ops[1], ops[2]));
+            }
+            OP_TYPE_MATRIX if ops.len() >= 3 => {
+                types.insert(ops[0], Ty::Matrix(ops[1], ops[2]));
+            }
+            OP_TYPE_ARRAY if ops.len() >= 3 => {
+                types.insert(ops[0], Ty::Array(ops[1], ops[2]));
+            }
+            OP_TYPE_RUNTIME_ARRAY if ops.len() >= 2 => {
+                types.insert(ops[0], Ty::RuntimeArray(ops[1]));
+            }
+            OP_TYPE_STRUCT if !ops.is_empty() => {
+                types.insert(ops[0], Ty::Struct);
+                struct_members.insert(ops[0], ops[1..].to_vec());
+            }
+            OP_TYPE_POINTER if ops.len() >= 3 => {
+                types.insert(ops[0], Ty::Pointer(ops[1], ops[2]));
+            }
+            OP_CONSTANT | OP_SPEC_CONSTANT if ops.len() >= 3 => {
+                // Only single-word (<=32-bit) constants matter here: array
+                // lengths and workgroup dimensions are all 32-bit.
+                constants.insert(ops[1], ops[2]);
+            }
+            OP_VARIABLE if ops.len() >= 3 => {
+                variables.push((ops[0], ops[1], ops[2]));
+            }
+            _ => {}
+        }
+        i += count;
+    }
+
+    // Descriptor bindings: every id carrying a Binding decoration.
+    for (id, decs) in &decorations {
+        let Some(binding) = decs.get(&DEC_BINDING).and_then(|v| v.first()).copied() else {
+            continue;
+        };
+        // An undecorated set defaults to 0 in GLSL.
+        let set = decs
+            .get(&DEC_DESCRIPTOR_SET)
+            .and_then(|v| v.first())
+            .copied()
+            .unwrap_or(0);
+        let _ = id;
+        r.bindings.push((set, binding));
+    }
+    // A binding may be declared by SEVERAL variables — the ggml-derived
+    // shaders routinely alias one storage buffer under two block types
+    // (`layout(binding=2) buffer Activ {float x[];}` +
+    //  `layout(binding=2) buffer ActivV4 {vec4 xv4[];}` in
+    //  mul_mat_vec_fp8_fast.comp, or the A/A_PACKED16/A_PACKED32 trio in
+    // generic_binary_head.glsl). That is one descriptor, so dedupe.
+    r.bindings.sort_unstable();
+    r.bindings.dedup();
+
+    // Push-constant block: the (single) PushConstant OpVariable, its pointee
+    // struct, sized from the member Offset decorations glslang always emits.
+    for (result_type, _id, sc) in &variables {
+        if *sc != SC_PUSH_CONSTANT {
+            continue;
+        }
+        let Some(Ty::Pointer(_, pointee)) = types.get(result_type).copied() else {
+            return Err("PushConstant variable has a non-pointer result type".to_string());
+        };
+        let size = size_of_ty(pointee, &types, &struct_members, &member_decorations, &constants, &decorations)
+            .ok_or_else(|| "could not size the push-constant block type".to_string())?;
+        r.push_constant_size = Some(size);
+    }
+
+    // Workgroup size.
+    for (_target, mode, lits) in &exec_modes {
+        if *mode == EXEC_MODE_LOCAL_SIZE && lits.len() >= 3 {
+            r.local_size = Some((lits[0], lits[1], lits[2]));
+        } else if *mode == EXEC_MODE_LOCAL_SIZE_ID {
+            r.local_size_is_spec = true;
+            if lits.len() >= 3 {
+                if let (Some(x), Some(y), Some(z)) = (
+                    constants.get(&lits[0]),
+                    constants.get(&lits[1]),
+                    constants.get(&lits[2]),
+                ) {
+                    r.local_size = Some((*x, *y, *z));
+                }
+            }
+        }
+    }
+    // `layout(local_size_x_id = 0)` lowers to a spec-constant composite tagged
+    // `BuiltIn WorkgroupSize` rather than a LocalSizeId execution mode.
+    if decorations
+        .values()
+        .any(|d| d.get(&DEC_BUILT_IN).and_then(|v| v.first()) == Some(&BUILTIN_WORKGROUP_SIZE))
+    {
+        r.local_size_is_spec = true;
+    }
+
+    Ok(r)
+}
+
+/// Byte size of a type, using the explicit layout decorations glslang emits
+/// for interface blocks. `None` when the type is not one we can size.
+fn size_of_ty(
+    id: u32,
+    types: &HashMap<u32, Ty>,
+    struct_members: &HashMap<u32, Vec<u32>>,
+    member_decorations: &HashMap<(u32, u32), HashMap<u32, Vec<u32>>>,
+    constants: &HashMap<u32, u32>,
+    decorations: &HashMap<u32, HashMap<u32, Vec<u32>>>,
+) -> Option<u32> {
+    match types.get(&id)? {
+        Ty::Scalar(w) => Some(*w),
+        Ty::Vector(comp, n) => {
+            let cw = size_of_ty(*comp, types, struct_members, member_decorations, constants, decorations)?;
+            Some(cw * n)
+        }
+        Ty::Matrix(col, n) => {
+            if let Some(stride) = decorations
+                .get(&id)
+                .and_then(|d| d.get(&DEC_MATRIX_STRIDE))
+                .and_then(|v| v.first())
+            {
+                return Some(stride * n);
+            }
+            let cw = size_of_ty(*col, types, struct_members, member_decorations, constants, decorations)?;
+            Some(cw * n)
+        }
+        Ty::Array(elem, len_id) => {
+            let len = *constants.get(len_id)?;
+            let stride = decorations
+                .get(&id)
+                .and_then(|d| d.get(&DEC_ARRAY_STRIDE))
+                .and_then(|v| v.first())
+                .copied();
+            let elem_size = match stride {
+                Some(s) => s,
+                None => size_of_ty(*elem, types, struct_members, member_decorations, constants, decorations)?,
+            };
+            Some(elem_size * len)
+        }
+        // A runtime array has no static size; it can never appear in a
+        // push-constant block (Vulkan forbids it), so treat it as unsizeable.
+        Ty::RuntimeArray(_) => None,
+        Ty::Struct => {
+            let members = struct_members.get(&id)?;
+            let mut end = 0u32;
+            for (idx, mty) in members.iter().enumerate() {
+                let off = member_decorations
+                    .get(&(id, idx as u32))
+                    .and_then(|d| d.get(&DEC_OFFSET))
+                    .and_then(|v| v.first())
+                    .copied()?;
+                let sz = size_of_ty(*mty, types, struct_members, member_decorations, constants, decorations)?;
+                end = end.max(off + sz);
+            }
+            Some(end)
+        }
+        Ty::Pointer(..) => None,
+    }
+}
+
+/// Decode a SPIR-V literal string (NUL-terminated, packed little-endian).
+fn decode_string(words: &[u32]) -> String {
+    let mut bytes = Vec::with_capacity(words.len() * 4);
+    'outer: for w in words {
+        for b in w.to_le_bytes() {
+            if b == 0 {
+                break 'outer;
+            }
+            bytes.push(b);
+        }
+    }
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+// ── The invariants ─────────────────────────────────────────────────────────
+
+/// I1: the module is a compute shader with a `main` entry point, and its
+/// SPIR-V version matches what the instance is created with.
+///
+/// Evidence: `pipeline.rs` names the entry point `c"main"` unconditionally
+/// (`compile_one_with_spec`, `compile_with_spec_timeout`) and always builds a
+/// `ComputePipelineCreateInfo` with `ShaderStageFlags::COMPUTE`. A module with
+/// a differently-named entry point fails `vkCreateComputePipelines` at load.
+/// `device.rs` requests `vk::API_VERSION_1_3` and `scripts/compile_shaders.sh`
+/// compiles `--target-env vulkan1.3` (SPIR-V 1.6); a module built for a newer
+/// target would be rejected by the driver.
+pub fn check_entry_point(r: &Reflection) -> Result<(), String> {
+    if r.entry_points.len() != 1 {
+        return Err(format!(
+            "expected exactly 1 OpEntryPoint, found {} ({:?}); pipeline.rs always \
+             creates the pipeline with entry point \"main\"",
+            r.entry_points.len(),
+            r.entry_points
+        ));
+    }
+    let (model, name) = &r.entry_points[0];
+    if *model != EXEC_MODEL_GL_COMPUTE {
+        return Err(format!(
+            "entry point \"{name}\" has execution model {model}, expected GLCompute ({EXEC_MODEL_GL_COMPUTE}); \
+             pipeline.rs only ever builds COMPUTE pipelines"
+        ));
+    }
+    if name != "main" {
+        return Err(format!(
+            "entry point is named \"{name}\", but pipeline.rs hardcodes c\"main\" \
+             (vkCreateComputePipelines would fail on device)"
+        ));
+    }
+    if r.version != (1, 6) {
+        return Err(format!(
+            "SPIR-V version {}.{}, expected 1.6 (scripts/compile_shaders.sh uses \
+             --target-env vulkan1.3 and device.rs requests API_VERSION_1_3)",
+            r.version.0, r.version.1
+        ));
+    }
+    Ok(())
+}
+
+/// I2a: every descriptor binding is in set 0, below `MAX_BINDINGS`.
+///
+/// Evidence: `PipelineCache::new` creates exactly ONE `DescriptorSetLayout`,
+/// with bindings `(0..MAX_BINDINGS)`, and `compute.rs::record_to` binds it with
+/// `cmd_bind_descriptor_sets(.., first_set = 0, &[ds], ..)`. A binding in set 1
+/// — or at index >= MAX_BINDINGS — has no descriptor bound at all. `record_to`
+/// additionally hard-errors above `MAX_BINDINGS` buffers.
+pub fn check_bindings(r: &Reflection) -> Result<(), String> {
+    let max = crate::pipeline::MAX_BINDINGS;
+    for (set, binding) in &r.bindings {
+        if *set != 0 {
+            return Err(format!(
+                "binding (set={set}, binding={binding}) is not in set 0; compute.rs \
+                 binds a single descriptor set at first_set=0, so a set-{set} \
+                 binding would have no descriptor bound"
+            ));
+        }
+        if *binding >= max {
+            return Err(format!(
+                "binding {binding} >= MAX_BINDINGS ({max}); pipeline.rs's descriptor \
+                 set layout only declares bindings 0..{}",
+                max - 1
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// I2b: the bindings are contiguous from 0 — the invariant the dispatch path
+/// relies on *positionally*.
+///
+/// Evidence: `compute.rs::record_to` writes the caller's buffer slice by INDEX:
+///
+/// ```text
+/// for (i, b) in buffers.iter().enumerate() { buffer_infos[i] = ...buffer(b.buffer)... }
+/// for i in 0..n { writes[i] = ...dst_set(ds).dst_binding(i as u32)... }
+/// ```
+///
+/// so `buffers[i]` always lands on binding `i`. A shader that declared, say,
+/// bindings {0, 1, 3} would read binding 3 while the host wrote binding 2 —
+/// undefined descriptor, garbage or hang, with nothing failing host-side.
+/// `record_to_off` does the identical positional mapping.
+pub fn check_bindings_contiguous(r: &Reflection) -> Result<(), String> {
+    check_bindings(r)?;
+    let got: Vec<u32> = r.bindings.iter().map(|(_, b)| *b).collect();
+    let expected: Vec<u32> = (0..got.len() as u32).collect();
+    if got != expected {
+        return Err(format!(
+            "descriptor bindings are not contiguous from 0: declared {got:?}, expected \
+             {expected:?}. compute.rs::record_to writes buffers[i] to dst_binding(i), \
+             so a hole silently misroutes every buffer after it"
+        ));
+    }
+    Ok(())
+}
+
+/// Modules that deliberately leave a hole in their binding numbering, with the
+/// reason. Anything NOT on this list must be contiguous (see
+/// `check_bindings_contiguous`); a newly-holed shader therefore fails the gate
+/// instead of reaching a GPU.
+const BINDING_HOLE_ALLOWLIST: &[(&str, &str)] = &[
+    // shaders/rms_norm.comp, `#if RMS_NORM_ROPE_FUSION` branch: "Binding 2 is
+    // not used" — the rms_norm→rope handoff goes through shared memory, so the
+    // fused variant declares 0,1,3,4,5,6. Upstream (llama.cpp) shape; this
+    // crate compiles it but never dispatches it (no `rms_norm_mul_rope`
+    // reference anywhere in src/), so no `record_to` call is exposed to the
+    // hole. If it is ever dispatched, the caller must pass a filler buffer at
+    // index 2.
+    ("rms_norm_mul_rope_f32_f32", "rms_norm.comp: binding 2 intentionally unused"),
+    ("rms_norm_mul_rope_f32_f16", "rms_norm.comp: binding 2 intentionally unused"),
+];
+
+/// I3: the declared push-constant block fits in the pipeline layout's range.
+///
+/// Evidence: every `PipelineLayoutCreateInfo` in `pipeline.rs` declares one
+/// `PushConstantRange { offset: 0, size: 128 }`, and `compute.rs` pushes at
+/// offset 0. A block larger than the range is a validation error at pipeline
+/// creation, and the tail bytes would never be written.
+pub fn check_push_constant_range(r: &Reflection) -> Result<(), String> {
+    if let Some(sz) = r.push_constant_size {
+        if sz > PUSH_CONSTANT_RANGE_BYTES {
+            return Err(format!(
+                "push-constant block is {sz} bytes, exceeding the \
+                 PushConstantRange size pipeline.rs declares ({PUSH_CONSTANT_RANGE_BYTES})"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// I4: the workgroup size is either a literal `LocalSize` within the Vulkan
+/// guaranteed minimum (1024 invocations), or specialization-constant driven —
+/// in which case `pipeline.rs` supplies `BLOCK_SIZE` at pipeline creation.
+pub fn check_local_size(r: &Reflection) -> Result<(), String> {
+    match (r.local_size, r.local_size_is_spec) {
+        (Some((x, y, z)), false) => {
+            let total = x as u64 * y as u64 * z as u64;
+            if total == 0 {
+                return Err("LocalSize has a zero dimension".to_string());
+            }
+            if total > 1024 {
+                return Err(format!(
+                    "LocalSize {x}x{y}x{z} = {total} invocations exceeds the Vulkan \
+                     guaranteed maxComputeWorkGroupInvocations (1024)"
+                ));
+            }
+            Ok(())
+        }
+        (_, true) => Ok(()),
+        (None, false) => Err(
+            "no LocalSize execution mode and no spec-constant WorkgroupSize — the \
+             workgroup size is undefined"
+                .to_string(),
+        ),
+    }
+}
+
+/// Modules whose push-constant block does NOT fit the 128-byte
+/// `PushConstantRange` that `pipeline.rs` declares — i.e. modules that cannot
+/// be fed correctly on a device with the Vulkan guaranteed-minimum
+/// `maxPushConstantsSize` (which is what GFX1013/RADV reports).
+///
+/// All four are upstream-ggml shaders (`multi_add.comp`'s `uint nb[12][4]`
+/// stride table = 4 + 192 + 4 = 212 bytes; `rms_norm.comp`'s
+/// `RMS_NORM_ROPE_FUSION` branch pulls in `rope_params.glsl` for 228 bytes).
+/// Upstream llama.cpp sizes its push-constant range from the device limit;
+/// this fork hardcodes 128. They are compiled and registered but NEVER
+/// dispatched — no `add_rms`/`rms_norm_mul_rope` string appears anywhere in
+/// `src/` — so nothing reads the truncated tail today. They would trip
+/// `VUID-VkComputePipelineCreateInfo-layout` under the validation layers.
+///
+/// The list is exact (see `oversize_push_constant_set_is_exactly_the_known_four`):
+/// a NEW shader with an oversize block fails the gate.
+const PUSH_CONSTANT_OVERSIZE_ALLOWLIST: &[&str] = &[
+    "add_rms_f32_f32_f32",
+    "add_rms_f32_f32_f16",
+    "rms_norm_mul_rope_f32_f32",
+    "rms_norm_mul_rope_f32_f16",
+];
+
+/// Run every module-level invariant for the shader named `name`.
+pub fn check_module(name: &str, r: &Reflection) -> Result<(), String> {
+    check_entry_point(r)?;
+    if BINDING_HOLE_ALLOWLIST.iter().any(|(n, _)| *n == name) {
+        check_bindings(r)?;
+    } else {
+        check_bindings_contiguous(r)?;
+    }
+    if !PUSH_CONSTANT_OVERSIZE_ALLOWLIST.contains(&name) {
+        check_push_constant_range(r)?;
+    }
+    check_local_size(r)?;
+    Ok(())
+}
+
+// ── kernel → (Rust push-constant producer, binding count) ──────────────────
+
+/// The Rust helper in `push_constants.rs` that feeds each required kernel, as
+/// a name plus the byte length it produces, together with the number of
+/// storage buffers the shader declares.
+///
+/// `push_constants.rs` has no `#[repr(C)]` structs — every push-constant block
+/// is produced by a helper that serialises into a `Vec<u8>` — so the Rust-side
+/// size is that helper's output length, evaluated here by calling the helper.
+struct KernelContract {
+    kernel: &'static str,
+    /// Name of the `push_constants.rs` helper (for the failure message).
+    pc_helper: &'static str,
+    /// Byte length that helper produces.
+    pc_rust_bytes: u32,
+    /// Byte length the shader's push-constant block is expected to reflect as.
+    /// Normally identical to `pc_rust_bytes`; a smaller value means the shader
+    /// reads a strict PREFIX of what the helper pushes (legal — the tail is
+    /// ignored — but always a divergence worth naming), and requires
+    /// `divergence` to explain it. Larger is never allowed: the shader would
+    /// read bytes the host never wrote.
+    pc_shader_bytes: u32,
+    /// Why `pc_shader_bytes != pc_rust_bytes`, when they differ.
+    divergence: Option<&'static str>,
+    /// Storage buffers the shader binds (= the length of the `buffers` slice
+    /// the dispatch site must pass to `record_to`).
+    bindings: u32,
+}
+
+fn contracts() -> Vec<KernelContract> {
+    use crate::push_constants as pc;
+
+    // Evaluate each helper rather than hardcoding a number, so a change to a
+    // helper's layout shows up here instead of silently drifting.
+    let mlx4 = pc::matvec_mlx4_pc(64, 64, 64).len() as u32; // {k,n,gs,packed_off,sb_off}
+    let nvfp4_e4m3 = pc::matvec_nvfp4_e4m3_pc(64, 64, 16, 1.0).len() as u32; // + float global
+    let fp8 = pc::matvec_fp8_pc(64, 64, false).len() as u32;
+    let cols2 = pc::matvec_cols_pc2(64, 64).len() as u32;
+    let sdpa = pc::sdpa_pc(1, 1, 1, 64, 16, 1, 1.0, 0, 0).len() as u32;
+    let unary = pc::ew_unary_pc(1).len() as u32;
+
+    let c = |kernel, pc_helper, pc_rust_bytes, bindings| KernelContract {
+        kernel,
+        pc_helper,
+        pc_rust_bytes,
+        pc_shader_bytes: pc_rust_bytes,
+        divergence: None,
+        bindings,
+    };
+
+    vec![
+        // mlx4 (4-bit affine) family — all share matvec_mlx4_pc's 5-uint block
+        // ({ncols, nrows, group_size, packed_off, sb_off}); the `_batched`
+        // siblings say so verbatim in their .comp ("kept so matvec_mlx4_pc's
+        // 5-uint layout is reused verbatim") and add a `meta[]` binding.
+        c("mul_mat_vec_mlx4_f32_f32",               "matvec_mlx4_pc",       mlx4,       5),
+        c("mul_mat_vec_mlx4_cols",                  "matvec_mlx4_pc",       mlx4,       5),
+        c("mul_mat_vec_mlx4w8_f32_f32",             "matvec_mlx4_pc",       mlx4,       5),
+        c("mul_mat_vec_mlx4w16_f32_f32",            "matvec_mlx4_pc",       mlx4,       5),
+        c("mul_mat_vec_mlx4w8sg_f32_f32",           "matvec_mlx4_pc",       mlx4,       5),
+        c("mul_mat_vec_mlx4repack_f32_f32",         "matvec_mlx4_pc",       mlx4,       5),
+        c("mul_mat_vec_mlx4repack_batched_f32_f32", "matvec_mlx4_pc",       mlx4,       6),
+        // mlx2 / mlx6 / mlx8 — same 5-uint block (see each .comp's `parameter`).
+        c("mul_mat_vec_mlx2repack_f32_f32",         "matvec_mlx4_pc",       mlx4,       5),
+        c("mul_mat_vec_mlx2repack_batched_f32_f32", "matvec_mlx4_pc",       mlx4,       6),
+        c("mul_mat_vec_mlx6_f32_f32",               "matvec_mlx4_pc",       mlx4,       5),
+        c("mul_mat_vec_mlx8_f32_f32",               "matvec_mlx4_pc",       mlx4,       5),
+        // nvfp4: the f32-fold kernels reuse the 5-uint block; the E4M3-resident
+        // ones append `float global` (push_constants::nvfp4_dispatch routes
+        // between them, and documents that both share the same 4 bindings).
+        c("mul_mat_vec_nvfp4_f32_f32",              "matvec_mlx4_pc",       mlx4,       4),
+        c("mul_mat_vec_nvfp4repack_f32_f32",        "matvec_mlx4_pc",       mlx4,       4),
+        c("mul_mat_vec_nvfp4_e4m3_f32_f32",         "matvec_nvfp4_e4m3_pc", nvfp4_e4m3, 4),
+        c("mul_mat_vec_nvfp4_e4m3repack_f32_f32",   "matvec_nvfp4_e4m3_pc", nvfp4_e4m3, 4),
+        // fp8 ({k, n, scale_per_row, packed_off, sb_off}).
+        c("mul_mat_vec_fp8_f32_f32",                "matvec_fp8_pc",        fp8,        4),
+        c("mul_mat_vec_fp8fast_f32_f32",            "matvec_fp8_pc",        fp8,        4),
+        c("mul_mat_vec_fp8repack_f32_f32",          "matvec_fp8_pc",        fp8,        4),
+        // Column-batched dequant matvec (standalone kernels, 2-uint block —
+        // matvec_cols_pc2's doc comment names exactly these two shaders).
+        c("mul_mat_vec_q8_0_cols",                  "matvec_cols_pc2",      cols2,      3),
+        c("mul_mat_vec_f16_cols",                   "matvec_cols_pc2",      cols2,      3),
+        // Subgroup paged decode attention. f32 takes sdpa_pc's full 11 words;
+        // f16 stops one word short — see `divergence`.
+        c("paged_attn_decode_f32_sg",               "sdpa_pc",              sdpa,       4),
+        KernelContract {
+            kernel: "paged_attn_decode_f16_sg",
+            pc_helper: "sdpa_pc",
+            pc_rust_bytes: sdpa,
+            pc_shader_bytes: sdpa - 4,
+            divergence: Some(
+                "paged_attn_decode_f16_sg.comp's push block ends at `window_start` \
+                 and has NO `ring_capacity` word, unlike its f32 twin. sdpa_pc \
+                 pushes all 11 words; the f16 kernel ignores the 11th, i.e. the \
+                 f16-KV decode path silently does ABSOLUTE block-table addressing \
+                 even when the caller asks for ring addressing (ring_capacity > 0). \
+                 Harmless while the ring is only used with f32 KV; a real \
+                 mis-addressing bug the moment it is not.",
+            ),
+            bindings: 4,
+        },
+        // Elementwise (generic_head.glsl: {KX, KY, param1..4}).
+        c("relu2_f32",                              "ew_unary_pc",          unary,      2),
+    ]
+}
+
+/// I3b/I4b: the reflected push-constant block size equals what the Rust helper
+/// that feeds this kernel serialises, and the reflected binding count equals
+/// the number of buffers its dispatch site passes to `record_to`. Returns one
+/// message per violation (empty = the contract holds).
+fn check_contract(c: &KernelContract, r: &Reflection) -> Vec<String> {
+    let mut out = Vec::new();
+
+    // A shader must never declare MORE than the host pushes: those trailing
+    // bytes would be read but never written.
+    if c.pc_shader_bytes > c.pc_rust_bytes {
+        out.push(format!(
+            "{}: contract claims the shader block ({}) is larger than what \
+             push_constants::{} pushes ({}) — that is never legal",
+            c.kernel, c.pc_shader_bytes, c.pc_helper, c.pc_rust_bytes
+        ));
+    }
+    if c.pc_shader_bytes != c.pc_rust_bytes && c.divergence.is_none() {
+        out.push(format!(
+            "{}: shader block ({}) differs from push_constants::{} ({}) with no \
+             documented reason",
+            c.kernel, c.pc_shader_bytes, c.pc_helper, c.pc_rust_bytes
+        ));
+    }
+    match r.push_constant_size {
+        Some(sz) if sz == c.pc_shader_bytes => {}
+        Some(sz) => out.push(format!(
+            "{}: shader declares a {sz}-byte push-constant block but the dispatch \
+             contract expects {} (push_constants::{} produces {} bytes) — \
+             vkCmdPushConstants would leave {} byte(s) of the block undefined (or \
+             silently ignore that many)",
+            c.kernel,
+            c.pc_shader_bytes,
+            c.pc_helper,
+            c.pc_rust_bytes,
+            (sz as i64 - c.pc_shader_bytes as i64).abs()
+        )),
+        None => out.push(format!(
+            "{}: shader declares NO push-constant block but push_constants::{} \
+             produces {} bytes for it",
+            c.kernel, c.pc_helper, c.pc_rust_bytes
+        )),
+    }
+    let n = r.bindings.len() as u32;
+    if n != c.bindings {
+        out.push(format!(
+            "{}: shader declares {n} descriptor binding(s) but the dispatch contract \
+             binds {} buffer(s) — compute.rs::record_to maps buffers[i] to binding i, \
+             so the counts must agree",
+            c.kernel, c.bindings
+        ));
+    }
+    out
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry_tests::REQUIRED_QUANT_KERNELS;
+
+    fn shaders() -> HashMap<String, Vec<u8>> {
+        crate::include_all_shaders()
+    }
+
+    /// Every module in the shipped registry — not just the required quant
+    /// kernels — must parse and satisfy the module-level invariants.
+    #[test]
+    fn all_registered_modules_satisfy_dispatch_invariants() {
+        let mut failures: Vec<String> = Vec::new();
+        let mut checked = 0usize;
+        for (name, spv) in shaders() {
+            match reflect(&spv) {
+                Ok(r) => {
+                    checked += 1;
+                    if let Err(e) = check_module(&name, &r) {
+                        failures.push(format!("{name}: {e}"));
+                    }
+                }
+                Err(e) => failures.push(format!("{name}: unparseable SPIR-V: {e}")),
+            }
+        }
+        assert!(checked > 0, "no shaders in the registry to reflect");
+        assert!(
+            failures.is_empty(),
+            "{} of {checked} module(s) violate a dispatch invariant:\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
+
+    /// The two allowlists above must stay EXACT: they are the documented
+    /// exceptions to invariants the dispatch path otherwise relies on, so a
+    /// newly-added shader that trips either one has to be looked at (and a
+    /// fixed/removed one has to be de-listed) rather than silently inheriting
+    /// the exemption.
+    #[test]
+    fn oversize_push_constant_set_is_exactly_the_known_four() {
+        let mut oversize: Vec<String> = Vec::new();
+        let mut holed: Vec<String> = Vec::new();
+        for (name, spv) in shaders() {
+            let r = reflect(&spv).expect("parses");
+            if check_push_constant_range(&r).is_err() {
+                oversize.push(name.clone());
+            }
+            if check_bindings_contiguous(&r).is_err() {
+                holed.push(name);
+            }
+        }
+        oversize.sort();
+        holed.sort();
+        let mut expect_oversize: Vec<String> = PUSH_CONSTANT_OVERSIZE_ALLOWLIST
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        expect_oversize.sort();
+        assert_eq!(
+            oversize, expect_oversize,
+            "the set of shaders whose push-constant block exceeds pipeline.rs's \
+             128-byte PushConstantRange changed; see PUSH_CONSTANT_OVERSIZE_ALLOWLIST"
+        );
+        let mut expect_holed: Vec<String> = BINDING_HOLE_ALLOWLIST
+            .iter()
+            .map(|(n, _)| n.to_string())
+            .collect();
+        expect_holed.sort();
+        assert_eq!(
+            holed, expect_holed,
+            "the set of shaders with a non-contiguous binding numbering changed; \
+             see BINDING_HOLE_ALLOWLIST"
+        );
+    }
+
+    /// Every kernel named in `REQUIRED_QUANT_KERNELS` has a contract entry, and
+    /// every contract entry names a required kernel. Keeps the two lists from
+    /// drifting apart silently (a new required kernel must state its
+    /// push-constant producer).
+    #[test]
+    fn contract_table_covers_every_required_kernel() {
+        let contracts = contracts();
+        let covered: std::collections::HashSet<&str> =
+            contracts.iter().map(|c| c.kernel).collect();
+        let required: std::collections::HashSet<&str> =
+            REQUIRED_QUANT_KERNELS.iter().copied().collect();
+        let missing: Vec<&&str> = required.iter().filter(|k| !covered.contains(**k)).collect();
+        let extra: Vec<&&str> = covered.iter().filter(|k| !required.contains(**k)).collect();
+        assert!(
+            missing.is_empty() && extra.is_empty(),
+            "contract table out of sync with REQUIRED_QUANT_KERNELS: \
+             missing {missing:?}, unexpected {extra:?}"
+        );
+        assert_eq!(contracts.len(), REQUIRED_QUANT_KERNELS.len());
+    }
+
+    /// The heart of the gate: each required kernel's *reflected* push-constant
+    /// block size must equal the byte length the Rust helper that feeds it
+    /// produces, and its binding count must equal the number of buffers the
+    /// dispatch site passes.
+    #[test]
+    fn required_kernels_match_their_rust_push_constants() {
+        let map = shaders();
+        let mut failures: Vec<String> = Vec::new();
+        for c in contracts() {
+            let Some(spv) = map.get(c.kernel) else {
+                // registry_tests::quant_matvec_kernels_are_registered owns the
+                // "is it present" gate; don't duplicate its failure here.
+                continue;
+            };
+            let r = match reflect(spv) {
+                Ok(r) => r,
+                Err(e) => {
+                    failures.push(format!("{}: unparseable: {e}", c.kernel));
+                    continue;
+                }
+            };
+            failures.extend(check_contract(&c, &r));
+        }
+        assert!(
+            failures.is_empty(),
+            "{} push-constant/binding contract violation(s):\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
+
+    // ── Fail-injection: prove the gates can actually fail ──────────────────
+
+    /// Rewrite the operand of the last `OpDecorate <id> Binding <n>` in a
+    /// module, simulating a `.comp` whose bindings grew a hole.
+    fn corrupt_last_binding(spv: &[u8], new_value: u32) -> Vec<u8> {
+        let mut words: Vec<u32> = spv
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        let mut target: Option<usize> = None;
+        let mut i = 5;
+        while i < words.len() {
+            let count = (words[i] >> 16) as usize;
+            let op = (words[i] & 0xffff) as u16;
+            if count == 0 {
+                break;
+            }
+            if op == OP_DECORATE && count >= 4 && words[i + 2] == DEC_BINDING {
+                target = Some(i + 3);
+            }
+            i += count;
+        }
+        let idx = target.expect("module has at least one Binding decoration");
+        words[idx] = new_value;
+        words.iter().flat_map(|w| w.to_le_bytes()).collect()
+    }
+
+    /// A real module, byte-corrupted to have a binding hole, must be REJECTED
+    /// by `check_bindings` with a message that names the hole.
+    #[test]
+    fn fail_injection_binding_hole_is_caught() {
+        let map = shaders();
+        let spv = map
+            .get("mul_mat_vec_mlx4_f32_f32")
+            .expect("mlx4 matvec present");
+        // Sanity: the pristine module passes.
+        let good = reflect(spv).expect("pristine module parses");
+        check_module("mul_mat_vec_mlx4_f32_f32", &good)
+            .expect("pristine module satisfies every invariant");
+        assert_eq!(good.bindings.len(), 5);
+
+        // Bindings 0..4 -> 0,1,2,3,9: a hole at 4.
+        let bad_bytes = corrupt_last_binding(spv, 9);
+        let bad = reflect(&bad_bytes).expect("corrupted module still parses");
+        let err = check_bindings_contiguous(&bad).expect_err("binding hole must be rejected");
+        assert!(
+            err.contains("not contiguous") && err.contains('9'),
+            "unhelpful message for a binding hole: {err}"
+        );
+
+        // And a binding past the descriptor-set layout's last slot.
+        let oob = corrupt_last_binding(spv, crate::pipeline::MAX_BINDINGS + 3);
+        let oob_r = reflect(&oob).expect("corrupted module still parses");
+        let err = check_bindings(&oob_r).expect_err("out-of-range binding must be rejected");
+        assert!(err.contains("MAX_BINDINGS"), "unhelpful message: {err}");
+    }
+
+    /// A push-constant size mismatch must be reported by the SAME
+    /// `check_contract` the production test runs, with both sizes named.
+    #[test]
+    fn fail_injection_push_constant_size_mismatch_is_caught() {
+        let map = shaders();
+        let spv = map.get("mul_mat_vec_fp8_f32_f32").expect("fp8 matvec present");
+        let r = reflect(spv).expect("parses");
+        let real = r.push_constant_size.expect("fp8 matvec has a push block");
+        assert_eq!(real, crate::push_constants::matvec_fp8_pc(64, 64, false).len() as u32);
+
+        // (a) The Rust helper gains a word the shader does not have — exactly
+        // what adding a field to a `matvec_*_pc` helper and forgetting the
+        // `.comp` looks like.
+        let wrong = KernelContract {
+            kernel: "mul_mat_vec_fp8_f32_f32",
+            pc_helper: "matvec_fp8_pc",
+            pc_rust_bytes: real + 4,
+            pc_shader_bytes: real + 4,
+            divergence: None,
+            bindings: 4,
+        };
+        let errs = check_contract(&wrong, &r);
+        assert_eq!(errs.len(), 1, "expected exactly one violation, got {errs:?}");
+        assert!(
+            errs[0].contains(&format!("{real}-byte")) && errs[0].contains("matvec_fp8_pc"),
+            "unhelpful message: {}",
+            errs[0]
+        );
+
+        // (b) A shorter shader block with NO documented divergence must be
+        // rejected even though under-reading is technically harmless.
+        let undocumented = KernelContract {
+            kernel: "paged_attn_decode_f16_sg",
+            pc_helper: "sdpa_pc",
+            pc_rust_bytes: 44,
+            pc_shader_bytes: 40,
+            divergence: None,
+            bindings: 4,
+        };
+        let f16 = reflect(map.get("paged_attn_decode_f16_sg").expect("present")).expect("parses");
+        let errs = check_contract(&undocumented, &f16);
+        assert!(
+            errs.iter().any(|e| e.contains("no documented reason")),
+            "an undocumented push-constant divergence must be flagged: {errs:?}"
+        );
+
+        // (c) The binding-count half of the contract.
+        let wrong_bindings = KernelContract { bindings: 3, ..wrong };
+        let errs = check_contract(&wrong_bindings, &r);
+        assert!(
+            errs.iter().any(|e| e.contains("descriptor binding(s)")),
+            "a binding-count mismatch must be flagged: {errs:?}"
+        );
+    }
+
+    /// The header/entry-point gate must reject a truncated or mis-tagged module.
+    #[test]
+    fn fail_injection_bad_header_is_caught() {
+        let map = shaders();
+        let spv = map.get("relu2_f32").expect("relu2 present").clone();
+
+        let mut bad_magic = spv.clone();
+        bad_magic[0] ^= 0xff;
+        let err = reflect(&bad_magic).expect_err("bad magic must be rejected");
+        assert!(err.contains("bad magic"), "unhelpful message: {err}");
+
+        // Claim a 1.5 module (what --target-env vulkan1.2 would emit): the
+        // instance asks for Vulkan 1.3 / SPIR-V 1.6.
+        let mut old_version = spv.clone();
+        old_version[5] = 5; // version word = 0x0001_0500
+        let r = reflect(&old_version).expect("still parses");
+        let err = check_entry_point(&r).expect_err("wrong SPIR-V version must be rejected");
+        assert!(err.contains("1.6"), "unhelpful message: {err}");
+
+        // A module cut mid-instruction must be rejected, not silently
+        // half-reflected (which would let a truncated .spv pass every gate
+        // above by simply declaring nothing).
+        let truncated = &spv[..spv.len() / 2];
+        let err = reflect(truncated).expect_err("a truncated module must not reflect cleanly");
+        assert!(err.contains("words"), "unhelpful message: {err}");
+
+        // Not word-aligned at all.
+        assert!(reflect(&spv[..spv.len() - 2]).is_err());
+    }
+
+    /// `check_bindings` rejects a set-1 binding: nothing binds descriptor set 1.
+    #[test]
+    fn fail_injection_wrong_descriptor_set_is_caught() {
+        let r = Reflection {
+            version: (1, 6),
+            entry_points: vec![(EXEC_MODEL_GL_COMPUTE, "main".into())],
+            bindings: vec![(0, 0), (1, 1)],
+            ..Default::default()
+        };
+        let err = check_bindings(&r).expect_err("set-1 binding must be rejected");
+        assert!(err.contains("set 0"), "unhelpful message: {err}");
+    }
+
+    /// Parser unit checks against a known module, so a silent parser
+    /// regression (e.g. always returning zero bindings, which would make every
+    /// gate above vacuously pass) fails loudly.
+    #[test]
+    fn parser_extracts_known_values() {
+        let map = shaders();
+        let spv = map.get("mul_mat_vec_q8_0_cols").expect("present");
+        let r = reflect(spv).expect("parses");
+        assert_eq!(r.version, (1, 6));
+        assert_eq!(r.entry_points, vec![(EXEC_MODEL_GL_COMPUTE, "main".to_string())]);
+        // shaders/mul_mat_vec_q8_0_cols.comp: bindings 0 (W), 1 (Activ), 2 (Dst)
+        assert_eq!(r.bindings, vec![(0, 0), (0, 1), (0, 2)]);
+        // ... and `{ uint ncols; uint nrows; }`
+        assert_eq!(r.push_constant_size, Some(8));
+
+        // relu2.comp: `layout(local_size_x = 512, ...)` — a literal LocalSize.
+        let relu = reflect(map.get("relu2_f32").expect("present")).expect("parses");
+        assert_eq!(relu.local_size, Some((512, 1, 1)));
+        assert!(!relu.local_size_is_spec);
+        // generic_head.glsl: { uint KX; uint KY; float param1..4 } = 24 bytes.
+        assert_eq!(relu.push_constant_size, Some(24));
+
+        // mul_mat_vec_mlx4repack uses layout(local_size_x_id = 0) — pipeline.rs
+        // supplies BLOCK_SIZE as a specialization constant.
+        let repack = reflect(map.get("mul_mat_vec_mlx4repack_f32_f32").expect("present"))
+            .expect("parses");
+        assert!(
+            repack.local_size_is_spec,
+            "mlx4repack's workgroup size is spec-constant driven (local_size_x_id = 0)"
+        );
+    }
+}

--- a/tests/python/test_kv_ops.py
+++ b/tests/python/test_kv_ops.py
@@ -591,6 +591,7 @@ def test_select_decode_shader_prefers_block_size_matching_head_size():
     assert wg_512 == 512
 
 
+@pytest.mark.slow  # wall-clock comparison; unreliable on shared CI runners
 def test_cached_available_shaders_matches_uncached_reference_and_is_faster():
     """`kv_ops._cached_available_shaders` must return the exact same set
     of shader names as calling `ctx.available_shaders()` directly, just
@@ -797,6 +798,7 @@ def test_paged_attn_decode_pc_matches_old_layout_based_reference():
     assert new_pc == old_pc
 
 
+@pytest.mark.slow  # wall-clock comparison; unreliable on shared CI runners
 def test_paged_attn_decode_pc_resolved_spec_is_faster_than_relayout_lookup():
     """Measures the actual speedup: passing an already-resolved `spec`/
     `layer_base_offset` directly should be faster than re-deriving them
@@ -900,6 +902,7 @@ def test_block_table_to_u32_skips_dtype_conversion_for_already_int64_input(
     np.testing.assert_array_equal(result, np.array([2, 0, 3], dtype=np.uint32))
 
 
+@pytest.mark.slow  # wall-clock comparison; unreliable on shared CI runners
 def test_block_table_whole_batch_int64_conversion_is_faster_than_per_row():
     """Measures the actual speedup: converting a whole (B, blocks_per_row)
     int32 block table to int64 once, before splitting into per-row


### PR DESCRIPTION
Second PR of the upstreaming stack. Adds the quantized matvec kernels that every model path dispatches, plus the two subgroup paged-attention variants:
  - mlx4 family (4-bit): plain, _cols, _w8, _w16, w8sg, and the repack / repack_batched f32 variants
  - mlx2 / mlx6 / mlx8 repack variants
  - nvfp4 family: plain, _e4m3, and the e4m3repack / repack f32 variants
  - fp8: plain, _fast, and fp8repack
  - q8_0_cols and f16_cols (column-batched dequant matvec)
  - paged_attn_decode_f32_sg / _f16_sg (subgroup decode attention)
  - relu2 These are shared by every model, so they land once here rather than being duplicated across the per-model PRs that follow. The Rust-side push-constant helpers for them already shipped with the compute-engine foundation (PR1), where they were dead code; this activates them.
scripts/compile_shaders.sh gains the full compile map plus a skip-when-absent guard, so one script drives any feature slice: it compiles the shaders present in the tree and cleanly skips the rest. build.rs derives the shader registry from the compiled output, so a skipped shader is simply absent from the registry and its dispatch path is never reached in that slice. This lets each following model PR add its own .comp files and have them compile with no script edit. Gate: cargo build --no-default-features --features multiple-pymethods, 117 SPIR-V shaders compiled.